### PR TITLE
Refactor `Condition` 

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -523,8 +523,8 @@ pub trait QueryBuilder : QuotedBuilder {
 
     #[doc(hidden)]
     /// Translate part of a condition to part of a "WHERE" clause.
-    fn prepare_condition_where(&self, condition: &ConditionWhere, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value)) {
-        let is_any =  ConditionWhereType::Any == condition.condition_type;
+    fn prepare_condition_where(&self, condition: &Condition, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value)) {
+        let is_any =  ConditionType::Any == condition.condition_type;
         let mut is_first = true;
         for cond in &condition.conditions {
             if is_first {
@@ -537,7 +537,7 @@ pub trait QueryBuilder : QuotedBuilder {
                 }
             }
             match cond {
-                ConditionExpression::ConditionWhere(c) => {
+                ConditionExpression::Condition(c) => {
                     write!(sql, "(").unwrap();
                     self.prepare_condition_where(&c, sql, collector);
                     write!(sql, ")").unwrap();

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -6,7 +6,7 @@ pub enum ConditionType {
     All,
 }
 
-/// Represents the value of an [`any()`] or [`all()`]: a set of disjunctive or conjunctive conditions.
+/// Represents the value of an [`Condition::any`] or [`Condition::all`]: a set of disjunctive or conjunctive conditions.
 #[derive(Debug, Clone)]
 pub struct Condition {
     pub(crate) condition_type: ConditionType,
@@ -15,7 +15,7 @@ pub struct Condition {
 
 pub type Cond = Condition;
 
-/// Represents anything that can be passed to an [`any()`] or [`all()`]'s [`Condition::add`] method.
+/// Represents anything that can be passed to an [`Condition::any`] or [`Condition::all`]'s [`Condition::add`] method.
 ///
 /// The arguments are automatically converted to the right enum.
 #[derive(Debug, Clone)]
@@ -27,12 +27,12 @@ pub enum ConditionExpression {
 impl Condition {
     /// Add a condition to the set.
     ///
-    /// If it's an [`any()`], it will be separated from the others by an `" OR "` in the query. If it's
-    /// an [`all()`], it will be separated by an `" AND "`.
+    /// If it's an [`Condition::any`], it will be separated from the others by an `" OR "` in the query. If it's
+    /// an [`Condition::all`], it will be separated by an `" AND "`.
     #[allow(clippy::should_implement_trait)]
     pub fn add<C: Into<ConditionExpression>>(mut self, condition: C) -> Self {
         let expr = condition.into();
-        // Don't add empty `any()` and `all()`.
+        // Don't add empty `Condition::any` and `Condition::all`.
         if let ConditionExpression::Condition(c) = &expr {
             if c.conditions.is_empty() {
                 return self;
@@ -111,7 +111,7 @@ impl std::convert::From<SimpleExpr> for ConditionExpression {
     }
 }
 
-/// Macro to easily create an [`Cond::any()`].
+/// Macro to easily create an [`Condition::any`].
 ///
 /// # Examples
 ///
@@ -146,7 +146,7 @@ macro_rules! any {
     };
 }
 
-/// Macro to easily create an [`Cond::all()`].
+/// Macro to easily create an [`Condition::all`].
 ///
 /// # Examples
 ///

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -148,7 +148,7 @@ impl ConditionalStatement for DeleteStatement {
         self
     }
 
-    fn cond_where(&mut self, condition: ConditionWhere) -> &mut Self {
+    fn cond_where(&mut self, condition: Condition) -> &mut Self {
         self.wherei.set_where(condition);
         self
     }

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1018,7 +1018,7 @@ impl SelectStatement {
     ///     r#"SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `glyph`.`aspect` IN (3, 4) AND (`glyph`.`image` LIKE 'A%' OR `glyph`.`image` LIKE 'B%')"#
     /// );
     /// ```
-    pub fn cond_having(&mut self, condition: ConditionWhere) -> &mut Self {
+    pub fn cond_having(&mut self, condition: Condition) -> &mut Self {
         self.having.set_where(condition);
         self
     }
@@ -1191,7 +1191,7 @@ impl ConditionalStatement for SelectStatement {
         self
     }
 
-    fn cond_where(&mut self, condition: ConditionWhere) -> &mut Self {
+    fn cond_where(&mut self, condition: Condition) -> &mut Self {
         self.wherei.set_where(condition);
         self
     }

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -307,7 +307,7 @@ impl ConditionalStatement for UpdateStatement {
         self
     }
 
-    fn cond_where(&mut self, condition: ConditionWhere) -> &mut Self {
+    fn cond_where(&mut self, condition: Condition) -> &mut Self {
         self.wherei.set_where(condition);
         self
     }

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -53,7 +53,7 @@ macro_rules! impl_conditional_statement {
         #[allow(deprecated)]
         mod $mod_name {
 
-            use crate::{ConditionalStatement, SimpleExpr, ConditionWhere, $struct_name};
+            use crate::{ConditionalStatement, SimpleExpr, Condition, $struct_name};
 
             impl $struct_name {
                 pub fn and_where(&mut self, other: SimpleExpr) -> &mut Self {
@@ -72,7 +72,7 @@ macro_rules! impl_conditional_statement {
                     <Self as ConditionalStatement>::or_where(self, other)
                 }
 
-                pub fn cond_where(&mut self, condition: ConditionWhere) -> &mut Self {
+                pub fn cond_where(&mut self, condition: Condition) -> &mut Self {
                     <Self as ConditionalStatement>::cond_where(self, condition)
                 }
             }

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -549,7 +549,7 @@ fn select_36() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            any()
+            Cond::any()
             .add(Expr::col(Glyph::Aspect).is_null())
         )
         .build(sea_query::MysqlQueryBuilder);
@@ -563,7 +563,7 @@ fn select_37() {
     let (statement, values) = sea_query::Query::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
-        .cond_where(any().add(all()).add(any()))
+        .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
         .build(sea_query::MysqlQueryBuilder);
 
     assert_eq!(statement, r#"SELECT `id` FROM `glyph`"#);
@@ -576,7 +576,7 @@ fn select_38() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            any()
+            Cond::any()
             .add(Expr::col(Glyph::Aspect).is_null())
             .add(Expr::col(Glyph::Aspect).is_not_null())
         )
@@ -592,7 +592,7 @@ fn select_39() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            all()
+            Cond::all()
             .add(Expr::col(Glyph::Aspect).is_null())
             .add(Expr::col(Glyph::Aspect).is_not_null())
         )

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -549,7 +549,7 @@ fn select_36() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            any()
+            Cond::any()
             .add(Expr::col(Glyph::Aspect).is_null())
         )
         .build(sea_query::PostgresQueryBuilder);
@@ -563,7 +563,7 @@ fn select_37() {
     let (statement, values) = sea_query::Query::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
-        .cond_where(any().add(all()).add(any()))
+        .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
         .build(sea_query::PostgresQueryBuilder);
 
     assert_eq!(statement, r#"SELECT "id" FROM "glyph""#);
@@ -576,7 +576,7 @@ fn select_38() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            any()
+            Cond::any()
             .add(Expr::col(Glyph::Aspect).is_null())
             .add(Expr::col(Glyph::Aspect).is_not_null())
         )
@@ -592,7 +592,7 @@ fn select_39() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            all()
+            Cond::all()
             .add(Expr::col(Glyph::Aspect).is_null())
             .add(Expr::col(Glyph::Aspect).is_not_null())
         )

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -549,7 +549,7 @@ fn select_36() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            any()
+            Cond::any()
             .add(Expr::col(Glyph::Aspect).is_null())
         )
         .build(sea_query::SqliteQueryBuilder);
@@ -563,7 +563,7 @@ fn select_37() {
     let (statement, values) = sea_query::Query::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
-        .cond_where(any().add(all()).add(any()))
+        .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
         .build(sea_query::SqliteQueryBuilder);
 
     assert_eq!(statement, r#"SELECT `id` FROM `glyph`"#);
@@ -576,7 +576,7 @@ fn select_38() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            any()
+            Cond::any()
             .add(Expr::col(Glyph::Aspect).is_null())
             .add(Expr::col(Glyph::Aspect).is_not_null())
         )
@@ -592,7 +592,7 @@ fn select_39() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            all()
+            Cond::all()
             .add(Expr::col(Glyph::Aspect).is_null())
             .add(Expr::col(Glyph::Aspect).is_not_null())
         )


### PR DESCRIPTION
Follow up on #49 

Since now `Condition` is shared between `where` and `having`, we might rename it as simply Condition.

And also, I think any() and all() being methods instead of free standing functions adhere more to the library's style

Agree? @nitnelave 