### PR TITLE
Create a SQLx-SQLite driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "examples/rusqlite",
     "examples/sqlx_mysql",
     "examples/sqlx_postgres",
+    "examples/sqlx_sqlite",
 ]
 
 [package]
@@ -56,6 +57,7 @@ postgres-uuid = [ "with-uuid", "postgres-types/with-uuid-0_8" ]
 rusqlite = [ ]
 sqlx-mysql = [ ]
 sqlx-postgres = [ ]
+sqlx-sqlite = [ ]
 with-chrono = [ "chrono" ]
 with-json = [ "serde_json" ]
 with-uuid = [ "uuid" ]

--- a/README.md
+++ b/README.md
@@ -68,24 +68,24 @@ Why would you want to use a dynamic query builder?
 
 1. Parameter bindings
 
-One of the headaches if you are using raw SQL is parameter binding, where `IN` clauses are not very
-friendly.
+One of the headaches when using raw SQL is parameter binding. With SeaQuery you can:
 
 ```rust
 assert_eq!(
     Query::select()
         .column(Glyph::Image)
         .from(Glyph::Table)
+        .and_where(Expr::col(Glyph::Image).like("A"))
         .and_where(Expr::col(Glyph::Id).is_in(vec![1, 2, 3]))
         .build(PostgresQueryBuilder),
-    (r#"SELECT "image" FROM "glyph" WHERE "id" IN ($1, $2, $3)"#.to_owned(),
-     Values(vec![Value::Int(1), Value::Int(2), Value::Int(3)]))
+    (r#"SELECT "image" FROM "glyph" WHERE "image" LIKE $1 AND "id" IN ($2, $3, $4)"#.to_owned(),
+     Values(vec![Value::String(Box::new("A".to_owned())), Value::Int(1), Value::Int(2), Value::Int(3)]))
 );
 ```
 
 2. Dynamic query
 
-If you need to construct the query at runtime based on user inputs, then you can:
+You can construct the query at runtime based on user inputs:
 
 ```rust
 Query::select()

--- a/examples/sqlx_sqlite/Cargo.toml
+++ b/examples/sqlx_sqlite/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sea-query-sqlx-sqlite-example"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+async-std = { version = "1.8", features = [ "attributes" ] }
+sea-query = { path = "../../", features = ["sqlx-sqlite"] }
+# NOTE: if you are copying this example into your own project, use the following line instead:
+# sea-query = { version = "^0.11", features = ["sqlx-sqlite"] }
+
+[dependencies.sqlx]
+version = "^0.5"
+default-features = false
+features = [
+    "runtime-async-std-native-tls",
+    "macros",
+    "sqlite",
+]

--- a/examples/sqlx_sqlite/Readme.md
+++ b/examples/sqlx_sqlite/Readme.md
@@ -1,0 +1,25 @@
+# SeaQuery SQLx Postgres example
+
+Running:
+```sh
+cargo run
+```
+
+Example output:
+```
+Create table character: Ok(PgQueryResult { rows_affected: 0 })
+
+Insert into character: Ok(PgQueryResult { rows_affected: 1 })
+
+Select one from character:
+CharacterStruct { id: 1, character: "A", font_size: 12 }
+
+Update character: Ok(PgQueryResult { rows_affected: 1 })
+
+Select one from character:
+CharacterStruct { id: 1, character: "A", font_size: 24 }
+
+Count character: 1
+
+Delete character: Ok(PgQueryResult { rows_affected: 1 })
+```

--- a/examples/sqlx_sqlite/Readme.md
+++ b/examples/sqlx_sqlite/Readme.md
@@ -1,4 +1,4 @@
-# SeaQuery SQLx Postgres example
+# SeaQuery SQLx SQLite example
 
 Running:
 ```sh
