### PR TITLE
Implement traits for query builders and schema builders

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -21,59 +21,61 @@ pub use sqlite::*;
 
 pub trait GenericBuilder: QueryBuilder + TableBuilder + IndexBuilder + ForeignKeyBuilder {}
 
+pub trait SchemaBuilder: TableBuilder + IndexBuilder + ForeignKeyBuilder {}
+
 pub trait QueryBuilder {
-    
+
     /// Translate [`InsertStatement`] into SQL statement.
     fn prepare_insert_statement(&self, insert: &InsertStatement, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`SelectStatement`] into SQL statement.
     fn prepare_select_statement(&self, select: &SelectStatement, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`UpdateStatement`] into SQL statement.
     fn prepare_update_statement(&self, update: &UpdateStatement, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`DeleteStatement`] into SQL statement.
     fn prepare_delete_statement(&self, delete: &DeleteStatement, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`SimpleExpr`] into SQL statement.
     fn prepare_simple_expr(&self, simple_expr: &SimpleExpr, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`SelectDistinct`] into SQL statement.
     fn prepare_select_distinct(&self, select_distinct: &SelectDistinct, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`SelectExpr`] into SQL statement.
     fn prepare_select_expr(&self, select_expr: &SelectExpr, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`JoinExpr`] into SQL statement.
     fn prepare_join_expr(&self, join_expr: &JoinExpr, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`TableRef`] into SQL statement.
     fn prepare_table_ref(&self, table_ref: &TableRef, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`UnOper`] into SQL statement.
     fn prepare_un_oper(&self, un_oper: &UnOper, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`BinOper`] into SQL statement.
     fn prepare_bin_oper(&self, bin_oper: &BinOper, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`LogicalChainOper`] into SQL statement.
     fn prepare_logical_chain_oper(&self, log_chain_oper: &LogicalChainOper, i: usize, length: usize, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`Function`] into SQL statement.
     fn prepare_function(&self, function: &Function, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`JoinType`] into SQL statement.
     fn prepare_join_type(&self, join_type: &JoinType, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`OrderExpr`] into SQL statement.
     fn prepare_order_expr(&self, order_expr: &OrderExpr, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`JoinOn`] into SQL statement.
     fn prepare_join_on(&self, join_on: &JoinOn, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`Order`] into SQL statement.
     fn prepare_order(&self, order: &Order, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
-    
+
     /// Translate [`Value`] into SQL statement.
     fn prepare_value(&self, value: &Value, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value));
 

--- a/src/backend/mysql/mod.rs
+++ b/src/backend/mysql/mod.rs
@@ -18,3 +18,5 @@ impl Default for MysqlQueryBuilder {
 }
 
 impl GenericBuilder for MysqlQueryBuilder {}
+
+impl SchemaBuilder for MysqlQueryBuilder {}

--- a/src/backend/postgres/mod.rs
+++ b/src/backend/postgres/mod.rs
@@ -17,3 +17,5 @@ impl Default for PostgresQueryBuilder {
 }
 
 impl GenericBuilder for PostgresQueryBuilder {}
+
+impl SchemaBuilder for PostgresQueryBuilder {}

--- a/src/backend/sqlite/mod.rs
+++ b/src/backend/sqlite/mod.rs
@@ -16,3 +16,5 @@ impl Default for SqliteQueryBuilder {
 }
 
 impl GenericBuilder for SqliteQueryBuilder {}
+
+impl SchemaBuilder for SqliteQueryBuilder {}

--- a/src/foreign_key/create.rs
+++ b/src/foreign_key/create.rs
@@ -1,4 +1,5 @@
-use crate::{ForeignKeyAction, TableForeignKey, backend::ForeignKeyBuilder, types::*, prepare::*};
+use crate::{ForeignKeyAction, TableForeignKey, backend::SchemaBuilder, types::*, prepare::*};
+pub use crate::traits::SchemaStatementBuilder;
 
 /// Create a foreign key constraint for an existing table. Unsupported by Sqlite
 ///
@@ -172,23 +173,18 @@ impl ForeignKeyCreateStatement {
         self.foreign_key.on_update(action);
         self
     }
+}
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: ForeignKeyBuilder>(&self, foreign_key_builder: T) -> String {
+impl SchemaStatementBuilder for ForeignKeyCreateStatement {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = SqlWriter::new();
-        foreign_key_builder.prepare_foreign_key_create_statement(self, &mut sql);
+        schema_builder.prepare_foreign_key_create_statement(self, &mut sql);
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, foreign_key_builder: &dyn ForeignKeyBuilder) -> String {
+    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
-        foreign_key_builder.prepare_foreign_key_create_statement(self, &mut sql);
+        schema_builder.prepare_foreign_key_create_statement(self, &mut sql);
         sql.result()
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: ForeignKeyBuilder>(&self, foreign_key_builder: T) -> String {
-        self.build(foreign_key_builder)
     }
 }

--- a/src/foreign_key/create.rs
+++ b/src/foreign_key/create.rs
@@ -1,12 +1,12 @@
 use crate::{ForeignKeyAction, TableForeignKey, backend::ForeignKeyBuilder, types::*, prepare::*};
 
 /// Create a foreign key constraint for an existing table. Unsupported by Sqlite
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let foreign_key = ForeignKey::create()
 ///     .name("FK_character_font")
 ///     .from(Char::Table, Char::FontId)
@@ -14,7 +14,7 @@ use crate::{ForeignKeyAction, TableForeignKey, backend::ForeignKeyBuilder, types
 ///     .on_delete(ForeignKeyAction::Cascade)
 ///     .on_update(ForeignKeyAction::Cascade)
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     foreign_key.to_string(MysqlQueryBuilder),
 ///     vec![
@@ -33,11 +33,11 @@ use crate::{ForeignKeyAction, TableForeignKey, backend::ForeignKeyBuilder, types
 ///     ].join(" ")
 /// );
 /// ```
-/// 
+///
 /// Composite key
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let foreign_key = ForeignKey::create()
 ///     .name("FK_character_glyph")
 ///     .from(Char::Table, (Char::FontId, Char::Id))
@@ -45,7 +45,7 @@ use crate::{ForeignKeyAction, TableForeignKey, backend::ForeignKeyBuilder, types
 ///     .on_delete(ForeignKeyAction::Cascade)
 ///     .on_update(ForeignKeyAction::Cascade)
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     foreign_key.to_string(MysqlQueryBuilder),
 ///     vec![

--- a/src/foreign_key/drop.rs
+++ b/src/foreign_key/drop.rs
@@ -2,17 +2,17 @@ use std::rc::Rc;
 use crate::{TableForeignKey, backend::ForeignKeyBuilder, types::*, prepare::*};
 
 /// Drop a foreign key constraint for an existing table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let foreign_key = ForeignKey::drop()
 ///     .name("FK_character_font")
 ///     .table(Char::Table)
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     foreign_key.to_string(MysqlQueryBuilder),
 ///     r#"ALTER TABLE `character` DROP FOREIGN KEY `FK_character_font`"#

--- a/src/foreign_key/drop.rs
+++ b/src/foreign_key/drop.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
-use crate::{TableForeignKey, backend::ForeignKeyBuilder, types::*, prepare::*};
+use crate::{TableForeignKey, backend::SchemaBuilder, types::*, prepare::*};
+pub use crate::traits::SchemaStatementBuilder;
 
 /// Drop a foreign key constraint for an existing table
 ///
@@ -56,23 +57,18 @@ impl ForeignKeyDropStatement {
         self.table = Some(Rc::new(table));
         self
     }
+}
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: ForeignKeyBuilder>(&self, foreign_key_builder: T) -> String {
+impl SchemaStatementBuilder for ForeignKeyDropStatement {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = SqlWriter::new();
-        foreign_key_builder.prepare_foreign_key_drop_statement(self, &mut sql);
+        schema_builder.prepare_foreign_key_drop_statement(self, &mut sql);
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, foreign_key_builder: &dyn ForeignKeyBuilder) -> String {
+    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
-        foreign_key_builder.prepare_foreign_key_drop_statement(self, &mut sql);
+        schema_builder.prepare_foreign_key_drop_statement(self, &mut sql);
         sql.result()
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: ForeignKeyBuilder>(&self, foreign_key_builder: T) -> String {
-        self.build(foreign_key_builder)
     }
 }

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -1,6 +1,8 @@
 use std::rc::Rc;
-use crate::{backend::IndexBuilder, types::*, prepare::*};
+use crate::{backend::SchemaBuilder, types::*, prepare::*};
 use super::common::*;
+
+pub use crate::traits::SchemaStatementBuilder;
 
 /// Create an index for an existing table
 ///
@@ -177,23 +179,18 @@ impl IndexCreateStatement {
         self.index_type = Some(index_type);
         self
     }
+}
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: IndexBuilder>(&self, index_builder: T) -> String {
+impl SchemaStatementBuilder for IndexCreateStatement {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = SqlWriter::new();
-        index_builder.prepare_index_create_statement(self, &mut sql);
+        schema_builder.prepare_index_create_statement(self, &mut sql);
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, index_builder: &dyn IndexBuilder) -> String {
+    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
-        index_builder.prepare_index_create_statement(self, &mut sql);
+        schema_builder.prepare_index_create_statement(self, &mut sql);
         sql.result()
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: IndexBuilder>(&self, index_builder: T) -> String {
-        self.build(index_builder)
     }
 }

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -3,18 +3,18 @@ use crate::{backend::IndexBuilder, types::*, prepare::*};
 use super::common::*;
 
 /// Create an index for an existing table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let index = Index::create()
 ///     .name("idx-glyph-aspect")
 ///     .table(Glyph::Table)
 ///     .col(Glyph::Aspect)
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     index.to_string(MysqlQueryBuilder),
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"#
@@ -31,13 +31,13 @@ use super::common::*;
 /// Index with prefix
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let index = Index::create()
 ///     .name("idx-glyph-aspect")
 ///     .table(Glyph::Table)
 ///     .col((Glyph::Aspect, 128))
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     index.to_string(MysqlQueryBuilder),
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect` (128))"#
@@ -54,13 +54,13 @@ use super::common::*;
 /// Index with order
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let index = Index::create()
 ///     .name("idx-glyph-aspect")
 ///     .table(Glyph::Table)
 ///     .col((Glyph::Aspect, IndexOrder::Desc))
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     index.to_string(MysqlQueryBuilder),
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect` DESC)"#
@@ -77,13 +77,13 @@ use super::common::*;
 /// Index with prefix and order
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let index = Index::create()
 ///     .name("idx-glyph-aspect")
 ///     .table(Glyph::Table)
 ///     .col((Glyph::Aspect, 64, IndexOrder::Asc))
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     index.to_string(MysqlQueryBuilder),
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect` (64) ASC)"#
@@ -165,9 +165,9 @@ impl IndexCreateStatement {
         self
     }
 
-    /// Set index as full text. 
-    /// On MySQL, this is `FULLTEXT`. 
-    /// On PgSQL, this is `GIN`. 
+    /// Set index as full text.
+    /// On MySQL, this is `FULLTEXT`.
+    /// On PgSQL, this is `GIN`.
     pub fn full_text(self) -> Self {
         self.index_type(IndexType::FullText)
     }

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -2,17 +2,17 @@ use std::rc::Rc;
 use crate::{TableIndex, backend::IndexBuilder, types::*, prepare::*};
 
 /// Drop an index for an existing table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let index = Index::drop()
 ///     .name("idx-glyph-aspect")
 ///     .table(Glyph::Table)
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     index.to_string(MysqlQueryBuilder),
 ///     r#"DROP INDEX `idx-glyph-aspect` ON `glyph`"#

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
-use crate::{TableIndex, backend::IndexBuilder, types::*, prepare::*};
+use crate::{TableIndex, backend::SchemaBuilder, types::*, prepare::*};
+pub use crate::traits::SchemaStatementBuilder;
 
 /// Drop an index for an existing table
 ///
@@ -59,23 +60,18 @@ impl IndexDropStatement {
         self.table = Some(Rc::new(table));
         self
     }
+}
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: IndexBuilder>(&self, index_builder: T) -> String {
+impl SchemaStatementBuilder for IndexDropStatement {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = SqlWriter::new();
-        index_builder.prepare_index_drop_statement(self, &mut sql);
+        schema_builder.prepare_index_drop_statement(self, &mut sql);
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, index_builder: &dyn IndexBuilder) -> String {
+    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
-        index_builder.prepare_index_drop_statement(self, &mut sql);
+        schema_builder.prepare_index_drop_statement(self, &mut sql);
         sql.result()
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: IndexBuilder>(&self, index_builder: T) -> String {
-        self.build(index_builder)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,58 +2,58 @@
 #![deny(missing_debug_implementations)]
 
 //! <div align="center">
-//! 
+//!
 //!   <img src="https://raw.githubusercontent.com/SeaQL/sea-query/master/docs/SeaQL logo dual.png" width="320"/>
-//! 
+//!
 //!   <h1>SeaQuery</h1>
-//! 
+//!
 //!   <p>
 //!     <strong>A database agnostic runtime query builder for Rust</strong>
 //!   </p>
-//! 
+//!
 //!   [![crate](https://img.shields.io/crates/v/sea-query.svg)](https://crates.io/crates/sea-query)
 //!   [![docs](https://docs.rs/sea-query/badge.svg)](https://docs.rs/sea-query)
 //!   [![build status](https://github.com/SeaQL/sea-query/actions/workflows/rust.yml/badge.svg)](https://github.com/SeaQL/sea-query/actions/workflows/rust.yml)
-//! 
+//!
 //!   <sub>Built with ❤️ by 🌊🦀🐚</sub>
-//! 
+//!
 //! </div>
-//! 
+//!
 //! ## Introduction
-//! 
+//!
 //! SeaQuery is query builder to help you construct dynamic SQL queries in Rust.
 //! You can construct expressions, queries and schema as abstract syntax trees using an ergonomic API.
 //! We support MySQL, Postgres and SQLite behind a common interface that aligns their behaviour where appropriate.
-//! 
+//!
 //! This library is the foundation of upcoming projects: Document ORM (SeaORM) and Database Synchor (SeaHorse).
-//! 
+//!
 //! ## Install
-//! 
+//!
 //! ```toml
 //! # Cargo.toml
 //! [dependencies]
 //! sea-query = "^0"
 //! ```
-//! 
+//!
 //! ## Usage
-//! 
+//!
 //! Table of Content
-//! 
+//!
 //! 1. Basics
-//! 
+//!
 //!     1. [Iden](#iden)
 //!     1. [Expression](#expression)
 //!     1. [Builder](#builder)
-//! 
+//!
 //! 1. Query Statement
-//! 
+//!
 //!     1. [Query Select](#query-select)
 //!     1. [Query Insert](#query-insert)
 //!     1. [Query Update](#query-update)
 //!     1. [Query Delete](#query-delete)
-//! 
+//!
 //! 1. Table Statement
-//! 
+//!
 //!     1. [Table Create](#table-create)
 //!     1. [Table Alter](#table-alter)
 //!     1. [Table Drop](#table-drop)
@@ -63,25 +63,25 @@
 //!     1. [Foreign Key Drop](#foreign-key-drop)
 //!     1. [Index Create](#index-create)
 //!     1. [Index Drop](#index-drop)
-//! 
+//!
 //! ### Drivers
-//! 
-//! We provide integration for [SQLx](https://crates.io/crates/sqlx), 
+//!
+//! We provide integration for [SQLx](https://crates.io/crates/sqlx),
 //! [postgres](https://crates.io/crates/postgres) and [rusqlite](https://crates.io/crates/rusqlite).
 //! See [examples](https://github.com/SeaQL/sea-query/blob/master/examples) for usage.
-//! 
+//!
 //! ### Iden
-//! 
+//!
 //! `Iden` is a trait for identifiers used in any query statement.
-//! 
+//!
 //! Commonly implemented by Enum where each Enum represent a table found in a database,
 //! and its variants include table name and column name.
-//! 
+//!
 //! [`Iden::unquoted()`] must be implemented to provide a mapping between Enum variant and its corresponding string value.
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! // For example Character table with column id, character, font_size...
 //! pub enum Character {
 //!     Table,
@@ -92,7 +92,7 @@
 //!     SizeH,
 //!     FontId,
 //! }
-//! 
+//!
 //! // Mapping between Enum variant and its corresponding string value
 //! impl Iden for Character {
 //!     fn unquoted(&self, s: &mut dyn FmtWrite) {
@@ -108,16 +108,16 @@
 //!     }
 //! }
 //! ```
-//! 
+//!
 //! If you're okay with running another procedural macro, you can activate
 //! the `derive` feature on the crate to save you some boilerplate.
-//! For more information, look at 
+//! For more information, look at
 //! [the derive example](https://github.com/SeaQL/sea-query/blob/master/examples/derive.rs).
-//! 
+//!
 //! ```rust
 //! # #[cfg(feature = "derive")]
 //! use sea_query::Iden;
-//! 
+//!
 //! // This will implement Iden exactly as shown above
 //! # #[cfg(feature = "derive")]
 //! #[derive(Iden)]
@@ -131,14 +131,14 @@
 //!     FontId,
 //! }
 //! ```
-//! 
+//!
 //! ### Expression
-//! 
+//!
 //! Use [`Expr`] to construct select, join, where and having expression in query.
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! assert_eq!(
 //!     Query::select()
 //!         .column(Char::Character)
@@ -164,25 +164,25 @@
 //!     ].join(" ")
 //! );
 //! ```
-//! 
+//!
 //! ### Builder
-//! 
+//!
 //! All the query statements and table statements support the following ways to build database specific SQL statement:
-//! 
-//! 1. `build(&self, query_builder: T) -> (String, Values)`  
+//!
+//! 1. `build(&self, query_builder: T) -> (String, Values)`
 //!     Build a SQL statement as string and parameters as a vector of values, see [here](https://docs.rs/sea-query/*/sea_query/query/struct.SelectStatement.html#method.build) for example.
-//! 
-//! 1. `build_collect(&self, query_builder: T, collector: &mut dyn FnMut(Value)) -> String`  
+//!
+//! 1. `build_collect(&self, query_builder: T, collector: &mut dyn FnMut(Value)) -> String`
 //!     Build a SQL statement as string and collect paramaters (usually for binding to binary protocol), see [here](https://docs.rs/sea-query/*/sea_query/query/struct.SelectStatement.html#method.build_collect) for example.
-//! 
-//! 1. `to_string(&self, query_builder: T) -> String`  
+//!
+//! 1. `to_string(&self, query_builder: T) -> String`
 //!     Build a SQL statement as string with parameters injected, see [here](https://docs.rs/sea-query/*/sea_query/query/struct.SelectStatement.html#method.to_string) for example.
-//! 
+//!
 //! ### Query Select
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let query = Query::select()
 //!     .column(Char::Character)
 //!     .column((Font::Table, Font::Name))
@@ -191,7 +191,7 @@
 //!     .and_where(Expr::col(Char::SizeW).is_in(vec![3, 4]))
 //!     .and_where(Expr::col(Char::Character).like("A%"))
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     query.to_string(MysqlQueryBuilder),
 //!     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` WHERE `size_w` IN (3, 4) AND `character` LIKE 'A%'"#
@@ -205,12 +205,12 @@
 //!     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` WHERE `size_w` IN (3, 4) AND `character` LIKE 'A%'"#
 //! );
 //! ```
-//! 
+//!
 //! ### Query Insert
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let query = Query::insert()
 //!     .into_table(Glyph::Table)
 //!     .columns(vec![
@@ -226,7 +226,7 @@
 //!         "123".into(),
 //!     ])
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     query.to_string(MysqlQueryBuilder),
 //!     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (5.15, '12A'), (4.21, '123')"#
@@ -240,12 +240,12 @@
 //!     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (5.15, '12A'), (4.21, '123')"#
 //! );
 //! ```
-//! 
+//!
 //! ### Query Update
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let query = Query::update()
 //!     .table(Glyph::Table)
 //!     .values(vec![
@@ -254,7 +254,7 @@
 //!     ])
 //!     .and_where(Expr::col(Glyph::Id).eq(1))
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     query.to_string(MysqlQueryBuilder),
 //!     r#"UPDATE `glyph` SET `aspect` = 1.23, `image` = '123' WHERE `id` = 1"#
@@ -268,18 +268,18 @@
 //!     r#"UPDATE `glyph` SET `aspect` = 1.23, `image` = '123' WHERE `id` = 1"#
 //! );
 //! ```
-//! 
+//!
 //! ### Query Delete
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let query = Query::delete()
 //!     .from_table(Glyph::Table)
 //!     .or_where(Expr::col(Glyph::Id).lt(1))
 //!     .or_where(Expr::col(Glyph::Id).gt(10))
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     query.to_string(MysqlQueryBuilder),
 //!     r#"DELETE FROM `glyph` WHERE (`id` < 1) OR (`id` > 10)"#
@@ -293,12 +293,12 @@
 //!     r#"DELETE FROM `glyph` WHERE (`id` < 1) OR (`id` > 10)"#
 //! );
 //! ```
-//! 
+//!
 //! ### Table Create
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let table = Table::create()
 //!     .table(Char::Table)
 //!     .if_not_exists()
@@ -317,7 +317,7 @@
 //!             .on_update(ForeignKeyAction::Cascade)
 //!     )
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     table.to_string(MysqlQueryBuilder),
 //!     vec![
@@ -365,17 +365,17 @@
 //!     ].join(" ")
 //! );
 //! ```
-//! 
+//!
 //! ### Table Alter
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let table = Table::alter()
 //!     .table(Font::Table)
 //!     .add_column(ColumnDef::new(Alias::new("new_col")).integer().not_null().default(100))
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     table.to_string(MysqlQueryBuilder),
 //!     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
@@ -389,17 +389,17 @@
 //!     r#"ALTER TABLE `font` ADD COLUMN `new_col` integer NOT NULL DEFAULT 100"#,
 //! );
 //! ```
-//! 
+//!
 //! ### Table Drop
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let table = Table::drop()
 //!     .table(Glyph::Table)
 //!     .table(Char::Table)
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     table.to_string(MysqlQueryBuilder),
 //!     r#"DROP TABLE `glyph`, `character`"#
@@ -413,16 +413,16 @@
 //!     r#"DROP TABLE `glyph`, `character`"#
 //! );
 //! ```
-//! 
+//!
 //! ### Table Rename
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let table = Table::rename()
 //!     .table(Font::Table, Alias::new("font_new"))
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     table.to_string(MysqlQueryBuilder),
 //!     r#"RENAME TABLE `font` TO `font_new`"#
@@ -436,16 +436,16 @@
 //!     r#"ALTER TABLE `font` RENAME TO `font_new`"#
 //! );
 //! ```
-//! 
+//!
 //! ### Table Truncate
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let table = Table::truncate()
 //!     .table(Font::Table)
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     table.to_string(MysqlQueryBuilder),
 //!     r#"TRUNCATE TABLE `font`"#
@@ -459,12 +459,12 @@
 //!     r#"TRUNCATE TABLE `font`"#
 //! );
 //! ```
-//! 
+//!
 //! ### Foreign Key Create
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let foreign_key = ForeignKey::create()
 //!     .name("FK_character_font")
 //!     .from(Char::Table, Char::FontId)
@@ -472,7 +472,7 @@
 //!     .on_delete(ForeignKeyAction::Cascade)
 //!     .on_update(ForeignKeyAction::Cascade)
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     foreign_key.to_string(MysqlQueryBuilder),
 //!     vec![
@@ -492,17 +492,17 @@
 //! );
 //! // Sqlite does not support modification of foreign key constraints to existing tables
 //! ```
-//! 
+//!
 //! ### Foreign Key Drop
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let foreign_key = ForeignKey::drop()
 //!     .name("FK_character_font")
 //!     .table(Char::Table)
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     foreign_key.to_string(MysqlQueryBuilder),
 //!     r#"ALTER TABLE `character` DROP FOREIGN KEY `FK_character_font`"#
@@ -513,18 +513,18 @@
 //! );
 //! // Sqlite does not support modification of foreign key constraints to existing tables
 //! ```
-//! 
+//!
 //! ### Index Create
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let index = Index::create()
 //!     .name("idx-glyph-aspect")
 //!     .table(Glyph::Table)
 //!     .col(Glyph::Aspect)
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     index.to_string(MysqlQueryBuilder),
 //!     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"#
@@ -538,17 +538,17 @@
 //!     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"#
 //! );
 //! ```
-//! 
+//!
 //! ### Index Drop
-//! 
+//!
 //! ```rust
 //! use sea_query::{*, tests_cfg::*};
-//! 
+//!
 //! let index = Index::drop()
 //!     .name("idx-glyph-aspect")
 //!     .table(Glyph::Table)
 //!     .to_owned();
-//! 
+//!
 //! assert_eq!(
 //!     index.to_string(MysqlQueryBuilder),
 //!     r#"DROP INDEX `idx-glyph-aspect` ON `glyph`"#

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -577,6 +577,7 @@ pub mod prepare;
 pub mod schema;
 pub mod tests_cfg;
 pub mod token;
+pub mod traits;
 pub mod types;
 pub mod value;
 

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -1,18 +1,18 @@
 use crate::{backend::QueryBuilder, types::*, expr::*, value::*, prepare::*};
 
 /// Delete existing rows from the table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let query = Query::delete()
 ///     .from_table(Glyph::Table)
 ///     .or_where(Expr::col(Glyph::Id).lt(1))
 ///     .or_where(Expr::col(Glyph::Id).gt(10))
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     query.to_string(MysqlQueryBuilder),
 ///     r#"DELETE FROM `glyph` WHERE (`id` < 1) OR (`id` > 10)"#
@@ -52,17 +52,17 @@ impl DeleteStatement {
     }
 
     /// Specify which table to delete from.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::delete()
     ///     .from_table(Glyph::Table)
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"DELETE FROM `glyph` WHERE `id` = 1"#
@@ -84,18 +84,18 @@ impl DeleteStatement {
     }
 
     /// And where condition.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::delete()
     ///     .from_table(Glyph::Table)
     ///     .and_where(Expr::col(Glyph::Id).gt(1))
     ///     .and_where(Expr::col(Glyph::Id).lt(10))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"DELETE FROM `glyph` WHERE (`id` > 1) AND (`id` < 10)"#
@@ -114,18 +114,18 @@ impl DeleteStatement {
     }
 
     /// And where condition.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::delete()
     ///     .from_table(Glyph::Table)
     ///     .or_where(Expr::col(Glyph::Id).lt(1))
     ///     .or_where(Expr::col(Glyph::Id).gt(10))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"DELETE FROM `glyph` WHERE (`id` < 1) OR (`id` > 10)"#
@@ -145,7 +145,7 @@ impl DeleteStatement {
 
     fn and_or_where(&mut self, bopr: BinOper, right: SimpleExpr) -> &mut Self {
         self.wherei = Self::merge_expr(
-            self.wherei.take(), 
+            self.wherei.take(),
             match bopr {
                 BinOper::And => BinOper::And,
                 BinOper::Or => BinOper::Or,
@@ -168,7 +168,7 @@ impl DeleteStatement {
     }
 
     /// Order by column.
-    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self 
+    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self
         where T: IntoColumnRef {
         self.orders.push(OrderExpr {
             expr: SimpleExpr::Column(col.into_column_ref()),
@@ -183,7 +183,7 @@ impl DeleteStatement {
     )]
     /// Order by column with table name prefix.
     pub fn order_by_tbl<T, C>
-        (&mut self, table: T, col: C, order: Order) -> &mut Self 
+        (&mut self, table: T, col: C, order: Order) -> &mut Self
         where T: IntoIden, C: IntoIden {
         self.order_by((table.into_iden(), col.into_iden()), order)
     }
@@ -254,25 +254,25 @@ impl DeleteStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::delete()
     ///     .from_table(Glyph::Table)
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"DELETE FROM `glyph` WHERE `id` = 1"#
     /// );
-    /// 
+    ///
     /// let mut params = Vec::new();
     /// let mut collector = |v| params.push(v);
-    /// 
+    ///
     /// assert_eq!(
     ///     query.build_collect(MysqlQueryBuilder, &mut collector),
     ///     r#"DELETE FROM `glyph` WHERE `id` = ?"#
@@ -290,7 +290,7 @@ impl DeleteStatement {
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and collect query parameters    
+    /// Build corresponding SQL statement for certain database backend and collect query parameters
     pub fn build_collect_any(&self, query_builder: &dyn QueryBuilder, collector: &mut dyn FnMut(Value)) -> String {
         let mut sql = SqlWriter::new();
         query_builder.prepare_delete_statement(self, &mut sql, collector);
@@ -298,17 +298,17 @@ impl DeleteStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let (query, params) = Query::delete()
     ///     .from_table(Glyph::Table)
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .build(MysqlQueryBuilder);
-    /// 
+    ///
     /// assert_eq!(
     ///     query,
     ///     r#"DELETE FROM `glyph` WHERE `id` = ?"#
@@ -336,17 +336,17 @@ impl DeleteStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::delete()
     ///     .from_table(Glyph::Table)
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .to_string(MysqlQueryBuilder);
-    /// 
+    ///
     /// assert_eq!(
     ///     query,
     ///     r#"DELETE FROM `glyph` WHERE `id` = 1"#

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 #[cfg(feature="with-json")]
 use serde_json::Value as JsonValue;
 use crate::{backend::QueryBuilder, Query, SelectExpr, SelectStatement, types::*, value::*, prepare::*, error::*};
+pub use crate::traits::QueryStatementBuilder;
 
 /// Insert any new rows into an existing table
 ///
@@ -272,7 +273,9 @@ impl InsertStatement {
         self.values.push(values);
         self
     }
+}
 
+impl QueryStatementBuilder for InsertStatement {
     /// Build corresponding SQL statement for certain database backend and collect query parameters
     ///
     /// # Examples
@@ -312,91 +315,15 @@ impl InsertStatement {
     ///     ]
     /// );
     /// ```
-    pub fn build_collect<T: QueryBuilder>(&self, query_builder: T, collector: &mut dyn FnMut(Value)) -> String {
+    fn build_collect<T: QueryBuilder>(&self, query_builder: T, collector: &mut dyn FnMut(Value)) -> String {
         let mut sql = SqlWriter::new();
         query_builder.prepare_insert_statement(self, &mut sql, collector);
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and collect query parameters
-    pub fn build_collect_any(&self, query_builder: &dyn QueryBuilder, collector: &mut dyn FnMut(Value)) -> String {
+    fn build_collect_any(&self, query_builder: &dyn QueryBuilder, collector: &mut dyn FnMut(Value)) -> String {
         let mut sql = SqlWriter::new();
         query_builder.prepare_insert_statement(self, &mut sql, collector);
         sql.result()
-    }
-
-    /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
-    /// 
-    /// # Examples
-    /// 
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    /// 
-    /// let (query, params) = Query::insert()
-    ///     .into_table(Glyph::Table)
-    ///     .columns(vec![
-    ///         Glyph::Aspect,
-    ///         Glyph::Image,
-    ///     ])
-    ///     .values_panic(vec![
-    ///         3.1415.into(),
-    ///         "04108048005887010020060000204E0180400400".into(),
-    ///     ])
-    ///     .build(MysqlQueryBuilder);
-    /// 
-    /// assert_eq!(
-    ///     query,
-    ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (?, ?)"#
-    /// );
-    /// assert_eq!(
-    ///     params,
-    ///     Values(vec![
-    ///         Value::Double(3.1415),
-    ///         Value::String(Box::new(String::from("04108048005887010020060000204E0180400400"))),
-    ///     ])
-    /// );
-    /// ```
-    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
-        let mut values = Vec::new();
-        let mut collector = |v| values.push(v);
-        let sql = self.build_collect(query_builder, &mut collector);
-        (sql, Values(values))
-    }
-
-    /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
-    pub fn build_any(&self, query_builder: &dyn QueryBuilder) -> (String, Values) {
-        let mut values = Vec::new();
-        let mut collector = |v| values.push(v);
-        let sql = self.build_collect_any(query_builder, &mut collector);
-        (sql, Values(values))
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    /// 
-    /// # Examples
-    /// 
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    /// 
-    /// let query = Query::insert()
-    ///     .into_table(Glyph::Table)
-    ///     .columns(vec![
-    ///         Glyph::Aspect,
-    ///         Glyph::Image,
-    ///     ])
-    ///     .values_panic(vec![
-    ///         3.1415.into(),
-    ///         "041".into(),
-    ///     ])
-    ///     .to_string(MysqlQueryBuilder);
-    /// 
-    /// assert_eq!(
-    ///     query,
-    ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (3.1415, '041')"#
-    /// );
-    /// ```
-    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
-        let (sql, values) = self.build_any(&query_builder);
-        inject_parameters(&sql, values.0, &query_builder)
     }
 }

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -4,12 +4,12 @@ use serde_json::Value as JsonValue;
 use crate::{backend::QueryBuilder, Query, SelectExpr, SelectStatement, types::*, value::*, prepare::*, error::*};
 
 /// Insert any new rows into an existing table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let query = Query::insert()
 ///     .into_table(Glyph::Table)
 ///     .columns(vec![
@@ -25,7 +25,7 @@ use crate::{backend::QueryBuilder, Query, SelectExpr, SelectStatement, types::*,
 ///         "123".into(),
 ///     ])
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     query.to_string(MysqlQueryBuilder),
 ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (5.15, '12A'), (4.21, '123')"#
@@ -54,9 +54,9 @@ impl InsertStatement {
     }
 
     /// Specify which table to insert into.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// See [`InsertStatement::values`]
     #[allow(clippy::wrong_self_convention)]
     pub fn into_table<T>(&mut self, tbl_ref: T) -> &mut Self
@@ -66,9 +66,9 @@ impl InsertStatement {
     }
 
     /// Specify what columns to insert.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// See [`InsertStatement::values`]
     pub fn columns<C, I>(&mut self, columns: I) -> &mut Self
     where
@@ -80,12 +80,12 @@ impl InsertStatement {
     }
 
     /// Specify a row of values to be inserted.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns(vec![
@@ -102,7 +102,7 @@ impl InsertStatement {
     ///         "12A".into(),
     ///     ])
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (2.1345, '24B'), (5.15, '12A')"#
@@ -139,11 +139,11 @@ impl InsertStatement {
         self.values(values).unwrap()
     }
 
-    /// RETURNING expressions. Postgres only. 
-    /// 
+    /// RETURNING expressions. Postgres only.
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns(vec![
@@ -154,7 +154,7 @@ impl InsertStatement {
     ///     ])
     ///     .returning(Query::select().column(Glyph::Id).take())
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     "INSERT INTO `glyph` (`image`) VALUES ('12A')"
@@ -175,10 +175,10 @@ impl InsertStatement {
 
     /// RETURNING a column after insertion. Postgres only. This is equivalent to MySQL's LAST_INSERT_ID.
     /// Wrapper over [`InsertStatement::returning()`].
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns(vec![
@@ -189,7 +189,7 @@ impl InsertStatement {
     ///     ])
     ///     .returning_col(Glyph::Id)
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     "INSERT INTO `glyph` (`image`) VALUES ('12A')"
@@ -210,12 +210,12 @@ impl InsertStatement {
 
     /// Specify a row of values to be inserted, taking input of json values. A convenience method if you have multiple
     /// rows to insert at once.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns(vec![
@@ -231,7 +231,7 @@ impl InsertStatement {
     ///         "image": "123",
     ///     }))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (2.1345, '24B'), (4.21, '123')"#
@@ -274,12 +274,12 @@ impl InsertStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns(vec![
@@ -291,15 +291,15 @@ impl InsertStatement {
     ///         "041080".into(),
     ///     ])
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (3.1415, '041080')"#
     /// );
-    /// 
+    ///
     /// let mut params = Vec::new();
     /// let mut collector = |v| params.push(v);
-    /// 
+    ///
     /// assert_eq!(
     ///     query.build_collect(MysqlQueryBuilder, &mut collector),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (?, ?)"#

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,7 +1,7 @@
 //! Query statements (select, insert, update & delete).
-//! 
+//!
 //! # Usage
-//! 
+//!
 //! - Query Select, see [`SelectStatement`]
 //! - Query Insert, see [`InsertStatement`]
 //! - Query Update, see [`UpdateStatement`]

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -3,12 +3,12 @@ use crate::{backend::QueryBuilder, types::*, expr::*, value::*, prepare::*};
 use std::iter::FromIterator;
 
 /// Select rows from an existing table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let query = Query::select()
 ///     .column(Char::Character)
 ///     .table_column(Font::Table, Font::Name)
@@ -17,7 +17,7 @@ use std::iter::FromIterator;
 ///     .and_where(Expr::col(Char::SizeW).is_in(vec![3, 4]))
 ///     .and_where(Expr::col(Char::Character).like("A%"))
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     query.to_string(MysqlQueryBuilder),
 ///     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` WHERE `size_w` IN (3, 4) AND `character` LIKE 'A%'"#
@@ -117,12 +117,12 @@ impl SelectStatement {
     }
 
     /// A shorthand to express if ... else ... when constructing the select statement.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Char::Character)
     ///     .from(Char::Table)
@@ -132,7 +132,7 @@ impl SelectStatement {
     ///         |x| { x.and_where(Expr::col(Char::FontId).eq(10)); }
     ///     )
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5"#
@@ -163,12 +163,12 @@ impl SelectStatement {
     }
 
     /// Add an expression to the select expression list.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .from(Char::Table)
     ///     .expr(Expr::val(42))
@@ -177,7 +177,7 @@ impl SelectStatement {
     ///         expr.add(Expr::value(i))
     ///     }))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT 42, MAX(`id`), 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 FROM `character`"#
@@ -198,12 +198,12 @@ impl SelectStatement {
     }
 
     /// Add select expressions from vector of [`SelectExpr`].
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .from(Char::Table)
     ///     .exprs(vec![
@@ -213,7 +213,7 @@ impl SelectStatement {
     ///         }),
     ///     ])
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT MAX(`id`), 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 FROM `character`"#
@@ -244,19 +244,19 @@ impl SelectStatement {
     }
 
     /// Add a column to the select expression list.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .from(Char::Table)
     ///     .column(Char::Character)
     ///     .column(Char::SizeW)
     ///     .column(Char::SizeH)
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character`"#
@@ -270,15 +270,15 @@ impl SelectStatement {
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character`"#
     /// );
     /// ```
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .from(Char::Table)
     ///     .column((Char::Table, Char::Character))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`.`character` FROM `character`"#
@@ -307,12 +307,12 @@ impl SelectStatement {
     }
 
     /// Select columns.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .from(Char::Table)
     ///     .columns(vec![
@@ -321,7 +321,7 @@ impl SelectStatement {
     ///         Char::SizeH,
     ///     ])
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character`"#
@@ -335,10 +335,10 @@ impl SelectStatement {
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character`"#
     /// );
     /// ```
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .from(Char::Table)
     ///     .columns(vec![
@@ -347,7 +347,7 @@ impl SelectStatement {
     ///         (Char::Table, Char::SizeH),
     ///     ])
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`.`character`, `character`.`size_w`, `character`.`size_h` FROM `character`"#
@@ -390,17 +390,17 @@ impl SelectStatement {
     }
 
     /// Select column.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .from(Char::Table)
     ///     .expr_as(Expr::col(Char::Character), Alias::new("C"))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character` AS `C` FROM `character`"#
@@ -433,17 +433,17 @@ impl SelectStatement {
     }
 
     /// From table.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Char::FontSize)
     ///     .from(Char::Table)
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `font_size` FROM `character`"#
@@ -457,15 +457,15 @@ impl SelectStatement {
     ///     r#"SELECT `font_size` FROM `character`"#
     /// );
     /// ```
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Char::FontSize)
     ///     .from((Char::Table, Glyph::Table))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `font_size` FROM `character`.`glyph`"#
@@ -489,17 +489,17 @@ impl SelectStatement {
         note = "Please use the [`SelectStatement::from`] with a tuple as [`TableRef`]"
     )]
     /// From schema.table.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Char::FontSize)
     ///     .from_schema(Char::Table, Glyph::Table)
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `font_size` FROM `character`.`glyph`"#
@@ -519,20 +519,20 @@ impl SelectStatement {
     }
 
     /// From table with alias.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use std::rc::Rc;
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let table_as: Rc<dyn Iden> = Rc::new(Alias::new("char"));
-    /// 
+    ///
     /// let query = Query::select()
     ///     .from_as(Char::Table, table_as.clone())
     ///     .table_column(table_as.clone(), Char::Character)
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `char`.`character` FROM `character` AS `char`"#
@@ -549,14 +549,14 @@ impl SelectStatement {
     ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let table_as = Alias::new("alias");
-    /// 
+    ///
     /// let query = Query::select()
     ///     .from_as((Font::Table, Char::Table), table_as.clone())
     ///     .table_column(table_as, Char::Character)
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `alias`.`character` FROM `font`.`character` AS `alias`"#
@@ -594,12 +594,12 @@ impl SelectStatement {
     }
 
     /// From sub-query.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .columns(vec![
     ///         Glyph::Image
@@ -614,7 +614,7 @@ impl SelectStatement {
     ///         Alias::new("subglyph")
     ///     )
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `image` FROM (SELECT `image`, `aspect` FROM `glyph`) AS `subglyph`"#
@@ -639,19 +639,19 @@ impl SelectStatement {
     }
 
     /// Left join.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Char::Character)
     ///     .table_column(Font::Table, Font::Name)
     ///     .from(Char::Table)
     ///     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id`"#
@@ -665,25 +665,25 @@ impl SelectStatement {
     ///     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// ```
-    pub fn left_join<R>(&mut self, tbl_ref: R, condition: SimpleExpr) -> &mut Self 
+    pub fn left_join<R>(&mut self, tbl_ref: R, condition: SimpleExpr) -> &mut Self
         where R: IntoTableRef {
         self.join(JoinType::LeftJoin, tbl_ref, condition)
     }
 
     /// Inner join.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Char::Character)
     ///     .table_column(Font::Table, Font::Name)
     ///     .from(Char::Table)
     ///     .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
@@ -697,25 +697,25 @@ impl SelectStatement {
     ///     r#"SELECT `character`, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// ```
-    pub fn inner_join<R>(&mut self, tbl_ref: R, condition: SimpleExpr) -> &mut Self 
+    pub fn inner_join<R>(&mut self, tbl_ref: R, condition: SimpleExpr) -> &mut Self
         where R: IntoTableRef {
         self.join(JoinType::InnerJoin, tbl_ref, condition)
     }
 
     /// Join with other table by [`JoinType`].
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Char::Character)
     ///     .table_column(Font::Table, Font::Name)
     ///     .from(Char::Table)
     ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id`"#
@@ -729,7 +729,7 @@ impl SelectStatement {
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// ```
-    pub fn join<R>(&mut self, join: JoinType, tbl_ref: R, condition: SimpleExpr) -> &mut Self 
+    pub fn join<R>(&mut self, join: JoinType, tbl_ref: R, condition: SimpleExpr) -> &mut Self
         where R: IntoTableRef {
         self.join_join(join, tbl_ref.into_table_ref(), JoinOn::Condition(Box::new(condition)))
     }
@@ -766,7 +766,7 @@ impl SelectStatement {
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` AS `f` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// ```
-    pub fn join_as<R, A>(&mut self, join: JoinType, tbl_ref: R, alias: A, condition: SimpleExpr) -> &mut Self 
+    pub fn join_as<R, A>(&mut self, join: JoinType, tbl_ref: R, alias: A, condition: SimpleExpr) -> &mut Self
         where R: IntoTableRef, A: IntoIden {
         self.join_join(join, tbl_ref.into_table_ref().alias(alias.into_iden()), JoinOn::Condition(Box::new(condition)))
     }
@@ -775,19 +775,19 @@ impl SelectStatement {
         since = "0.6.1",
         note = "Please use the [`SelectStatement::join_as`] instead"
     )]
-    pub fn join_alias<R, A>(&mut self, join: JoinType, tbl_ref: R, alias: A, condition: SimpleExpr) -> &mut Self 
+    pub fn join_alias<R, A>(&mut self, join: JoinType, tbl_ref: R, alias: A, condition: SimpleExpr) -> &mut Self
         where R: IntoTableRef, A: IntoIden {
         self.join_as(join, tbl_ref, alias, condition)
     }
 
     /// Join with sub-query.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use std::rc::Rc;
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let sub_glyph: Rc<dyn Iden> = Rc::new(Alias::new("sub_glyph"));
     /// let query = Query::select()
     ///     .column(Font::Name)
@@ -802,7 +802,7 @@ impl SelectStatement {
     ///         Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id)
     ///     )
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `name` FROM `font` LEFT JOIN (SELECT `id` FROM `glyph`) AS `sub_glyph` ON `font`.`id` = `sub_glyph`.`id`"#
@@ -816,7 +816,7 @@ impl SelectStatement {
     ///     r#"SELECT `name` FROM `font` LEFT JOIN (SELECT `id` FROM `glyph`) AS `sub_glyph` ON `font`.`id` = `sub_glyph`.`id`"#
     /// );
     /// ```
-    /// 
+    ///
     pub fn join_subquery<T>(&mut self, join: JoinType, query: SelectStatement, alias: T, condition: SimpleExpr) -> &mut Self
         where T: IntoIden {
         self.join_join(join, TableRef::SubQuery(query, alias.into_iden()), JoinOn::Condition(Box::new(condition)))
@@ -832,12 +832,12 @@ impl SelectStatement {
     }
 
     /// Group by columns.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Char::Character)
     ///     .table_column(Font::Table, Font::Name)
@@ -847,7 +847,7 @@ impl SelectStatement {
     ///         Char::Character,
     ///     ])
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id` GROUP BY `character`"#
@@ -861,10 +861,10 @@ impl SelectStatement {
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id` GROUP BY `character`"#
     /// );
     /// ```
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Char::Character)
     ///     .table_column(Font::Table, Font::Name)
@@ -874,7 +874,7 @@ impl SelectStatement {
     ///         (Char::Table, Char::Character),
     ///     ])
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id` GROUP BY `character`.`character`"#
@@ -901,10 +901,10 @@ impl SelectStatement {
     }
 
     /// Add a group by column.
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Char::Character)
     ///     .table_column(Font::Table, Font::Name)
@@ -912,7 +912,7 @@ impl SelectStatement {
     ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
     ///     .group_by_col((Char::Table, Char::Character))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id` GROUP BY `character`.`character`"#
@@ -950,19 +950,19 @@ impl SelectStatement {
     }
 
     /// And where condition.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .table_column(Glyph::Table, Glyph::Image)
     ///     .from(Glyph::Table)
     ///     .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
     ///     .and_where(Expr::tbl(Glyph::Table, Glyph::Image).like("A%"))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `glyph`.`image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4) AND `glyph`.`image` LIKE 'A%'"#
@@ -990,19 +990,19 @@ impl SelectStatement {
     }
 
     /// Or where condition.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .table_column(Glyph::Table, Glyph::Image)
     ///     .from(Glyph::Table)
     ///     .or_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
     ///     .or_where(Expr::tbl(Glyph::Table, Glyph::Image).like("A%"))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `glyph`.`image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4) OR `glyph`.`image` LIKE 'A%'"#
@@ -1022,12 +1022,12 @@ impl SelectStatement {
     }
 
     /// Add group by expressions from vector of [`SelectExpr`].
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .from(Char::Table)
     ///     .column(Char::Character)
@@ -1036,7 +1036,7 @@ impl SelectStatement {
     ///         Expr::col(Char::SizeH).into(),
     ///     ])
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` GROUP BY `size_w`, `size_h`"#
@@ -1059,12 +1059,12 @@ impl SelectStatement {
     }
 
     /// And having condition.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .expr(Expr::col(Glyph::Image).max())
@@ -1075,7 +1075,7 @@ impl SelectStatement {
     ///     .and_having(Expr::col(Glyph::Aspect).gt(2))
     ///     .and_having(Expr::col(Glyph::Aspect).lt(8))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` > 2 AND `aspect` < 8"#
@@ -1095,12 +1095,12 @@ impl SelectStatement {
     }
 
     /// Or having condition.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .expr(Expr::col(Glyph::Image).max())
@@ -1111,7 +1111,7 @@ impl SelectStatement {
     ///     .or_having(Expr::col(Glyph::Aspect).lt(1))
     ///     .or_having(Expr::col(Glyph::Aspect).gt(10))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` < 1 OR `aspect` > 10"#
@@ -1131,12 +1131,12 @@ impl SelectStatement {
     }
 
     /// Order by column.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
@@ -1144,7 +1144,7 @@ impl SelectStatement {
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
@@ -1158,7 +1158,7 @@ impl SelectStatement {
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
     /// ```
-    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self 
+    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self
         where T: IntoColumnRef {
         self.orders.push(OrderExpr {
             expr: SimpleExpr::Column(col.into_column_ref()),
@@ -1172,7 +1172,7 @@ impl SelectStatement {
         note = "Please use the [`SelectStatement::order_by`] with a tuple as [`ColumnRef`]"
     )]
     pub fn order_by_tbl<T, C>
-        (&mut self, table: T, col: C, order: Order) -> &mut Self 
+        (&mut self, table: T, col: C, order: Order) -> &mut Self
         where T: IntoIden, C: IntoIden {
         self.order_by((table.into_iden(), col.into_iden()), order)
     }
@@ -1237,18 +1237,18 @@ impl SelectStatement {
     }
 
     /// Limit the number of returned rows.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
     ///     .limit(10)
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `aspect` FROM `glyph` LIMIT 10"#
@@ -1268,19 +1268,19 @@ impl SelectStatement {
     }
 
     /// Offset number of returned rows.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
     ///     .limit(10)
     ///     .offset(10)
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `aspect` FROM `glyph` LIMIT 10 OFFSET 10"#
@@ -1300,12 +1300,12 @@ impl SelectStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
@@ -1313,15 +1313,15 @@ impl SelectStatement {
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by_tbl(Glyph::Table, Glyph::Aspect, Order::Asc)
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
-    /// 
+    ///
     /// let mut params = Vec::new();
     /// let mut collector = |v| params.push(v);
-    /// 
+    ///
     /// assert_eq!(
     ///     query.build_collect(MysqlQueryBuilder, &mut collector),
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, ?) > ? ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
@@ -1345,12 +1345,12 @@ impl SelectStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let (query, params) = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
@@ -1358,7 +1358,7 @@ impl SelectStatement {
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by_tbl(Glyph::Table, Glyph::Aspect, Order::Asc)
     ///     .build(MysqlQueryBuilder);
-    /// 
+    ///
     /// assert_eq!(
     ///     query,
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, ?) > ? ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
@@ -1384,12 +1384,12 @@ impl SelectStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
@@ -1397,7 +1397,7 @@ impl SelectStatement {
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by_tbl(Glyph::Table, Glyph::Aspect, Order::Asc)
     ///     .to_string(MysqlQueryBuilder);
-    /// 
+    ///
     /// assert_eq!(
     ///     query,
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -3,12 +3,12 @@ use serde_json::Value as JsonValue;
 use crate::{backend::QueryBuilder, types::*, expr::*, value::*, prepare::*};
 
 /// Update existing rows in the table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let query = Query::update()
 ///     .table(Glyph::Table)
 ///     .values(vec![
@@ -17,7 +17,7 @@ use crate::{backend::QueryBuilder, types::*, expr::*, value::*, prepare::*};
 ///     ])
 ///     .and_where(Expr::col(Glyph::Id).eq(1))
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     query.to_string(MysqlQueryBuilder),
 ///     r#"UPDATE `glyph` SET `aspect` = 1.23, `image` = '123' WHERE `id` = 1"#
@@ -59,9 +59,9 @@ impl UpdateStatement {
     }
 
     /// Specify which table to update.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// See [`UpdateStatement::values`]
     #[allow(clippy::wrong_self_convention)]
     pub fn table<T>(&mut self, tbl_ref: T) -> &mut Self
@@ -81,12 +81,12 @@ impl UpdateStatement {
     }
 
     /// Update column value by [`SimpleExpr`].
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::update()
     ///     .table(Glyph::Table)
     ///     .value_expr(Glyph::Aspect, Expr::cust("60 * 24 * 24"))
@@ -95,7 +95,7 @@ impl UpdateStatement {
     ///     ])
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 60 * 24 * 24, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1"#
@@ -116,12 +116,12 @@ impl UpdateStatement {
     }
 
     /// Update column values by [`JsonValue`]. A convenience method if you have multiple column-value pairs to set at once.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::update()
     ///     .table(Glyph::Table)
     ///     .json(json!({
@@ -130,7 +130,7 @@ impl UpdateStatement {
     ///     }))
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#
@@ -159,12 +159,12 @@ impl UpdateStatement {
     }
 
     /// Update column values.. A convenience method if you have multiple column-value pairs to set at once.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::update()
     ///     .table(Glyph::Table)
     ///     .values(vec![
@@ -173,7 +173,7 @@ impl UpdateStatement {
     ///     ])
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#
@@ -199,19 +199,19 @@ impl UpdateStatement {
     }
 
     /// Update column values.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::update()
     ///     .table(Glyph::Table)
     ///     .value(Glyph::Aspect, 2.1345.into())
     ///     .value(Glyph::Image, "235m".into())
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#
@@ -237,12 +237,12 @@ impl UpdateStatement {
     }
 
     /// And where condition.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::update()
     ///     .table(Glyph::Table)
     ///     .values(vec![
@@ -252,7 +252,7 @@ impl UpdateStatement {
     ///     .and_where(Expr::col(Glyph::Id).gt(1))
     ///     .and_where(Expr::col(Glyph::Id).lt(3))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE (`id` > 1) AND (`id` < 3)"#
@@ -271,12 +271,12 @@ impl UpdateStatement {
     }
 
     /// Or where condition.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::update()
     ///     .table(Glyph::Table)
     ///     .values(vec![
@@ -286,7 +286,7 @@ impl UpdateStatement {
     ///     .or_where(Expr::col(Glyph::Aspect).lt(1))
     ///     .or_where(Expr::col(Glyph::Aspect).gt(3))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE (`aspect` < 1) OR (`aspect` > 3)"#
@@ -306,7 +306,7 @@ impl UpdateStatement {
 
     fn and_or_where(&mut self, bopr: BinOper, right: SimpleExpr) -> &mut Self {
         self.wherei = Self::merge_expr(
-            self.wherei.take(), 
+            self.wherei.take(),
             match bopr {
                 BinOper::And => BinOper::And,
                 BinOper::Or => BinOper::Or,
@@ -329,7 +329,7 @@ impl UpdateStatement {
     }
 
     /// Order by column.
-    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self 
+    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self
         where T: IntoColumnRef {
         self.orders.push(OrderExpr {
             expr: SimpleExpr::Column(col.into_column_ref()),
@@ -343,7 +343,7 @@ impl UpdateStatement {
         note = "Please use the [`UpdateStatement::order_by`] with a tuple as [`ColumnRef`]"
     )]
     pub fn order_by_tbl<T, C>
-        (&mut self, table: T, col: C, order: Order) -> &mut Self 
+        (&mut self, table: T, col: C, order: Order) -> &mut Self
         where T: IntoIden, C: IntoIden {
         self.order_by((table.into_iden(), col.into_iden()), order)
     }
@@ -415,12 +415,12 @@ impl UpdateStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::update()
     ///     .table(Glyph::Table)
     ///     .values(vec![
@@ -429,15 +429,15 @@ impl UpdateStatement {
     ///     ])
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#
     /// );
-    /// 
+    ///
     /// let mut params = Vec::new();
     /// let mut collector = |v| params.push(v);
-    /// 
+    ///
     /// assert_eq!(
     ///     query.build_collect(MysqlQueryBuilder, &mut collector),
     ///     r#"UPDATE `glyph` SET `aspect` = ?, `image` = ? WHERE `id` = ?"#
@@ -465,12 +465,12 @@ impl UpdateStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let (query, params) = Query::update()
     ///     .table(Glyph::Table)
     ///     .values(vec![
@@ -479,7 +479,7 @@ impl UpdateStatement {
     ///     ])
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .build(MysqlQueryBuilder);
-    /// 
+    ///
     /// assert_eq!(
     ///     query,
     ///     r#"UPDATE `glyph` SET `aspect` = ?, `image` = ? WHERE `id` = ?"#
@@ -509,12 +509,12 @@ impl UpdateStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let query = Query::update()
     ///     .table(Glyph::Table)
     ///     .values(vec![
@@ -523,7 +523,7 @@ impl UpdateStatement {
     ///     ])
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
     ///     .to_string(MysqlQueryBuilder);
-    /// 
+    ///
     /// assert_eq!(
     ///     query,
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -2,17 +2,17 @@ use std::rc::Rc;
 use crate::{ColumnDef, backend::TableBuilder, types::*, prepare::*};
 
 /// Alter a table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let table = Table::alter()
 ///     .table(Font::Table)
 ///     .add_column(ColumnDef::new(Alias::new("new_col")).integer().not_null().default(100))
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     table.to_string(MysqlQueryBuilder),
 ///     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
@@ -64,17 +64,17 @@ impl TableAlterStatement {
     }
 
     /// Add a column to an existing table
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let table = Table::alter()
     ///     .table(Font::Table)
     ///     .add_column(ColumnDef::new(Alias::new("new_col")).integer().not_null().default(100))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     table.to_string(MysqlQueryBuilder),
     ///     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
@@ -93,17 +93,17 @@ impl TableAlterStatement {
     }
 
     /// Modify a column in an existing table
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let table = Table::alter()
     ///     .table(Font::Table)
     ///     .modify_column(ColumnDef::new(Alias::new("new_col")).big_integer().default(999))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     table.to_string(MysqlQueryBuilder),
     ///     r#"ALTER TABLE `font` MODIFY COLUMN `new_col` bigint DEFAULT 999"#
@@ -123,17 +123,17 @@ impl TableAlterStatement {
     }
 
     /// Rename a column in an existing table
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let table = Table::alter()
     ///     .table(Font::Table)
     ///     .rename_column(Alias::new("new_col"), Alias::new("new_column"))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     table.to_string(MysqlQueryBuilder),
     ///     r#"ALTER TABLE `font` RENAME COLUMN `new_col` TO `new_column`"#
@@ -153,17 +153,17 @@ impl TableAlterStatement {
     }
 
     /// Add a column to existing table
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let table = Table::alter()
     ///     .table(Font::Table)
     ///     .drop_column(Alias::new("new_column"))
     ///     .to_owned();
-    /// 
+    ///
     /// assert_eq!(
     ///     table.to_string(MysqlQueryBuilder),
     ///     r#"ALTER TABLE `font` DROP COLUMN `new_column`"#

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
-use crate::{ColumnDef, backend::TableBuilder, types::*, prepare::*};
+use crate::{ColumnDef, backend::SchemaBuilder, types::*, prepare::*};
+pub use crate::traits::SchemaStatementBuilder;
 
 /// Alter a table
 ///
@@ -183,23 +184,18 @@ impl TableAlterStatement {
         self.alter_option = Some(alter_option);
         self
     }
+}
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: TableBuilder>(&self, table_builder: T) -> String {
+impl SchemaStatementBuilder for TableAlterStatement {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = SqlWriter::new();
-        table_builder.prepare_table_alter_statement(self, &mut sql);
+        schema_builder.prepare_table_alter_statement(self, &mut sql);
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, table_builder: &dyn TableBuilder) -> String {
+    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
-        table_builder.prepare_table_alter_statement(self, &mut sql);
+        schema_builder.prepare_table_alter_statement(self, &mut sql);
         sql.result()
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: TableBuilder>(&self, table_builder: T) -> String {
-        self.build(table_builder)
     }
 }

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -2,12 +2,12 @@ use std::rc::Rc;
 use crate::{ColumnDef, backend::TableBuilder, foreign_key::*, index::*, types::*, prepare::*};
 
 /// Create a table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let table = Table::create()
 ///     .table(Char::Table)
 ///     .if_not_exists()
@@ -26,7 +26,7 @@ use crate::{ColumnDef, backend::TableBuilder, foreign_key::*, index::*, types::*
 ///             .on_update(ForeignKeyAction::Cascade)
 ///     )
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     table.to_string(MysqlQueryBuilder),
 ///     vec![
@@ -149,13 +149,13 @@ impl TableCreateStatement {
         self
     }
 
-    /// Add an index. MySQL only. 
-    /// 
+    /// Add an index. MySQL only.
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// assert_eq!(
     ///     Table::create()
     ///         .table(Glyph::Table)
@@ -181,12 +181,12 @@ impl TableCreateStatement {
     }
 
     /// Add an primary key.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use sea_query::{*, tests_cfg::*};
-    /// 
+    ///
     /// let mut statement = Table::create();
     /// statement
     ///     .table(Glyph::Table)

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
-use crate::{ColumnDef, backend::TableBuilder, foreign_key::*, index::*, types::*, prepare::*};
+use crate::{ColumnDef, backend::SchemaBuilder, foreign_key::*, index::*, types::*, prepare::*};
+pub use crate::traits::SchemaStatementBuilder;
 
 /// Create a table
 ///
@@ -266,23 +267,18 @@ impl TableCreateStatement {
         self.partitions.push(partition);
         self
     }
+}
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: TableBuilder>(&self, table_builder: T) -> String {
+impl SchemaStatementBuilder for TableCreateStatement {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = SqlWriter::new();
-        table_builder.prepare_table_create_statement(self, &mut sql);
+        schema_builder.prepare_table_create_statement(self, &mut sql);
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, table_builder: &dyn TableBuilder) -> String {
+    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
-        table_builder.prepare_table_create_statement(self, &mut sql);
+        schema_builder.prepare_table_create_statement(self, &mut sql);
         sql.result()
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: TableBuilder>(&self, table_builder: T) -> String {
-        self.build(table_builder)
     }
 }

--- a/src/table/drop.rs
+++ b/src/table/drop.rs
@@ -2,17 +2,17 @@ use std::rc::Rc;
 use crate::{backend::TableBuilder, types::*, prepare::*};
 
 /// Drop a table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let table = Table::drop()
 ///     .table(Glyph::Table)
 ///     .table(Char::Table)
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     table.to_string(MysqlQueryBuilder),
 ///     r#"DROP TABLE `glyph`, `character`"#

--- a/src/table/drop.rs
+++ b/src/table/drop.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
-use crate::{backend::TableBuilder, types::*, prepare::*};
+use crate::{backend::SchemaBuilder, types::*, prepare::*};
+pub use crate::traits::SchemaStatementBuilder;
 
 /// Drop a table
 ///
@@ -80,23 +81,18 @@ impl TableDropStatement {
         self.options.push(TableDropOpt::Cascade);
         self
     }
+}
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: TableBuilder>(&self, table_builder: T) -> String {
+impl SchemaStatementBuilder for TableDropStatement {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = SqlWriter::new();
-        table_builder.prepare_table_drop_statement(self, &mut sql);
+        schema_builder.prepare_table_drop_statement(self, &mut sql);
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, table_builder: &dyn TableBuilder) -> String {
+    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
-        table_builder.prepare_table_drop_statement(self, &mut sql);
+        schema_builder.prepare_table_drop_statement(self, &mut sql);
         sql.result()
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: TableBuilder>(&self, table_builder: T) -> String {
-        self.build(table_builder)
     }
 }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -8,7 +8,7 @@
 //! - Table Rename, see [`TableRenameStatement`]
 //! - Table Truncate, see [`TableTruncateStatement`]
 
-use crate::TableBuilder;
+use crate::SchemaBuilder;
 
 mod alter;
 mod column;
@@ -67,7 +67,7 @@ impl Table {
 
 impl TableStatement {
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: TableBuilder>(&self, table_builder: T) -> String {
+    pub fn build<T: SchemaBuilder>(&self, table_builder: T) -> String {
         match self {
             Self::Create(stat) => stat.build(table_builder),
             Self::Alter(stat) => stat.build(table_builder),
@@ -78,7 +78,7 @@ impl TableStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, table_builder: &dyn TableBuilder) -> String {
+    pub fn build_any(&self, table_builder: &dyn SchemaBuilder) -> String {
         match self {
             Self::Create(stat) => stat.build_any(table_builder),
             Self::Alter(stat) => stat.build_any(table_builder),
@@ -89,7 +89,7 @@ impl TableStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: TableBuilder>(&self, table_builder: T) -> String {
+    pub fn to_string<T: SchemaBuilder>(&self, table_builder: T) -> String {
         match self {
             Self::Create(stat) => stat.to_string(table_builder),
             Self::Alter(stat) => stat.to_string(table_builder),

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,7 +1,7 @@
 //! Table definition & alternations statements.
-//! 
+//!
 //! # Usage
-//! 
+//!
 //! - Table Create, see [`TableCreateStatement`]
 //! - Table Alter, see [`TableAlterStatement`]
 //! - Table Drop, see [`TableDropStatement`]
@@ -43,7 +43,7 @@ impl Table {
     pub fn create() -> TableCreateStatement {
         TableCreateStatement::new()
     }
-    
+
     /// Construct table [`TableAlterStatement`]
     pub fn alter() -> TableAlterStatement {
         TableAlterStatement::new()

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -2,16 +2,16 @@ use std::rc::Rc;
 use crate::{backend::TableBuilder, types::*, prepare::*};
 
 /// Rename a table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let table = Table::rename()
 ///     .table(Font::Table, Alias::new("font_new"))
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     table.to_string(MysqlQueryBuilder),
 ///     r#"RENAME TABLE `font` TO `font_new`"#

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
-use crate::{backend::TableBuilder, types::*, prepare::*};
+use crate::{backend::SchemaBuilder, types::*, prepare::*};
+pub use crate::traits::SchemaStatementBuilder;
 
 /// Rename a table
 ///
@@ -53,23 +54,19 @@ impl TableRenameStatement {
         self.to_name = Some(Rc::new(to_name));
         self
     }
+}
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: TableBuilder>(&self, table_builder: T) -> String {
+impl SchemaStatementBuilder for TableRenameStatement {
+
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = SqlWriter::new();
-        table_builder.prepare_table_rename_statement(self, &mut sql);
+        schema_builder.prepare_table_rename_statement(self, &mut sql);
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, table_builder: &dyn TableBuilder) -> String {
+    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
-        table_builder.prepare_table_rename_statement(self, &mut sql);
+        schema_builder.prepare_table_rename_statement(self, &mut sql);
         sql.result()
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: TableBuilder>(&self, table_builder: T) -> String {
-        self.build(table_builder)
     }
 }

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -2,16 +2,16 @@ use std::rc::Rc;
 use crate::{backend::TableBuilder, types::*, prepare::*};
 
 /// Drop a table
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use sea_query::{*, tests_cfg::*};
-/// 
+///
 /// let table = Table::truncate()
 ///     .table(Font::Table)
 ///     .to_owned();
-/// 
+///
 /// assert_eq!(
 ///     table.to_string(MysqlQueryBuilder),
 ///     r#"TRUNCATE TABLE `font`"#

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
-use crate::{backend::TableBuilder, types::*, prepare::*};
+use crate::{backend::SchemaBuilder, types::*, prepare::*};
+pub use crate::traits::SchemaStatementBuilder;
 
 /// Drop a table
 ///
@@ -50,23 +51,18 @@ impl TableTruncateStatement {
         self.table = Some(Rc::new(table));
         self
     }
+}
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: TableBuilder>(&self, table_builder: T) -> String {
+impl SchemaStatementBuilder for TableTruncateStatement {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = SqlWriter::new();
-        table_builder.prepare_table_truncate_statement(self, &mut sql);
+        schema_builder.prepare_table_truncate_statement(self, &mut sql);
         sql.result()
     }
 
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, table_builder: &dyn TableBuilder) -> String {
+    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
-        table_builder.prepare_table_truncate_statement(self, &mut sql);
+        schema_builder.prepare_table_truncate_statement(self, &mut sql);
         sql.result()
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: TableBuilder>(&self, table_builder: T) -> String {
-        self.build(table_builder)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,118 @@
+use crate::{backend::QueryBuilder, value::{Values, Value}, prepare::inject_parameters, SchemaBuilder};
+
+pub trait QueryStatementBuilder {
+    /// Build corresponding SQL statement for certain database backend and return SQL string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Glyph::Aspect)
+    ///     .from(Glyph::Table)
+    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .order_by(Glyph::Image, Order::Desc)
+    ///     .order_by_tbl(Glyph::Table, Glyph::Aspect, Order::Asc)
+    ///     .to_string(MysqlQueryBuilder);
+    ///
+    /// assert_eq!(
+    ///     query,
+    ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
+    /// );
+    /// ```
+    fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
+        let (sql, values) = self.build_any(&query_builder);
+        inject_parameters(&sql, values.0, &query_builder)
+    }
+
+
+    /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let (query, params) = Query::select()
+    ///     .column(Glyph::Aspect)
+    ///     .from(Glyph::Table)
+    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .order_by(Glyph::Image, Order::Desc)
+    ///     .order_by_tbl(Glyph::Table, Glyph::Aspect, Order::Asc)
+    ///     .build(MysqlQueryBuilder);
+    ///
+    /// assert_eq!(
+    ///     query,
+    ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, ?) > ? ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
+    /// );
+    /// assert_eq!(
+    ///     params,
+    ///     Values(vec![Value::Int(0), Value::Int(2)])
+    /// );
+    /// ```
+    fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
+        let mut values = Vec::new();
+        let mut collector = |v| values.push(v);
+        let sql = self.build_collect(query_builder, &mut collector);
+        (sql, Values(values))
+    }
+
+    /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
+    fn build_any(&self, query_builder: &dyn QueryBuilder) -> (String, Values) {
+        let mut values = Vec::new();
+        let mut collector = |v| values.push(v);
+        let sql = self.build_collect_any(query_builder, &mut collector);
+        (sql, Values(values))
+    }
+
+    /// Build corresponding SQL statement for certain database backend and collect query parameters
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Glyph::Aspect)
+    ///     .from(Glyph::Table)
+    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .order_by(Glyph::Image, Order::Desc)
+    ///     .order_by_tbl(Glyph::Table, Glyph::Aspect, Order::Asc)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
+    /// );
+    ///
+    /// let mut params = Vec::new();
+    /// let mut collector = |v| params.push(v);
+    ///
+    /// assert_eq!(
+    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
+    ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, ?) > ? ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
+    /// );
+    /// assert_eq!(
+    ///     params,
+    ///     vec![Value::Int(0), Value::Int(2)]
+    /// );
+    /// ```
+    fn build_collect<T: QueryBuilder>(&self, query_builder: T, collector: &mut dyn FnMut(Value)) -> String;
+
+    /// Build corresponding SQL statement for certain database backend and collect query parameters
+    fn build_collect_any(&self, query_builder: &dyn QueryBuilder, collector: &mut dyn FnMut(Value)) -> String;
+}
+
+pub trait SchemaStatementBuilder {
+    /// Build corresponding SQL statement for certain database backend and return SQL string
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String;
+
+    /// Build corresponding SQL statement for certain database backend and return SQL string
+    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String;
+
+    /// Build corresponding SQL statement for certain database backend and return SQL string
+    fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        self.build(schema_builder)
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/SeaQL/sea-query/issues/43#issuecomment-841167153

Two new traits are added:

- `traits::QueryStatementBuilder`, for queries (with values)
- `traits::SchemaStatementBuilder`, for schema-altering queries (without values).

They are imported publicly by every relevant statement builder types, so that users' code will not break due to a missing trait.

The `backend::SchemaBuilder` trait has also been added to gather the `backend::{TableBuilder, IndexBuilder, ForeignKeyBuilder}` traits. Since the `SchemaStatementBuilder` trait is now taking a `SchemaBuilder` as argument instead of the relevant sub-trait, there is the slight downside that it's now not possible to use the methods with a builder that implements `TableBuilder` but not `IndexBuilder` and `ForeignKeyBuilder`. However, all of the implementations in the crate implement all 3, and a search in GitHub for `backend::TableBuilder` (and others) brings up no result. While technically a breaking change, I don't think it's a big issue.

Some doc examples were removed (the `to_string`, `build` and `build_any` functions for the query statements) because they are present in the trait, and the example and usage is clear enough that I don't think the variant for each implementor is needed.

Note: due to my editor stripping the extra whitespace at the end of lines, I have a bigger diff than needed. I split the whitespace changes in a separate commit, which I can remove if needed.
