### PR TITLE
remove anyhow as dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ chrono = { version = "^0", optional = true }
 postgres-types = { version = "^0", optional = true }
 rust_decimal = { version = "^1", optional = true }
 uuid = { version = "^0", optional = true }
-anyhow = { version = "^1" }
 thiserror = { version = "^1" }
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types used in sea-query.
 
 /// Result type for sea-query
-pub type Result<T> = anyhow::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum Error {


### PR DESCRIPTION
While working on some of the issues I raised, I found that anyhow was being used simply for its re-export of the [`Result`](https://doc.rust-lang.org/std/result/enum.Result.html) enum. This was without using anyhow's [`Error`](https://docs.rs/anyhow/1.0.42/anyhow/struct.Error.html) type.

So this just changes the type alias to use directly the standard library's `Result` and removes anyhow from the list of dependencies