@@ -7,19 +7,19 @@ cargo run
 
 Example output:
 ```
-Create table character: Ok(PgQueryResult { rows_affected: 0 })
+Create table character: Ok(SqliteQueryResult { changes: 0, last_insert_rowid: 0 })
 
-Insert into character: Ok(PgQueryResult { rows_affected: 1 })
+Insert into character: last_insert_id = 1
 
 Select one from character:
 CharacterStruct { id: 1, character: "A", font_size: 12 }
 
-Update character: Ok(PgQueryResult { rows_affected: 1 })
+Update character: Ok(SqliteQueryResult { changes: 1, last_insert_rowid: 1 })
 
 Select one from character:
 CharacterStruct { id: 1, character: "A", font_size: 24 }
 
 Count character: 1
 
-Delete character: Ok(PgQueryResult { rows_affected: 1 })
+Delete character: Ok(SqliteQueryResult { changes: 1, last_insert_rowid: 1 })
 ```

--- a/examples/sqlx_sqlite/src/main.rs
+++ b/examples/sqlx_sqlite/src/main.rs
@@ -1,0 +1,137 @@
+use sea_query::{ColumnDef, Expr, Func, Iden, Order, Query, SqliteQueryBuilder, Table};
+use sqlx::{Row, SqlitePool};
+
+sea_query::sea_query_driver_sqlite!();
+use sea_query_driver_sqlite::{bind_query, bind_query_as};
+
+#[async_std::main]
+async fn main() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+
+    // Schema
+    let sql = Table::create()
+        .table(Character::Table)
+        .if_not_exists()
+        .col(
+            ColumnDef::new(Character::Id)
+                .integer()
+                .not_null()
+                .auto_increment()
+                .primary_key(),
+        )
+        .col(ColumnDef::new(Character::FontSize).integer())
+        .col(ColumnDef::new(Character::Character).string())
+        .build(SqliteQueryBuilder);
+
+    let result = sqlx::query(&sql).execute(&pool).await;
+    println!("Create table character: {:?}\n", result);
+
+    // Create
+    let (sql, values) = Query::insert()
+        .into_table(Character::Table)
+        .columns(vec![Character::Character, Character::FontSize])
+        .values_panic(vec!["A".into(), 12.into()])
+        .build(SqliteQueryBuilder);
+
+    //TODO: Implement RETURNING (returning_col) for the Sqlite driver.
+    let row = bind_query(sqlx::query(&sql), &values)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let id: i64 = row.last_insert_rowid();
+    println!("Insert into character: last_insert_id = {}\n", id);
+
+    // Read
+    let (sql, values) = Query::select()
+        .columns(vec![
+            Character::Id,
+            Character::Character,
+            Character::FontSize,
+        ])
+        .from(Character::Table)
+        .order_by(Character::Id, Order::Desc)
+        .limit(1)
+        .build(SqliteQueryBuilder);
+
+    let rows = bind_query_as(sqlx::query_as::<_, CharacterStruct>(&sql), &values)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    println!("Select one from character:");
+    for row in rows.iter() {
+        println!("{:?}", row);
+    }
+    println!();
+
+    // Update
+    let (sql, values) = Query::update()
+        .table(Character::Table)
+        .values(vec![(Character::FontSize, 24.into())])
+        .and_where(Expr::col(Character::Id).eq(id))
+        .build(SqliteQueryBuilder);
+
+    let result = bind_query(sqlx::query(&sql), &values).execute(&pool).await;
+    println!("Update character: {:?}\n", result);
+
+    // Read
+    let (sql, values) = Query::select()
+        .columns(vec![
+            Character::Id,
+            Character::Character,
+            Character::FontSize,
+        ])
+        .from(Character::Table)
+        .order_by(Character::Id, Order::Desc)
+        .limit(1)
+        .build(SqliteQueryBuilder);
+
+    let rows = bind_query_as(sqlx::query_as::<_, CharacterStruct>(&sql), &values)
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+    println!("Select one from character:");
+    for row in rows.iter() {
+        println!("{:?}\n", row);
+    }
+
+    // Count
+    let (sql, values) = Query::select()
+        .from(Character::Table)
+        .expr(Func::count(Expr::col(Character::Id)))
+        .build(SqliteQueryBuilder);
+
+    let row = bind_query(sqlx::query(&sql), &values)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    let count: i64 = row.try_get(0).unwrap();
+    println!("Count character: {}\n", count);
+
+    // Delete
+    let (sql, values) = Query::delete()
+        .from_table(Character::Table)
+        .and_where(Expr::col(Character::Id).eq(id))
+        .build(SqliteQueryBuilder);
+
+    let result = bind_query(sqlx::query(&sql), &values).execute(&pool).await;
+
+    println!("Delete character: {:?}", result);
+}
+
+#[derive(Iden)]
+enum Character {
+    Table,
+    Id,
+    Character,
+    FontSize,
+}
+
+#[derive(sqlx::FromRow, Debug)]
+struct CharacterStruct {
+    id: i32,
+    character: String,
+    font_size: i32,
+}

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -19,3 +19,8 @@ pub use sqlx_mysql::*;
 mod sqlx_postgres;
 #[cfg(feature = "sqlx-postgres")]
 pub use sqlx_postgres::*;
