### PR TITLE
Support Uuid column type

### DIFF
--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -82,6 +82,7 @@ impl TableBuilder for MysqlQueryBuilder {
                 ColumnType::Json => "json".into(),
                 ColumnType::JsonBinary => "json".into(),
                 ColumnType::Custom(iden) => iden.to_string(),
+                ColumnType::Uuid => format!("binary(16)"),
             }
         )
         .unwrap()

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -82,6 +82,7 @@ impl TableBuilder for PostgresQueryBuilder {
                 ColumnType::Json => "json".into(),
                 ColumnType::JsonBinary => "jsonb".into(),
                 ColumnType::Custom(iden) => iden.to_string(),
+                ColumnType::Uuid => "uuid".into(),
             }
         )
         .unwrap()

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -102,6 +102,7 @@ impl TableBuilder for SqliteQueryBuilder {
                 ColumnType::Json => "text".into(),
                 ColumnType::JsonBinary => "text".into(),
                 ColumnType::Custom(iden) => iden.to_string(),
+                ColumnType::Uuid => "text(36)".into(),
             }
         )
         .unwrap()

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -32,6 +32,7 @@ pub enum ColumnType {
     Json,
     JsonBinary,
     Custom(DynIden),
+    Uuid,
 }
 
 /// All column specification keywords
@@ -320,5 +321,11 @@ impl ColumnDef {
 
     pub fn get_column_spec(&self) -> &Vec<ColumnSpec> {
         self.spec.as_ref()
+    }
+
+    /// Set column type as uuid
+    pub fn uuid(mut self) -> Self {
+        self.types = Some(ColumnType::Uuid);
+        self
     }
 }


### PR DESCRIPTION
While adding the Uuid type in the Sea-Orm tests I found that I needed make these changes to make it all work.