### PR TITLE
Create the OrderedStatement and ConditionalStatement traits

### DIFF
--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -133,9 +133,11 @@ impl QueryBuilder for MysqlQueryBuilder {
             false
         });
 
-        if let Some(wherei) = &update.wherei {
+        if !update.wherei.is_empty() {
             write!(sql, " WHERE ").unwrap();
-            self.prepare_simple_expr(wherei, sql, collector);
+        }
+        for (i, log_chain_oper) in update.wherei.iter().enumerate() {
+            self.prepare_logical_chain_oper(log_chain_oper, i, update.wherei.len(), sql, collector);
         }
 
         if !update.orders.is_empty() {
@@ -163,9 +165,11 @@ impl QueryBuilder for MysqlQueryBuilder {
             self.prepare_table_ref(table, sql, collector);
         }
 
-        if let Some(wherei) = &delete.wherei {
+        if !delete.wherei.is_empty() {
             write!(sql, " WHERE ").unwrap();
-            self.prepare_simple_expr(wherei, sql, collector);
+        }
+        for (i, log_chain_oper) in delete.wherei.iter().enumerate() {
+            self.prepare_logical_chain_oper(log_chain_oper, i, delete.wherei.len(), sql, collector);
         }
 
         if !delete.orders.is_empty() {

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -157,7 +157,7 @@ impl QueryBuilder for MysqlQueryBuilder {
 
     fn prepare_delete_statement(&self, delete: &DeleteStatement, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value)) {
         write!(sql, "DELETE ").unwrap();
-        
+
         if let Some(table) = &delete.table {
             write!(sql, "FROM ").unwrap();
             self.prepare_table_ref(table, sql, collector);

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -144,9 +144,11 @@ impl QueryBuilder for PostgresQueryBuilder {
             false
         });
 
-        if let Some(wherei) = &update.wherei {
+        if !update.wherei.is_empty() {
             write!(sql, " WHERE ").unwrap();
-            self.prepare_simple_expr(wherei, sql, collector);
+        }
+        for (i, log_chain_oper) in update.wherei.iter().enumerate() {
+            self.prepare_logical_chain_oper(log_chain_oper, i, update.wherei.len(), sql, collector);
         }
 
         if !update.orders.is_empty() {
@@ -174,9 +176,11 @@ impl QueryBuilder for PostgresQueryBuilder {
             self.prepare_table_ref(table, sql, collector);
         }
 
-        if let Some(wherei) = &delete.wherei {
+        if !delete.wherei.is_empty() {
             write!(sql, " WHERE ").unwrap();
-            self.prepare_simple_expr(wherei, sql, collector);
+        }
+        for (i, log_chain_oper) in delete.wherei.iter().enumerate() {
+            self.prepare_logical_chain_oper(log_chain_oper, i, delete.wherei.len(), sql, collector);
         }
 
         if !delete.orders.is_empty() {

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -168,7 +168,7 @@ impl QueryBuilder for PostgresQueryBuilder {
 
     fn prepare_delete_statement(&self, delete: &DeleteStatement, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value)) {
         write!(sql, "DELETE ").unwrap();
-        
+
         if let Some(table) = &delete.table {
             write!(sql, "FROM ").unwrap();
             self.prepare_table_ref(table, sql, collector);

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -133,9 +133,11 @@ impl QueryBuilder for SqliteQueryBuilder {
             false
         });
 
-        if let Some(wherei) = &update.wherei {
+        if !update.wherei.is_empty() {
             write!(sql, " WHERE ").unwrap();
-            self.prepare_simple_expr(wherei, sql, collector);
+        }
+        for (i, log_chain_oper) in update.wherei.iter().enumerate() {
+            self.prepare_logical_chain_oper(log_chain_oper, i, update.wherei.len(), sql, collector);
         }
 
         if !update.orders.is_empty() {
@@ -163,9 +165,11 @@ impl QueryBuilder for SqliteQueryBuilder {
             self.prepare_table_ref(table, sql, collector);
         }
 
-        if let Some(wherei) = &delete.wherei {
+        if !delete.wherei.is_empty() {
             write!(sql, " WHERE ").unwrap();
-            self.prepare_simple_expr(wherei, sql, collector);
+        }
+        for (i, log_chain_oper) in delete.wherei.iter().enumerate() {
+            self.prepare_logical_chain_oper(log_chain_oper, i, delete.wherei.len(), sql, collector);
         }
 
         if !delete.orders.is_empty() {

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -157,7 +157,7 @@ impl QueryBuilder for SqliteQueryBuilder {
 
     fn prepare_delete_statement(&self, delete: &DeleteStatement, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value)) {
         write!(sql, "DELETE ").unwrap();
-        
+
         if let Some(table) = &delete.table {
             write!(sql, "FROM ").unwrap();
             self.prepare_table_ref(table, sql, collector);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,15 +282,15 @@
 //!
 //! assert_eq!(
 //!     query.to_string(MysqlQueryBuilder),
-//!     r#"DELETE FROM `glyph` WHERE (`id` < 1) OR (`id` > 10)"#
+//!     r#"DELETE FROM `glyph` WHERE `id` < 1 OR `id` > 10"#
 //! );
 //! assert_eq!(
 //!     query.to_string(PostgresQueryBuilder),
-//!     r#"DELETE FROM "glyph" WHERE ("id" < 1) OR ("id" > 10)"#
+//!     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 //! );
 //! assert_eq!(
 //!     query.to_string(SqliteQueryBuilder),
-//!     r#"DELETE FROM `glyph` WHERE (`id` < 1) OR (`id` > 10)"#
+//!     r#"DELETE FROM `glyph` WHERE `id` < 1 OR `id` > 10"#
 //! );
 //! ```
 //!

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -1,0 +1,61 @@
+use crate::{expr::SimpleExpr, types::LogicalChainOper};
+
+pub trait ConditionalStatement {
+    /// And where condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Glyph::Image)
+    ///     .from(Glyph::Table)
+    ///     .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
+    ///     .and_where(Expr::tbl(Glyph::Table, Glyph::Image).like("A%"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4) AND `glyph`.`image` LIKE 'A%'"#
+    /// );
+    /// ```
+    fn and_where(&mut self, other: SimpleExpr) -> &mut Self {
+        self.and_or_where(LogicalChainOper::And(other))
+    }
+
+    /// And where condition, short hand for `if c.is_some() q.and_where(c)`.
+    fn and_where_option(&mut self, other: Option<SimpleExpr>) -> &mut Self {
+        if let Some(other) = other {
+            self.and_or_where(LogicalChainOper::And(other));
+        }
+        self
+    }
+
+    /// Or where condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Glyph::Image)
+    ///     .from(Glyph::Table)
+    ///     .or_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
+    ///     .or_where(Expr::tbl(Glyph::Table, Glyph::Image).like("A%"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4) OR `glyph`.`image` LIKE 'A%'"#
+    /// );
+    /// ```
+    fn or_where(&mut self, other: SimpleExpr) -> &mut Self {
+        self.and_or_where(LogicalChainOper::Or(other))
+    }
+
+    #[doc(hidden)]
+    // Trait implementation.
+    fn and_or_where(&mut self, condition: LogicalChainOper) -> &mut Self;
+}

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -1,4 +1,4 @@
-use crate::{backend::QueryBuilder, QueryStatementBuilder, types::*, expr::*, value::*, prepare::*};
+use crate::{backend::QueryBuilder, QueryStatementBuilder, query::OrderedStatement, types::*, expr::*, value::*, prepare::*};
 
 /// Delete existing rows from the table
 ///
@@ -167,86 +167,6 @@ impl DeleteStatement {
         }))
     }
 
-    /// Order by column.
-    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self
-        where T: IntoColumnRef {
-        self.orders.push(OrderExpr {
-            expr: SimpleExpr::Column(col.into_column_ref()),
-            order,
-        });
-        self
-    }
-
-    #[deprecated(
-        since = "0.9.0",
-        note = "Please use the [`DeleteStatement::order_by`] with a tuple as [`ColumnRef`]"
-    )]
-    /// Order by column with table name prefix.
-    pub fn order_by_tbl<T, C>
-        (&mut self, table: T, col: C, order: Order) -> &mut Self
-        where T: IntoIden, C: IntoIden {
-        self.order_by((table.into_iden(), col.into_iden()), order)
-    }
-
-    /// Order by [`SimpleExpr`].
-    pub fn order_by_expr(&mut self, expr: SimpleExpr, order: Order) -> &mut Self {
-        self.orders.push(OrderExpr {
-            expr,
-            order,
-        });
-        self
-    }
-
-    /// Order by custom string.
-    pub fn order_by_customs<T, I>(&mut self, cols: I) -> &mut Self
-    where
-        T: ToString,
-        I: IntoIterator<Item = (T, Order)>,
-    {
-        let mut orders = cols
-            .into_iter()
-            .map(|(c, order)| OrderExpr {
-                expr: SimpleExpr::Custom(c.to_string()),
-                order,
-            })
-            .collect();
-        self.orders.append(&mut orders);
-        self
-    }
-
-    /// Order by columns.
-    pub fn order_by_columns<T, I>(&mut self, cols: I) -> &mut Self
-    where
-        T: IntoColumnRef,
-        I: IntoIterator<Item = (T, Order)>,
-    {
-        let mut orders = cols
-            .into_iter()
-            .map(|(c, order)| OrderExpr {
-                expr: SimpleExpr::Column(c.into_column_ref()),
-                order,
-            })
-            .collect();
-        self.orders.append(&mut orders);
-        self
-    }
-
-    #[deprecated(
-        since = "0.9.0",
-        note = "Please use the [`DeleteStatement::order_by_columns`] with a tuple as [`ColumnRef`]"
-    )]
-    pub fn order_by_table_columns<T, C>(&mut self, cols: Vec<(T, C, Order)>) -> &mut Self
-    where
-        T: IntoIden,
-        C: IntoIden,
-    {
-        self.order_by_columns(
-            cols.into_iter()
-                .map(|(t, c, o)| ((t.into_iden(), c.into_iden()), o))
-                .collect::<Vec<_>>(),
-        )
-    }
-
     /// Limit number of updated rows.
     pub fn limit(&mut self, limit: u64) -> &mut Self {
         self.limit = Some(Value::BigUnsigned(limit));
@@ -308,5 +228,12 @@ impl QueryStatementBuilder for DeleteStatement {
         let mut sql = SqlWriter::new();
         query_builder.prepare_delete_statement(self, &mut sql, collector);
         sql.result()
+    }
+}
+
+impl OrderedStatement for DeleteStatement {
+    fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
+        self.orders.push(order);
+        self
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -7,11 +7,13 @@
 //! - Query Update, see [`UpdateStatement`]
 //! - Query Delete, see [`DeleteStatement`]
 
+mod ordered;
 mod select;
 mod insert;
 mod update;
 mod delete;
 
+pub use ordered::*;
 pub use select::*;
 pub use insert::*;
 pub use update::*;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -7,12 +7,14 @@
 //! - Query Update, see [`UpdateStatement`]
 //! - Query Delete, see [`DeleteStatement`]
 
+mod condition;
 mod ordered;
 mod select;
 mod insert;
 mod update;
 mod delete;
 
+pub use condition::*;
 pub use ordered::*;
 pub use select::*;
 pub use insert::*;

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1,5 +1,5 @@
 use std::rc::Rc;
-use crate::{backend::QueryBuilder, QueryStatementBuilder, types::*, expr::*, value::*, prepare::*};
+use crate::{backend::QueryBuilder, QueryStatementBuilder, query::OrderedStatement, types::*, expr::*, value::*, prepare::*};
 use std::iter::FromIterator;
 
 /// Select rows from an existing table
@@ -1135,112 +1135,6 @@ impl SelectStatement {
         self
     }
 
-    /// Order by column.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .column(Glyph::Aspect)
-    ///     .from(Glyph::Table)
-    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-    ///     .order_by(Glyph::Image, Order::Desc)
-    ///     .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2 ORDER BY "image" DESC, "glyph"."aspect" ASC"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
-    /// );
-    /// ```
-    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self
-        where T: IntoColumnRef {
-        self.orders.push(OrderExpr {
-            expr: SimpleExpr::Column(col.into_column_ref()),
-            order,
-        });
-        self
-    }
-
-    #[deprecated(
-        since = "0.9.0",
-        note = "Please use the [`SelectStatement::order_by`] with a tuple as [`ColumnRef`]"
-    )]
-    pub fn order_by_tbl<T, C>
-        (&mut self, table: T, col: C, order: Order) -> &mut Self
-        where T: IntoIden, C: IntoIden {
-        self.order_by((table.into_iden(), col.into_iden()), order)
-    }
-
-    /// Order by [`SimpleExpr`].
-    pub fn order_by_expr(&mut self, expr: SimpleExpr, order: Order) -> &mut Self {
-        self.orders.push(OrderExpr {
-            expr,
-            order,
-        });
-        self
-    }
-
-    /// Order by custom string expression.
-    pub fn order_by_customs<T: 'static, I>(&mut self, cols: I) -> &mut Self
-    where
-        T: ToString,
-        I: IntoIterator<Item = (T, Order)>,
-    {
-        let mut orders = cols
-            .into_iter()
-            .map(|(c, order)| OrderExpr {
-                expr: SimpleExpr::Custom(c.to_string()),
-                order,
-            })
-            .collect();
-        self.orders.append(&mut orders);
-        self
-    }
-
-    /// Order by vector of columns.
-    pub fn order_by_columns<T, I>(&mut self, cols: I) -> &mut Self
-    where
-        T: IntoColumnRef,
-        I: IntoIterator<Item = (T, Order)>,
-    {
-        let mut orders = cols
-            .into_iter()
-            .map(|(c, order)| OrderExpr {
-                expr: SimpleExpr::Column(c.into_column_ref()),
-                order,
-            })
-            .collect();
-        self.orders.append(&mut orders);
-        self
-    }
-
-    #[deprecated(
-        since = "0.9.0",
-        note = "Please use the [`SelectStatement::order_by_columns`] with a tuple as [`ColumnRef`]"
-    )]
-    pub fn order_by_table_columns<T, C>(&mut self, cols: Vec<(T, C, Order)>) -> &mut Self
-    where
-        T: IntoIden,
-        C: IntoIden,
-    {
-        self.order_by_columns(
-            cols.into_iter()
-                .map(|(t, c, o)| ((t.into_iden(), c.into_iden()), o))
-                .collect::<Vec<_>>(),
-        )
-    }
-
     /// Limit the number of returned rows.
     ///
     /// # Examples
@@ -1360,5 +1254,12 @@ impl QueryStatementBuilder for SelectStatement {
         let mut sql = SqlWriter::new();
         query_builder.prepare_select_statement(self, &mut sql, collector);
         sql.result()
+    }
+}
+
+impl OrderedStatement for SelectStatement {
+    fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
+        self.orders.push(order);
+        self
     }
 }


### PR DESCRIPTION
This refactoring reduces the amount of code and increases the consistency between the different queries.

Based on https://github.com/SeaQL/sea-query/pull/44.

Note that this changes the semantics of `and_where` and `or_where` for
Delete and Update, to align them with Select. The difference is in the
operator precedence (see https://github.com/SeaQL/sea-query/issues/45)

Previously, we had:

```rust
Query::delete()
  .from_table(Glyph::Table)
  .or_where(Expr::col(Glyph::Id).eq(1))
  .or_where(Expr::col(Glyph::Id).eq(2))
  .and_where(Expr::col(Glyph::Id).eq(3))
  .to_string(PostgresQueryBuilder);
```

equal to

```sql
DELETE FROM "glyph" WHERE (("id" = 1) OR ("id" = 2)) AND ("id" = 3)
```

I.e. it was using left-associativity. With this change, we now have the
less surprising:

```sql
DELETE FROM "glyph" WHERE "id" = 1 OR "id" = 2 AND "id" = 3
```

I.e. using the natural operator precedence from SQL, with AND before OR.
In that case, the parentheses would be:

```sql
DELETE FROM "glyph" WHERE "id" = 1 OR ("id" = 2 AND "id" = 3)
```