+
+#[cfg(feature = "sqlx-sqlite")]
+mod sqlx_sqlite;
+#[cfg(feature = "sqlx-sqlite")]
+pub use sqlx_sqlite::*;

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -1,0 +1,60 @@
+#[macro_export]
+macro_rules! bind_params_sqlx_sqlite {
+    ( $query:expr, $params:expr ) => {{
+        let mut query = $query;
+        for value in $params.iter() {
+            query = match value {
+                Value::Null => query.bind(None::<bool>),
+                Value::Bool(v) => query.bind(v),
+                Value::TinyInt(v) => query.bind(v),
+                Value::SmallInt(v) => query.bind(v),
+                Value::Int(v) => query.bind(v),
+                Value::BigInt(v) => query.bind(v),
+                Value::TinyUnsigned(v) => query.bind(v),
+                Value::SmallUnsigned(v) => query.bind(v),
+                Value::Unsigned(v) => query.bind(v),
+                Value::BigUnsigned(v) => query.bind(*v as i64),
+                Value::Float(v) => query.bind(v),
+                Value::Double(v) => query.bind(v),
+                Value::String(v) => query.bind(v.as_str()),
+                Value::Bytes(v) => query.bind(v.as_ref()),
+                _ => {
+                    if value.is_json() {
+                        query.bind(value.as_ref_json())
+                    } else if value.is_date_time() {
+                        query.bind(value.as_ref_date_time())
+                    } else if value.is_uuid() {
+                        query.bind(value.as_ref_uuid())
+                    } else {
+                        unimplemented!();
+                    }
+                }
+            };
+        }
+        query
+    }};
+}
+
+#[macro_export]
+macro_rules! sea_query_driver_sqlite {
+    () => {
+        mod sea_query_driver_sqlite {
+            use sqlx::{query::Query, query::QueryAs, sqlite::SqliteArguments, Sqlite};
+            use $crate::{Value, Values};
+
+            type SqlxQuery<'a> = sqlx::query::Query<'a, Sqlite, SqliteArguments<'a>>;
+            type SqlxQueryAs<'a, T> = sqlx::query::QueryAs<'a, Sqlite, T, SqliteArguments<'a>>;
+
+            pub fn bind_query<'a>(query: SqlxQuery<'a>, params: &'a Values) -> SqlxQuery<'a> {
+                $crate::bind_params_sqlx_sqlite!(query, params.0)
+            }
+
+            pub fn bind_query_as<'a, T>(
+                query: SqlxQueryAs<'a, T>,
+                params: &'a Values,
+            ) -> SqlxQueryAs<'a, T> {
+                $crate::bind_params_sqlx_sqlite!(query, params.0)
+            }
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,7 @@
 //!
 //! 1. Parameter bindings
 //!
-//! One of the headaches if you are using raw SQL is parameter binding, where `IN` clauses are not very
-//! friendly.
+//! One of the headaches when using raw SQL is parameter binding. With SeaQuery you can:
 //!
 //! ```
 //! # use sea_query::{*, tests_cfg::*};
@@ -80,16 +79,17 @@
 //!     Query::select()
 //!         .column(Glyph::Image)
 //!         .from(Glyph::Table)
+//!         .and_where(Expr::col(Glyph::Image).like("A"))
 //!         .and_where(Expr::col(Glyph::Id).is_in(vec![1, 2, 3]))
 //!         .build(PostgresQueryBuilder),
-//!     (r#"SELECT "image" FROM "glyph" WHERE "id" IN ($1, $2, $3)"#.to_owned(),
-//!      Values(vec![Value::Int(1), Value::Int(2), Value::Int(3)]))
+//!     (r#"SELECT "image" FROM "glyph" WHERE "image" LIKE $1 AND "id" IN ($2, $3, $4)"#.to_owned(),
+//!      Values(vec![Value::String(Box::new("A".to_owned())), Value::Int(1), Value::Int(2), Value::Int(3)]))
 //! );
 //! ```
 //!
 //! 2. Dynamic query
 //!
-//! If you need to construct the query at runtime based on user inputs, then you can:
+//! You can construct the query at runtime based on user inputs:
 //!
 //! ```
 //! # use sea_query::{*, tests_cfg::*};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,12 +68,12 @@
 //! ### Motivation
 //!
 //! Why would you want to use a dynamic query builder?
-//! 
+//!
 //! 1. Parameter bindings
 //!
 //! One of the headaches if you are using raw SQL is parameter binding, where `IN` clauses are not very
 //! friendly.
-//! 
+//!
 //! ```
 //! # use sea_query::{*, tests_cfg::*};
 //! assert_eq!(
@@ -119,7 +119,7 @@
 //! Commonly implemented by Enum where each Enum represents a table found in a database,
 //! and its variants include table name and column name.
 //!
-//! [`Iden::unquoted()`] must be implemented to provide a mapping between Enum variants and its 
+//! [`Iden::unquoted()`] must be implemented to provide a mapping between Enum variants and its
 //! corresponding string value.
 //!
 //! ```rust

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -166,7 +166,7 @@ impl ConditionalStatement for DeleteStatement {
     }
 
     fn cond_where(&mut self, condition: Condition) -> &mut Self {
-        self.wherei.set_where(condition);
+        self.wherei.add_condition(condition);
         self
     }
 }

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1111,7 +1111,7 @@ impl SelectStatement {
     /// );
     /// ```
     pub fn cond_having(&mut self, condition: Condition) -> &mut Self {
-        self.having.set_where(condition);
+        self.having.add_condition(condition);
         self
     }
 
@@ -1292,7 +1292,7 @@ impl ConditionalStatement for SelectStatement {
     }
 
     fn cond_where(&mut self, condition: Condition) -> &mut Self {
-        self.wherei.set_where(condition);
+        self.wherei.add_condition(condition);
         self
     }
 }

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -332,7 +332,7 @@ impl ConditionalStatement for UpdateStatement {
     }
 
     fn cond_where(&mut self, condition: Condition) -> &mut Self {
-        self.wherei.set_where(condition);
+        self.wherei.add_condition(condition);
         self
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,9 +1,6 @@
 //! Schema definition & alternations statements
 
-use crate::{
-    backend::SchemaBuilder,
-    TableStatement, IndexStatement, ForeignKeyStatement
-};
+use crate::{backend::SchemaBuilder, ForeignKeyStatement, IndexStatement, TableStatement};
 
 #[derive(Debug, Clone)]
 pub enum SchemaStatement {


### PR DESCRIPTION
Should fix #51 

It's mostly a copy paste from the sqlx-postgres driver.
The only real changes are that `TinyUnsigned` and `SmallUnsigned` don't have to be cast to u32, as SQLx has `Encode` implementations for u8 and u16 for SQLite.

The sqlx_example is much the same as the postgres one as well, making use of an in-memory database instead, as well as removing the `returning_col()` on the read example (which SQLite now supports, so could be something to consider adding in the future).