### PR TITLE
Implements returning and returning_col for update statement

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -165,6 +165,8 @@ pub trait QueryBuilder: QuotedBuilder {
             write!(sql, " LIMIT ").unwrap();
             self.prepare_value(limit, sql, collector);
         }
+
+        self.prepare_returning(&update.returning, sql, collector);
     }
 
     /// Translate [`DeleteStatement`] into SQL statement.

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -1,4 +1,4 @@
-use sea_query::{*, tests_cfg::*, error::*};
+use sea_query::{error::*, tests_cfg::*, *};
 
 #[test]
 fn insert_values_1() {


### PR DESCRIPTION
* Adds `returning` and `returning_col` to `UpdateStatement`.
* Adds doc tests for `returning` and `returning_col` methods.
* Adds preparation call to `QueryBuilder` for update statements in Postgres backend.