### PR TITLE
Uniform derive api

### DIFF
--- a/sea-query-derive/Cargo.toml
+++ b/sea-query-derive/Cargo.toml
@@ -18,6 +18,7 @@ syn = { version = "1", default-features = false, features = [ "derive", "parsing
 quote = "1"
 heck = "0.3"
 proc-macro2 = "1"
+thiserror = "^1.0"
 
 [dev-dependencies]
 trybuild = "^1.0"

--- a/sea-query-derive/src/error.rs
+++ b/sea-query-derive/src/error.rs
@@ -1,0 +1,21 @@
+use syn::Ident;
+
+use crate::iden_path::IdenPath;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ErrorMsg {
+    #[error("Only the attributes `#[iden = \"name\"]` or `#[iden(rename = \"name\") are supported in this position")]
+    ContainerAttr,
+    #[error("Must be a string literal")]
+    WrongLiteral,
+    #[error("The method attribute only supports the `#[{0} = \"name\"]` or `#[iden({0} = \"name\")]` formats")]
+    WrongNamedValueFormat(IdenPath, IdenPath),
+    #[error("Must one of the following attributes: `flatten`, `rename` or `method`")]
+    WrongListFormat,
+    #[error("The iden attribute supports only the formats `#[iden = \"name\"]` or `#[iden(<ATTRIBUTE>)]` where ATTRIBUTE is either `flatten`, `rename` or `method`")]
+    WrongAttributeFormat,
+    #[error("{0} is not a supported keyword")]
+    UnsupportedKeyword(Ident),
+    #[error("Must have a single field is supported for flattenning")]
+    UnsupportedFlattenTarget,
+}

--- a/sea-query-derive/src/iden_attr.rs
+++ b/sea-query-derive/src/iden_attr.rs
@@ -2,6 +2,8 @@ use std::convert::{TryFrom, TryInto};
 
 use syn::{Attribute, Error, Ident, Lit, Meta, MetaNameValue, NestedMeta};
 
+use crate::iden_path::IdenPath;
+
 #[derive(PartialEq)]
 pub enum IdenAttr {
     Rename(String),
@@ -33,7 +35,7 @@ impl IdenAttr {
                 )),
             },
             Meta::List(list) => match list.nested.first() {
-                Some(NestedMeta::Meta(Meta::Path(p))) if p.is_ident("flatten") => {
+                Some(NestedMeta::Meta(Meta::Path(p))) if p.is_ident(&IdenPath::Flatten) => {
                     Ok(IdenAttr::Flatten)
                 }
                 Some(NestedMeta::Meta(Meta::NameValue(nv))) => Self::extract_named_value_iden(nv),
@@ -53,9 +55,9 @@ impl IdenAttr {
         match &nv.lit {
             Lit::Str(name) => {
                 // Don't match "iden" since that would mean `#[iden(iden = "name")]` would be accepted
-                if nv.path.is_ident("rename") {
+                if nv.path.is_ident(&IdenPath::Rename) {
                     Ok(Self::Rename(name.value()))
-                } else if nv.path.is_ident("method") {
+                } else if nv.path.is_ident(&IdenPath::Method) {
                     Ok(Self::Method(Ident::new(name.value().as_str(), name.span())))
                 } else {
                     Err(Error::new_spanned(
@@ -85,9 +87,9 @@ impl TryFrom<Meta> for IdenAttr {
 
     fn try_from(value: Meta) -> Result<Self, Self::Error> {
         let path = value.path();
-        if path.is_ident("method") {
+        if path.is_ident(&IdenPath::Method) {
             Self::extract_method(value)
-        } else if path.is_ident("iden") {
+        } else if path.is_ident(&IdenPath::Iden) {
             Self::extract_iden(value)
         } else {
             todo!()

--- a/sea-query-derive/src/iden_path.rs
+++ b/sea-query-derive/src/iden_path.rs
@@ -1,0 +1,17 @@
+pub enum IdenPath {
+    Iden,
+    Method,
+    Rename,
+    Flatten,
+}
+
+impl PartialEq<IdenPath> for syn::Ident {
+    fn eq(&self, other: &IdenPath) -> bool {
+        match other {
+            IdenPath::Iden => self.eq("iden"),
+            IdenPath::Method => self.eq("method"),
+            IdenPath::Rename => self.eq("rename"),
+            IdenPath::Flatten => self.eq("flatten"),
+        }
+    }
+}

--- a/sea-query-derive/src/iden_path.rs
+++ b/sea-query-derive/src/iden_path.rs
@@ -1,3 +1,6 @@
+use std::fmt::Display;
+
+#[derive(Debug)]
 pub enum IdenPath {
     Iden,
     Method,
@@ -5,13 +8,25 @@ pub enum IdenPath {
     Flatten,
 }
 
+impl IdenPath {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            IdenPath::Iden => "iden",
+            IdenPath::Method => "method",
+            IdenPath::Rename => "rename",
+            IdenPath::Flatten => "flatten",
+        }
+    }
+}
+
+impl Display for IdenPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 impl PartialEq<IdenPath> for syn::Ident {
     fn eq(&self, other: &IdenPath) -> bool {
-        match other {
-            IdenPath::Iden => self.eq("iden"),
-            IdenPath::Method => self.eq("method"),
-            IdenPath::Rename => self.eq("rename"),
-            IdenPath::Flatten => self.eq("flatten"),
-        }
+        self.eq(other.as_str())
     }
 }

--- a/sea-query-derive/src/lib.rs
+++ b/sea-query-derive/src/lib.rs
@@ -6,14 +6,15 @@ use quote::{quote, quote_spanned};
 use syn::{parse_macro_input, Attribute, DataEnum, DataStruct, DeriveInput, Fields};
 
 mod iden_attr;
+mod iden_path;
 mod iden_variant;
 
-use self::{iden_attr::IdenAttr, iden_variant::IdenVariant};
+use self::{iden_attr::IdenAttr, iden_path::IdenPath, iden_variant::IdenVariant};
 
 fn find_attr(attrs: &[Attribute]) -> Option<&Attribute> {
     attrs
         .iter()
-        .find(|attr| attr.path.is_ident("iden") || attr.path.is_ident("method"))
+        .find(|attr| attr.path.is_ident(&IdenPath::Iden) || attr.path.is_ident(&IdenPath::Method))
 }
 
 #[proc_macro_derive(Iden, attributes(iden, method))]

--- a/sea-query-derive/src/lib.rs
+++ b/sea-query-derive/src/lib.rs
@@ -5,11 +5,12 @@ use proc_macro::{self, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::{parse_macro_input, Attribute, DataEnum, DataStruct, DeriveInput, Fields};
 
+mod error;
 mod iden_attr;
 mod iden_path;
 mod iden_variant;
 
-use self::{iden_attr::IdenAttr, iden_path::IdenPath, iden_variant::IdenVariant};
+use self::{error::ErrorMsg, iden_attr::IdenAttr, iden_path::IdenPath, iden_variant::IdenVariant};
 
 fn find_attr(attrs: &[Attribute]) -> Option<&Attribute> {
     attrs
@@ -27,12 +28,9 @@ pub fn derive_iden(input: TokenStream) -> TokenStream {
         Some(att) => match att.try_into() {
             Ok(IdenAttr::Rename(lit)) => lit,
             Ok(_) => {
-                return syn::Error::new_spanned(
-                    att,
-                    r#"Only the `#[iden = "name"]` attribute is supported in this position"#,
-                )
-                .into_compile_error()
-                .into()
+                return syn::Error::new_spanned(att, ErrorMsg::ContainerAttr)
+                    .into_compile_error()
+                    .into()
             }
             Err(e) => return e.into_compile_error().into(),
         },

--- a/sea-query-derive/tests/compile-fail/empty_list_iden.stderr
+++ b/sea-query-derive/tests/compile-fail/empty_list_iden.stderr
@@ -1,4 +1,4 @@
-error: must be of the form `#[iden(flatten)]`
+error: Must one of the following attributes: `flatten`, `rename` or `method`
  --> $DIR/empty_list_iden.rs:8:7
   |
 8 |     #[iden()]

--- a/sea-query-derive/tests/compile-fail/mutli_field_flatten.stderr
+++ b/sea-query-derive/tests/compile-fail/mutli_field_flatten.stderr
@@ -1,4 +1,4 @@
-error: Only a single field is supported for flattenning
+error: Must have a single field is supported for flattenning
  --> $DIR/mutli_field_flatten.rs:9:13
   |
 9 |     Creation(CreationInfo, CreationInfo),

--- a/sea-query-derive/tests/compile-fail/path_iden.stderr
+++ b/sea-query-derive/tests/compile-fail/path_iden.stderr
@@ -1,4 +1,4 @@
-error: The iden attribute supports only the formats `#[iden = "name"]` and #[iden(flatten)]
+error: The iden attribute supports only the formats `#[iden = "name"]` or `#[iden(<ATTRIBUTE>)]` where ATTRIBUTE is either `flatten`, `rename` or `method`
  --> $DIR/path_iden.rs:8:7
   |
 8 |     #[iden]

--- a/sea-query-derive/tests/compile-fail/path_method.stderr
+++ b/sea-query-derive/tests/compile-fail/path_method.stderr
@@ -1,4 +1,4 @@
-error: The method attribute only supports the `#[method = "name"]` format
+error: The method attribute only supports the `#[method = "name"]` or `#[iden(method = "name")]` formats
  --> $DIR/path_method.rs:8:7
   |
 8 |     #[method]

--- a/sea-query-derive/tests/compile-fail/unsupported_container.rs
+++ b/sea-query-derive/tests/compile-fail/unsupported_container.rs
@@ -1,0 +1,8 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+struct User {
+    id: usize,
+}
+
+fn main() {}

--- a/sea-query-derive/tests/compile-fail/unsupported_container.stderr
+++ b/sea-query-derive/tests/compile-fail/unsupported_container.stderr
@@ -1,0 +1,5 @@
+error: you can only derive Iden on enums or unit structs
+ --> $DIR/unsupported_container.rs:4:8
+  |
+4 | struct User {
+  |        ^^^^

--- a/sea-query-derive/tests/compile-fail/wrong_literal_type.stderr
+++ b/sea-query-derive/tests/compile-fail/wrong_literal_type.stderr
@@ -1,4 +1,4 @@
-error: Only string literals are permitted in this position
+error: Must be a string literal
  --> $DIR/wrong_literal_type.rs:6:14
   |
 6 |     #[iden = 123]

--- a/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
+++ b/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
@@ -1,0 +1,40 @@
+use sea_query::Iden;
+use strum::{EnumIter, IntoEnumIterator};
+
+#[derive(Iden, EnumIter)]
+// Outer iden attributes overrides what's used for "Table"...
+#[iden(rename = "user")]
+enum Custom {
+    Table,
+    #[iden(rename = "my_id")]
+    Id,
+    #[iden(rename = "name")]
+    FirstName,
+    #[iden(rename = "surname")]
+    LastName,
+    // Custom casing if needed
+    #[iden(rename = "EMail")]
+    // the tuple value will be ignored
+    Email(String),
+    // Custom method
+    #[iden(method = "custom_to_string")]
+    Custom(String),
+}
+
+impl Custom {
+    pub fn custom_to_string(&self) -> &str {
+        match self {
+            Self::Custom(custom) => custom,
+            _ => panic!("not Custom::Custom"),
+        }
+    }
+}
+
+fn main() {
+    // custom ends up being default string which is an empty string
+    let expected = ["user", "my_id", "name", "surname", "EMail", ""];
+    Custom::iter()
+        .map(|var| Iden::to_string(&var))
+        .zip(expected)
+        .for_each(|(iden, exp)| assert_eq!(iden, exp))
+}


### PR DESCRIPTION
Add support for `#[iden(method="name")]` and `#[iden(rename = "name")]` with refactoring of path equality and error messages to dedicated types