### PR TITLE
#89 flattening iden enums

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,14 +53,12 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-features
-        working-directory: sea-query-derive
+          args: --package sea-query-derive --all-features
 
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
-        working-directory: sea-query-derive
+          args: --package sea-query-derive --all-features
 
   sqlite:
     name: SQLite

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,32 @@ jobs:
           command: test
           args: --all-features
 
+  derive-test:
+    name: Derive Tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
+        working-directory: sea-query-derive
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+        working-directory: sea-query-derive
+
   sqlite:
     name: SQLite
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *.sublime*
 .vscode
+wip/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ chrono = { version = "^0", optional = true }
 postgres-types = { version = "^0", optional = true }
 rust_decimal = { version = "^1", optional = true }
 uuid = { version = "^0", optional = true }
-anyhow = { version = "^1" }
 thiserror = { version = "^1" }
 
 [features]

--- a/sea-query-derive/Cargo.toml
+++ b/sea-query-derive/Cargo.toml
@@ -18,3 +18,8 @@ syn = { version = "1", default-features = false, features = [ "derive", "parsing
 quote = "1"
 heck = "0.3"
 proc-macro2 = "1"
+
+[dev-dependencies]
+trybuild = "^1.0"
+sea-query = { path = "../" }
+strum = { version = "^0.21", features = ["derive"] }

--- a/sea-query-derive/src/iden_attr.rs
+++ b/sea-query-derive/src/iden_attr.rs
@@ -1,0 +1,64 @@
+use std::convert::{TryFrom, TryInto};
+
+use syn::{Attribute, Error, Ident, Lit, Meta};
+
+#[derive(PartialEq)]
+pub enum IdenAttr {
+    Rename(syn::LitStr),
+    Method(Ident),
+    Flatten,
+}
+
+impl IdenAttr {
+    fn extract_method(meta: Meta) -> syn::Result<Self> {
+        match meta {
+            Meta::NameValue(nv) => match nv.lit {
+                Lit::Str(name) => Ok(Self::Method(Ident::new(name.value().as_str(), name.span()))),
+                _ => Err(Error::new_spanned(nv, "Must be a string literal")),
+            },
+            a => Err(Error::new_spanned(
+                a,
+                r#"The method attribute only supports the `#[method = "name"]` format"#,
+            )),
+        }
+    }
+
+    fn extract_iden(meta: Meta) -> syn::Result<Self> {
+        match meta {
+            Meta::NameValue(nv) => match nv.lit {
+                Lit::Str(lit) => Ok(IdenAttr::Rename(lit)),
+                _ => Err(Error::new_spanned(
+                    nv.lit,
+                    "Only string literals are permitted in this position",
+                )),
+            },
+            a => Err(Error::new_spanned(
+                a,
+                r#"The iden attribute supports only the formats `#[iden = "name"]` and #[iden(flatten)]"#,
+            )),
+        }
+    }
+}
+
+impl TryFrom<&Attribute> for IdenAttr {
+    type Error = Error;
+
+    fn try_from(value: &Attribute) -> Result<Self, Self::Error> {
+        value.parse_meta()?.try_into()
+    }
+}
+
+impl TryFrom<Meta> for IdenAttr {
+    type Error = Error;
+
+    fn try_from(value: Meta) -> Result<Self, Self::Error> {
+        let path = value.path();
+        if path.is_ident("method") {
+            Self::extract_method(value)
+        } else if path.is_ident("iden") {
+            Self::extract_iden(value)
+        } else {
+            todo!()
+        }
+    }
+}

--- a/sea-query-derive/src/iden_attr.rs
+++ b/sea-query-derive/src/iden_attr.rs
@@ -4,7 +4,7 @@ use syn::{Attribute, Error, Ident, Lit, Meta};
 
 #[derive(PartialEq)]
 pub enum IdenAttr {
-    Rename(syn::LitStr),
+    Rename(String),
     Method(Ident),
     Flatten,
 }
@@ -26,7 +26,7 @@ impl IdenAttr {
     fn extract_iden(meta: Meta) -> syn::Result<Self> {
         match meta {
             Meta::NameValue(nv) => match nv.lit {
-                Lit::Str(lit) => Ok(IdenAttr::Rename(lit)),
+                Lit::Str(lit) => Ok(IdenAttr::Rename(lit.value())),
                 _ => Err(Error::new_spanned(
                     nv.lit,
                     "Only string literals are permitted in this position",

--- a/sea-query-derive/src/iden_variant.rs
+++ b/sea-query-derive/src/iden_variant.rs
@@ -1,0 +1,161 @@
+use std::convert::TryFrom;
+
+use heck::SnakeCase;
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens, TokenStreamExt};
+use syn::{Error, Fields, FieldsNamed, Ident, Variant};
+
+use crate::{find_attr, iden_attr::IdenAttr};
+
+pub struct IdenVariant<'a> {
+    ident: &'a Ident,
+    fields: &'a Fields,
+    table_name: &'a str,
+    attr: Option<IdenAttr>,
+}
+
+impl<'a> TryFrom<(&'a str, &'a Variant)> for IdenVariant<'a> {
+    type Error = Error;
+
+    fn try_from((table_name, value): (&'a str, &'a Variant)) -> Result<Self, Self::Error> {
+        let Variant {
+            ident,
+            fields,
+            attrs,
+            ..
+        } = value;
+        let attr = find_attr(attrs).map(IdenAttr::try_from).transpose()?;
+
+        Self::new(ident, fields, table_name, attr)
+    }
+}
+
+impl ToTokens for IdenVariant<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self.fields {
+            Fields::Named(named) => self.to_tokens_from_named(named, tokens),
+            Fields::Unnamed(_) => self.to_tokens_from_unnamed(tokens),
+            Fields::Unit => self.to_tokens_from_unit(tokens),
+        }
+    }
+}
+
+impl<'a> IdenVariant<'a> {
+    fn new(
+        ident: &'a Ident,
+        fields: &'a Fields,
+        table_name: &'a str,
+        attr: Option<IdenAttr>,
+    ) -> syn::Result<Self> {
+        // sanity check to not have flatten on a unit variant, or variants with more than 1 field
+        static FLATTEN_ERR: &str = "Only a single field is supported for flattenning";
+        if attr == Some(IdenAttr::Flatten) {
+            match fields {
+                Fields::Named(n) => {
+                    if n.named.len() != 1 {
+                        return Err(Error::new_spanned(fields, FLATTEN_ERR));
+                    }
+                }
+                Fields::Unnamed(u) => {
+                    if u.unnamed.len() != 1 {
+                        return Err(Error::new_spanned(fields, FLATTEN_ERR));
+                    }
+                }
+                Fields::Unit => {
+                    return Err(Error::new_spanned(
+                        fields,
+                        "Must have a field in order to be flattened",
+                    ))
+                }
+            }
+        }
+
+        Ok(Self {
+            ident,
+            fields,
+            table_name,
+            attr,
+        })
+    }
+
+    fn to_tokens_from_named(&self, named: &FieldsNamed, tokens: &mut TokenStream) {
+        let ident = self.ident;
+
+        let match_arm = if self.attr == Some(IdenAttr::Flatten) {
+            // indexing is safe because len is guaranteed to be 1 from the constructor.
+            let field = &named.named[0];
+            // Unwrapping the ident is also safe because a named field always has an ident.
+            let capture = field.ident.as_ref().unwrap();
+            let variant = quote! { #ident{#capture} };
+            write_flattened(variant, capture)
+        } else {
+            let variant = quote! { #ident{..} };
+            self.write_variant_name(variant)
+        };
+
+        tokens.append_all(match_arm)
+    }
+
+    fn to_tokens_from_unnamed(&self, tokens: &mut TokenStream) {
+        let ident = self.ident;
+
+        let match_arm = if self.attr == Some(IdenAttr::Flatten) {
+            // The case where unnamed fields length is not 1 is handled by new
+            let capture = Delegated.into();
+            let variant = quote! { #ident(#capture) };
+            write_flattened(variant, &capture)
+        } else {
+            let variant = quote! { #ident(..) };
+            self.write_variant_name(variant)
+        };
+
+        tokens.append_all(match_arm)
+    }
+
+    fn to_tokens_from_unit(&self, tokens: &mut TokenStream) {
+        let ident = self.ident;
+        let variant = quote! { #ident };
+
+        tokens.append_all(self.write_variant_name(variant))
+    }
+
+    fn table_or_snake_case(&self) -> TokenStream {
+        if self.ident == "Table" {
+            let table_name = self.table_name;
+            quote! { #table_name }
+        } else {
+            let name = self.ident.to_string().to_snake_case();
+            quote! { #name }
+        }
+    }
+
+    fn write_variant_name(&self, variant: TokenStream) -> TokenStream {
+        let name = self
+            .attr
+            .as_ref()
+            .map(|a| match a {
+                IdenAttr::Rename(name) => quote! { #name },
+                IdenAttr::Method(method) => quote! { self.#method() },
+                IdenAttr::Flatten => unreachable!(),
+            })
+            .unwrap_or_else(|| self.table_or_snake_case());
+
+        write_variant(variant, name)
+    }
+}
+
+struct Delegated;
+
+impl From<Delegated> for Ident {
+    fn from(_: Delegated) -> Self {
+        Ident::new("delegated", Span::call_site())
+    }
+}
+
+fn write_variant(variant: TokenStream, name: TokenStream) -> TokenStream {
+    quote! { Self::#variant => write!(s, "{}", #name).unwrap() }
+}
+
+fn write_flattened(variant: TokenStream, name: &Ident) -> TokenStream {
+    quote! { Self::#variant => #name.unquoted(s) }
+}

--- a/sea-query-derive/src/lib.rs
+++ b/sea-query-derive/src/lib.rs
@@ -24,7 +24,7 @@ pub fn derive_iden(input: TokenStream) -> TokenStream {
 
     let table_name = match find_attr(&attrs) {
         Some(att) => match att.try_into() {
-            Ok(IdenAttr::Rename(lit)) => lit.value(),
+            Ok(IdenAttr::Rename(lit)) => lit,
             Ok(_) => {
                 return syn::Error::new_spanned(
                     att,

--- a/sea-query-derive/src/lib.rs
+++ b/sea-query-derive/src/lib.rs
@@ -1,33 +1,19 @@
+use std::convert::{TryFrom, TryInto};
+
 use heck::SnakeCase;
 use proc_macro::{self, TokenStream};
-use proc_macro2::Span;
 use quote::{quote, quote_spanned};
-use syn::{
-    parse_macro_input, Attribute, DataEnum, DataStruct, DeriveInput, Fields, Ident, Lit, Meta,
-    Variant,
-};
+use syn::{parse_macro_input, Attribute, DataEnum, DataStruct, DeriveInput, Fields};
 
-fn get_iden_attr(attrs: &[Attribute]) -> Option<syn::Lit> {
-    for attr in attrs {
-        let name_value = match attr.parse_meta() {
-            Ok(Meta::NameValue(nv)) => nv,
-            _ => continue,
-        };
-        if name_value.path.is_ident("iden") {
-            return Some(name_value.lit);
-        }
-    }
-    None
-}
+mod iden_attr;
+mod iden_variant;
 
-fn get_method_attr(attr: &Attribute) -> syn::Result<syn::Lit> {
-    match attr.parse_meta()? {
-        Meta::NameValue(nv) => Ok(nv.lit),
-        a => Err(syn::Error::new_spanned(
-            a,
-            r#"The method attribute only supports the `#[method = "name"]` format"#,
-        )),
-    }
+use self::{iden_attr::IdenAttr, iden_variant::IdenVariant};
+
+fn find_attr(attrs: &[Attribute]) -> Option<&Attribute> {
+    attrs
+        .iter()
+        .find(|attr| attr.path.is_ident("iden") || attr.path.is_ident("method"))
 }
 
 #[proc_macro_derive(Iden, attributes(iden, method))]
@@ -36,12 +22,20 @@ pub fn derive_iden(input: TokenStream) -> TokenStream {
         ident, data, attrs, ..
     } = parse_macro_input!(input);
 
-    let table_name = match get_iden_attr(&attrs) {
-        Some(lit) => quote! { #lit },
-        None => {
-            let normalized = ident.to_string().to_snake_case();
-            quote! { #normalized }
-        }
+    let table_name = match find_attr(&attrs) {
+        Some(att) => match att.try_into() {
+            Ok(IdenAttr::Rename(lit)) => lit.value(),
+            Ok(_) => {
+                return syn::Error::new_spanned(
+                    att,
+                    r#"Only the `#[iden = "name"]` attribute is supported in this position"#,
+                )
+                .into_compile_error()
+                .into()
+            }
+            Err(e) => return e.into_compile_error().into(),
+        },
+        None => ident.to_string().to_snake_case(),
     };
 
     // Currently we only support enums and unit structs
@@ -71,41 +65,21 @@ pub fn derive_iden(input: TokenStream) -> TokenStream {
         return TokenStream::new();
     }
 
-    let variant = variants
+    let match_arms = match variants
         .iter()
-        .map(|Variant { ident, fields, .. }| match fields {
-            Fields::Named(_) => quote! { #ident{..} },
-            Fields::Unnamed(_) => quote! { #ident(..) },
-            Fields::Unit => quote! { #ident },
-        });
-
-    let name = variants.iter().map(|v| {
-        if let Some(lit) = get_iden_attr(&v.attrs) {
-            // If the user supplied a name, just use it
-            quote! { #lit }
-        } else if let Some(lit) =
-            find_attr(&v.attrs, "method").and_then(|att| get_method_attr(att).ok())
-        {
-            // If the user supplied a method, call it
-            let name: String = match lit {
-                Lit::Str(name) => name.value(),
-                _ => panic!("expected string for `method`"),
-            };
-            let ident = Ident::new(name.as_str(), Span::call_site());
-            quote! { self.#ident() }
-        } else if v.ident == "Table" {
-            table_name.clone()
-        } else {
-            let ident = v.ident.to_string().to_snake_case();
-            quote! { #ident }
-        }
-    });
+        .map(|v| (table_name.as_str(), v))
+        .map(IdenVariant::try_from)
+        .collect::<syn::Result<Vec<_>>>()
+    {
+        Ok(v) => v,
+        Err(e) => return e.to_compile_error().into(),
+    };
 
     let output = quote! {
         impl sea_query::Iden for #ident {
             fn unquoted(&self, s: &mut dyn sea_query::Write) {
                 match self {
-                    #(Self::#variant => write!(s, "{}", #name).unwrap()),*
+                    #(#match_arms),*
                 };
             }
         }

--- a/sea-query-derive/tests/compile-fail/empty_list_iden.rs
+++ b/sea-query-derive/tests/compile-fail/empty_list_iden.rs
@@ -1,0 +1,19 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+enum Asset {
+    Table,
+    Id,
+    AssetName,
+    #[iden()]
+    Creation(CreationInfo),
+}
+
+#[derive(Iden)]
+enum CreationInfo {
+    UserId,
+    #[iden = "creation_date"]
+    Date,
+}
+
+fn main() {}

--- a/sea-query-derive/tests/compile-fail/empty_list_iden.stderr
+++ b/sea-query-derive/tests/compile-fail/empty_list_iden.stderr
@@ -1,0 +1,5 @@
+error: must be of the form `#[iden(flatten)]`
+ --> $DIR/empty_list_iden.rs:8:7
+  |
+8 |     #[iden()]
+  |       ^^^^^^

--- a/sea-query-derive/tests/compile-fail/mutli_field_flatten.rs
+++ b/sea-query-derive/tests/compile-fail/mutli_field_flatten.rs
@@ -1,0 +1,19 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+enum Asset {
+    Table,
+    Id,
+    AssetName,
+    #[iden(flatten)]
+    Creation(CreationInfo, CreationInfo),
+}
+
+#[derive(Iden)]
+enum CreationInfo {
+    UserId,
+    #[iden = "creation_date"]
+    Date,
+}
+
+fn main() {}

--- a/sea-query-derive/tests/compile-fail/mutli_field_flatten.stderr
+++ b/sea-query-derive/tests/compile-fail/mutli_field_flatten.stderr
@@ -1,0 +1,5 @@
+error: Only a single field is supported for flattenning
+ --> $DIR/mutli_field_flatten.rs:9:13
+  |
+9 |     Creation(CreationInfo, CreationInfo),
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/sea-query-derive/tests/compile-fail/path_iden.rs
+++ b/sea-query-derive/tests/compile-fail/path_iden.rs
@@ -1,0 +1,12 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+enum Asset {
+    Table,
+    Id,
+    AssetName,
+    #[iden]
+    Creation,
+}
+
+fn main() {}

--- a/sea-query-derive/tests/compile-fail/path_iden.stderr
+++ b/sea-query-derive/tests/compile-fail/path_iden.stderr
@@ -1,0 +1,5 @@
+error: The iden attribute supports only the formats `#[iden = "name"]` and #[iden(flatten)]
+ --> $DIR/path_iden.rs:8:7
+  |
+8 |     #[iden]
+  |       ^^^^

--- a/sea-query-derive/tests/compile-fail/path_method.rs
+++ b/sea-query-derive/tests/compile-fail/path_method.rs
@@ -1,0 +1,12 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+enum Asset {
+    Table,
+    Id,
+    AssetName,
+    #[method]
+    Creation,
+}
+
+fn main() {}

--- a/sea-query-derive/tests/compile-fail/path_method.stderr
+++ b/sea-query-derive/tests/compile-fail/path_method.stderr
@@ -1,0 +1,5 @@
+error: The method attribute only supports the `#[method = "name"]` format
+ --> $DIR/path_method.rs:8:7
+  |
+8 |     #[method]
+  |       ^^^^^^

--- a/sea-query-derive/tests/compile-fail/wrong_literal_type.rs
+++ b/sea-query-derive/tests/compile-fail/wrong_literal_type.rs
@@ -1,0 +1,13 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+enum User {
+    Table,
+    #[iden = 123]
+    Id,
+    FirstName,
+    LastName,
+    Email,
+}
+
+fn main() {}

--- a/sea-query-derive/tests/compile-fail/wrong_literal_type.stderr
+++ b/sea-query-derive/tests/compile-fail/wrong_literal_type.stderr
@@ -1,0 +1,5 @@
+error: Only string literals are permitted in this position
+ --> $DIR/wrong_literal_type.rs:6:14
+  |
+6 |     #[iden = 123]
+  |              ^^^

--- a/sea-query-derive/tests/pass/3_level_flatten.rs
+++ b/sea-query-derive/tests/pass/3_level_flatten.rs
@@ -1,0 +1,59 @@
+use sea_query::Iden;
+use strum::{EnumIter, IntoEnumIterator};
+
+#[derive(Iden, EnumIter)]
+enum Asset {
+    Table,
+    Id,
+    AssetName,
+    #[iden(flatten)]
+    First {
+        first: FirstLevel,
+    },
+}
+
+#[derive(Iden)]
+enum FirstLevel {
+    LevelOne,
+    #[iden(flatten)]
+    Second(SecondLevel),
+}
+
+#[derive(Iden, EnumIter)]
+enum SecondLevel {
+    LevelTwo,
+    #[iden(flatten)]
+    Third(LevelThree),
+    UserId,
+}
+
+#[derive(Iden, Default)]
+struct LevelThree;
+
+impl Default for FirstLevel {
+    fn default() -> Self {
+        Self::LevelOne
+    }
+}
+
+fn main() {
+    // custom ends up being default string which is an empty string
+    let expected = [
+        "asset",
+        "id",
+        "asset_name",
+        "level_one",
+        "level_two",
+        "level_three",
+        "user_id",
+    ];
+    Asset::iter()
+        .chain(
+            SecondLevel::iter()
+                .map(FirstLevel::Second)
+                .map(|s| Asset::First { first: s }),
+        )
+        .map(|var| Iden::to_string(&var))
+        .zip(expected)
+        .for_each(|(iden, exp)| assert_eq!(iden, exp))
+}

--- a/sea-query-derive/tests/pass/flattened_named.rs
+++ b/sea-query-derive/tests/pass/flattened_named.rs
@@ -1,0 +1,38 @@
+use sea_query::Iden;
+use strum::{EnumIter, IntoEnumIterator};
+
+#[derive(Iden, EnumIter)]
+enum Asset {
+    Table,
+    Id,
+    AssetName,
+    #[iden(flatten)]
+    Creation {
+        info: CreationInfo,
+    },
+}
+
+#[derive(Iden)]
+enum CreationInfo {
+    UserId,
+    #[iden = "creation_date"]
+    Date,
+}
+
+impl Default for CreationInfo {
+    fn default() -> Self {
+        Self::UserId
+    }
+}
+
+fn main() {
+    // custom ends up being default string which is an empty string
+    let expected = ["asset", "id", "asset_name", "user_id", "creation_date"];
+    Asset::iter()
+        .chain(std::iter::once(Asset::Creation {
+            info: CreationInfo::Date,
+        }))
+        .map(|var| Iden::to_string(&var))
+        .zip(expected)
+        .for_each(|(iden, exp)| assert_eq!(iden, exp))
+}

--- a/sea-query-derive/tests/pass/flattened_unnamed.rs
+++ b/sea-query-derive/tests/pass/flattened_unnamed.rs
@@ -1,0 +1,34 @@
+use sea_query::Iden;
+use strum::{EnumIter, IntoEnumIterator};
+
+#[derive(Iden, EnumIter)]
+enum Asset {
+    Table,
+    Id,
+    AssetName,
+    #[iden(flatten)]
+    Creation(CreationInfo),
+}
+
+#[derive(Iden)]
+enum CreationInfo {
+    UserId,
+    #[iden = "creation_date"]
+    Date,
+}
+
+impl Default for CreationInfo {
+    fn default() -> Self {
+        Self::UserId
+    }
+}
+
+fn main() {
+    // custom ends up being default string which is an empty string
+    let expected = ["asset", "id", "asset_name", "user_id", "creation_date"];
+    Asset::iter()
+        .chain(std::iter::once(Asset::Creation(CreationInfo::Date)))
+        .map(|var| Iden::to_string(&var))
+        .zip(expected)
+        .for_each(|(iden, exp)| assert_eq!(iden, exp))
+}

--- a/sea-query-derive/tests/pass/renamed_unit_struct.rs
+++ b/sea-query-derive/tests/pass/renamed_unit_struct.rs
@@ -1,0 +1,9 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+#[iden = "another_name"]
+pub struct CustomName;
+
+fn main() {
+    assert_eq!(Iden::to_string(&CustomName), "another_name")
+}

--- a/sea-query-derive/tests/pass/renaming_everything.rs
+++ b/sea-query-derive/tests/pass/renaming_everything.rs
@@ -1,0 +1,40 @@
+use sea_query::Iden;
+use strum::{EnumIter, IntoEnumIterator};
+
+#[derive(Iden, EnumIter)]
+// Outer iden attributes overrides what's used for "Table"...
+#[iden = "user"]
+enum Custom {
+    Table,
+    #[iden = "my_id"]
+    Id,
+    #[iden = "name"]
+    FirstName,
+    #[iden = "surname"]
+    LastName,
+    // Custom casing if needed
+    #[iden = "EMail"]
+    // the tuple value will be ignored
+    Email(String),
+    // Custom method
+    #[method = "custom_to_string"]
+    Custom(String),
+}
+
+impl Custom {
+    pub fn custom_to_string(&self) -> &str {
+        match self {
+            Self::Custom(custom) => custom,
+            _ => panic!("not Custom::Custom"),
+        }
+    }
+}
+
+fn main() {
+    // custom ends up being default string which is an empty string
+    let expected = ["user", "my_id", "name", "surname", "EMail", ""];
+    Custom::iter()
+        .map(|var| Iden::to_string(&var))
+        .zip(expected)
+        .for_each(|(iden, exp)| assert_eq!(iden, exp))
+}

--- a/sea-query-derive/tests/pass/renaming_table.rs
+++ b/sea-query-derive/tests/pass/renaming_table.rs
@@ -1,0 +1,20 @@
+use sea_query::Iden;
+use strum::{EnumIter, IntoEnumIterator};
+
+#[derive(Iden, EnumIter)]
+enum Something {
+    // ...the Table can also be overwritten like this
+    #[iden = "something_else"]
+    Table,
+    Id,
+    AssetName,
+    UserId,
+}
+
+fn main() {
+    let expected = ["something_else", "id", "asset_name", "user_id"];
+    Something::iter()
+        .map(|var| Iden::to_string(&var))
+        .zip(expected)
+        .for_each(|(iden, exp)| assert_eq!(iden, exp))
+}

--- a/sea-query-derive/tests/pass/simple_unit_struct.rs
+++ b/sea-query-derive/tests/pass/simple_unit_struct.rs
@@ -1,0 +1,8 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+pub struct SomeType;
+
+fn main() {
+    assert_eq!(Iden::to_string(&SomeType), "some_type")
+}

--- a/sea-query-derive/tests/pass/without_attributes.rs
+++ b/sea-query-derive/tests/pass/without_attributes.rs
@@ -1,4 +1,4 @@
-use sea_query::{Iden, IntoIden};
+use sea_query::Iden;
 use strum::{EnumIter, IntoEnumIterator};
 
 #[derive(Iden, EnumIter)]
@@ -13,7 +13,7 @@ enum User {
 fn main() {
     let expected = ["user", "id", "first_name", "last_name", "email"];
     User::iter()
-        .map(Iden::to_string)
+        .map(|var| Iden::to_string(&var))
         .zip(expected)
         .for_each(|(iden, exp)| assert_eq!(iden, exp))
 }

--- a/sea-query-derive/tests/pass/without_attributes.rs
+++ b/sea-query-derive/tests/pass/without_attributes.rs
@@ -1,0 +1,19 @@
+use sea_query::{Iden, IntoIden};
+use strum::{EnumIter, IntoEnumIterator};
+
+#[derive(Iden, EnumIter)]
+enum User {
+    Table,
+    Id,
+    FirstName,
+    LastName,
+    Email,
+}
+
+fn main() {
+    let expected = ["user", "id", "first_name", "last_name", "email"];
+    User::iter()
+        .map(|var| var.into_iden().to_string())
+        .zip(expected)
+        .for_each(|(iden, exp)| assert_eq!(iden, exp))
+}

--- a/sea-query-derive/tests/pass/without_attributes.rs
+++ b/sea-query-derive/tests/pass/without_attributes.rs
@@ -13,7 +13,7 @@ enum User {
 fn main() {
     let expected = ["user", "id", "first_name", "last_name", "email"];
     User::iter()
-        .map(|var| var.into_iden().to_string())
+        .map(Iden::to_string)
         .zip(expected)
         .for_each(|(iden, exp)| assert_eq!(iden, exp))
 }

--- a/sea-query-derive/tests/test_build.rs
+++ b/sea-query-derive/tests/test_build.rs
@@ -1,0 +1,8 @@
+#[test]
+fn build_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("./tests/compile-fail/*.rs");
+
+    // all of these are exactly the same as the examples in `examples/derive.rs`
+    t.pass("./tests/pass/*.rs");
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types used in sea-query.
 
 /// Result type for sea-query
-pub type Result<T> = anyhow::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum Error {


### PR DESCRIPTION
First let me apologize in advance for the monstrosity that is this pull request's size.

This pull request addresses #89. Even though the maintainers didn't voice any thoughts on the matter, I figured I'd try to implement it anyways rather than do a custom derive in my project.

I thought this was going to be a simple change but it turned out to be quite a endeavour. It ended up as pretty much an complete rewrite.

Along the way to add the `#[iden(flatten)]` attribute, I added the following:
* Error management instead of silently failing  on invalid attributes.
* 2 utility structs
  * `IdenAttr` manages the actual attribute used on a struct or variant.
  * `IdenVariant` manages a single enum variant according to its `IdenAttr` and the previously defined rules.
* tests for the derive crate. For this, a few test dependencies were added
  * [trybuild](https://docs.rs/trybuild/1.0.43/trybuild/)
  * [strum](https://docs.rs/strum/0.21.0/strum/)
  * and the sea-query crate for the trait.

`IdenVariant` has the additional advantage to implement `quote::ToTokens` which will expand into a match arm. This way you can just pass a variable of this type to `quote!{}` and it will expand according to the given rules.

For the tests I haven't touched the CI configuration since I'm not sure if you wish to keep test the workspace together or each crate separately.

Closes #89 