### PR TITLE
Revamp Value

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        version: [8.0, 5.7, 5.6]
+        version: [8.0, 5.7]
         example: [sqlx_mysql]
     services:
       mysql:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ bytes = { version = "^1", optional = true }
 chrono = { version = "^0", optional = true }
 postgres-types = { version = "^0", optional = true }
 rust_decimal = { version = "^1", optional = true }
+bigdecimal = { version = "^0", optional = true }
 uuid = { version = "^0", optional = true }
 thiserror = { version = "^1" }
 
@@ -55,6 +56,7 @@ postgres = ["bytes", "postgres-types"]
 postgres-chrono = ["with-chrono", "postgres-types/with-chrono-0_4"]
 postgres-json = ["with-json", "postgres-types/with-serde_json-1"]
 postgres-rust_decimal = ["with-rust_decimal", "rust_decimal/db-postgres"]
+postgres-bigdecimal = ["with-bigdecimal"]
 postgres-uuid = ["with-uuid", "postgres-types/with-uuid-0_8"]
 rusqlite = []
 sqlx-mysql = []
@@ -64,6 +66,7 @@ thread-safe = []
 with-chrono = ["chrono"]
 with-json = ["serde_json"]
 with-rust_decimal = ["rust_decimal"]
+with-bigdecimal = ["bigdecimal"]
 with-uuid = ["uuid"]
 
 [[test]]

--- a/examples/cockroach/Cargo.toml
+++ b/examples/cockroach/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 postgres = "^0.19"
 sea-query = { path = "../../", features = ["postgres"] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0.12", features = ["postgres"] }
+# sea-query = { version = "^0", features = ["postgres"] }

--- a/examples/cockroach_json/Cargo.toml
+++ b/examples/cockroach_json/Cargo.toml
@@ -6,7 +6,21 @@ edition = "2018"
 [dependencies]
 chrono = "^0"
 postgres = "^0.19"
-sea-query = { path = "../../", features = ["postgres", "postgres-chrono", "postgres-json", "postgres-uuid"] }
+sea-query = { path = "../../", features = [
+    "postgres",
+    "postgres-chrono",
+    "postgres-json",
+    "postgres-rust_decimal",
+    "postgres-bigdecimal",
+    "postgres-uuid",
+] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0.12", features = ["postgres", "postgres-chrono", "postgres-json"] }
+# sea-query = { version = "^0", features = [
+#     "postgres",
+#     "postgres-chrono",
+#     "postgres-json",
+#     "postgres-rust_decimal",
+#     "postgres-bigdecimal",
+#     "postgres-uuid",
+# ] }
 serde_json = "^1"

--- a/examples/cockroach_json/Cargo.toml
+++ b/examples/cockroach_json/Cargo.toml
@@ -6,21 +6,7 @@ edition = "2018"
 [dependencies]
 chrono = "^0"
 postgres = "^0.19"
-sea-query = { path = "../../", features = [
-    "postgres",
-    "postgres-chrono",
-    "postgres-json",
-    "postgres-rust_decimal",
-    "postgres-bigdecimal",
-    "postgres-uuid",
-] }
+sea-query = { path = "../../", features = ["postgres", "postgres-chrono", "postgres-json", "postgres-uuid"] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0", features = [
-#     "postgres",
-#     "postgres-chrono",
-#     "postgres-json",
-#     "postgres-rust_decimal",
-#     "postgres-bigdecimal",
-#     "postgres-uuid",
-# ] }
+# sea-query = { version = "^0", features = ["postgres", "postgres-chrono", "postgres-json"] }
 serde_json = "^1"

--- a/examples/postgres/Cargo.toml
+++ b/examples/postgres/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 postgres = "^0.19"
 sea-query = { path = "../../", features = ["postgres"] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0.12", features = ["postgres"] }
+# sea-query = { version = "^0", features = ["postgres"] }

--- a/examples/postgres_json/Cargo.toml
+++ b/examples/postgres_json/Cargo.toml
@@ -6,7 +6,21 @@ edition = "2018"
 [dependencies]
 chrono = "^0"
 postgres = "^0.19"
-sea-query = { path = "../../", features = ["postgres", "postgres-chrono", "postgres-json", "postgres-uuid"] }
+sea-query = { path = "../../", features = [
+    "postgres",
+    "postgres-chrono",
+    "postgres-json",
+    "postgres-rust_decimal",
+    "postgres-bigdecimal",
+    "postgres-uuid",
+] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0.12", features = ["postgres", "postgres-chrono", "postgres-json"] }
+# sea-query = { version = "^0", features = [
+#     "postgres",
+#     "postgres-chrono",
+#     "postgres-json",
+#     "postgres-rust_decimal",
+#     "postgres-bigdecimal",
+#     "postgres-uuid",
+# ] }
 serde_json = "^1"

--- a/examples/postgres_json/Cargo.toml
+++ b/examples/postgres_json/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2018"
 
 [dependencies]
 chrono = "^0"
+uuid = { version = "^0", features = ["serde", "v4"] }
+serde_json = "^1"
 postgres = "^0.19"
 sea-query = { path = "../../", features = [
     "postgres",
@@ -23,4 +25,3 @@ sea-query = { path = "../../", features = [
 #     "postgres-bigdecimal",
 #     "postgres-uuid",
 # ] }
-serde_json = "^1"

--- a/examples/postgres_json/Cargo.toml
+++ b/examples/postgres_json/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 chrono = "^0"
 uuid = { version = "^0", features = ["serde", "v4"] }
 serde_json = "^1"
+rust_decimal = { version = "^1" }
 postgres = "^0.19"
 sea-query = { path = "../../", features = [
     "postgres",
     "postgres-chrono",
     "postgres-json",
     "postgres-rust_decimal",
-    "postgres-bigdecimal",
     "postgres-uuid",
 ] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
@@ -22,6 +22,5 @@ sea-query = { path = "../../", features = [
 #     "postgres-chrono",
 #     "postgres-json",
 #     "postgres-rust_decimal",
-#     "postgres-bigdecimal",
 #     "postgres-uuid",
 # ] }

--- a/examples/postgres_json/src/main.rs
+++ b/examples/postgres_json/src/main.rs
@@ -67,6 +67,7 @@ fn main() {
             serde_json::to_value(document.json_field).unwrap().into(),
             document.timestamp.into(),
             document.timestamp_with_time_zone.into(),
+            document.decimal.into(),
         ])
         .build(PostgresQueryBuilder);
 

--- a/examples/postgres_json/src/main.rs
+++ b/examples/postgres_json/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
             .col(ColumnDef::new(Document::JsonField).json_binary())
             .col(ColumnDef::new(Document::Timestamp).timestamp())
             .col(ColumnDef::new(Document::TimestampWithTimeZone).timestamp_with_time_zone())
+            .col(ColumnDef::new(Document::Decimal).decimal())
             .build(PostgresQueryBuilder),
     ]
     .join("; ");

--- a/examples/postgres_json/src/main.rs
+++ b/examples/postgres_json/src/main.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime};
 use postgres::{Client, NoTls, Row};
+use rust_decimal::Decimal;
 use sea_query::{ColumnDef, Iden, Order, PostgresDriver, PostgresQueryBuilder, Query, Table};
 use uuid::Uuid;
 
@@ -50,6 +51,7 @@ fn main() {
         timestamp: NaiveDate::from_ymd(2020, 1, 1).and_hms(2, 2, 2),
         timestamp_with_time_zone: DateTime::parse_from_rfc3339("2020-01-01T02:02:02+08:00")
             .unwrap(),
+        decimal: Decimal::from_i128_with_scale(3141i128, 3),
     };
     let (sql, values) = Query::insert()
         .into_table(Document::Table)
@@ -58,6 +60,7 @@ fn main() {
             Document::JsonField,
             Document::Timestamp,
             Document::TimestampWithTimeZone,
+            Document::Decimal,
         ])
         .values_panic(vec![
             document.uuid.into(),
@@ -79,6 +82,7 @@ fn main() {
             Document::JsonField,
             Document::Timestamp,
             Document::TimestampWithTimeZone,
+            Document::Decimal,
         ])
         .from(Document::Table)
         .order_by(Document::Id, Order::Desc)
@@ -102,6 +106,7 @@ enum Document {
     JsonField,
     Timestamp,
     TimestampWithTimeZone,
+    Decimal,
 }
 
 #[derive(Debug)]
@@ -111,6 +116,7 @@ struct DocumentStruct {
     json_field: serde_json::Value,
     timestamp: NaiveDateTime,
     timestamp_with_time_zone: DateTime<FixedOffset>,
+    decimal: Decimal,
 }
 
 impl From<Row> for DocumentStruct {
@@ -121,6 +127,7 @@ impl From<Row> for DocumentStruct {
             json_field: row.get("json_field"),
             timestamp: row.get("timestamp"),
             timestamp_with_time_zone: row.get("timestamp_with_time_zone"),
+            decimal: row.get("decimal"),
         }
     }
 }

--- a/examples/postgres_json/src/main.rs
+++ b/examples/postgres_json/src/main.rs
@@ -54,6 +54,7 @@ fn main() {
     let (sql, values) = Query::insert()
         .into_table(Document::Table)
         .columns(vec![
+            Document::Uuid,
             Document::JsonField,
             Document::Timestamp,
             Document::TimestampWithTimeZone,

--- a/examples/rusqlite/Cargo.toml
+++ b/examples/rusqlite/Cargo.toml
@@ -4,10 +4,28 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-sea-query = { path = "../../", features = ["rusqlite"] }
+chrono = { version = "^0" }
+serde_json = { version = "^1" }
+uuid = { version = "^0", features = ["serde", "v4"] }
+sea-query = { path = "../../", features = [
+    "rusqlite",
+    "with-chrono",
+    "with-json",
+    "with-uuid",
+] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0", features = ["rusqlite"] }
+# sea-query = { version = "^0", features = [
+#     "rusqlite",
+#     "with-chrono",
+#     "with-json",
+#     "with-uuid",
+# ] }
 
 [dependencies.rusqlite]
 version = "^0.25"
-features = ["bundled"]
+features = [
+    "bundled",
+    "chrono",
+    "serde_json",
+    "uuid",
+]

--- a/examples/rusqlite/Cargo.toml
+++ b/examples/rusqlite/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 sea-query = { path = "../../", features = ["rusqlite"] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0.12", features = ["rusqlite"] }
+# sea-query = { version = "^0", features = ["rusqlite"] }
 
 [dependencies.rusqlite]
 version = "^0.25"

--- a/examples/rusqlite/src/main.rs
+++ b/examples/rusqlite/src/main.rs
@@ -4,8 +4,8 @@ use sea_query::{ColumnDef, Expr, Func, Iden, Order, Query, SqliteQueryBuilder, T
 
 sea_query::sea_query_driver_rusqlite!();
 use sea_query_driver_rusqlite::RusqliteValues;
+use serde_json::{json, Value as Json};
 use uuid::Uuid;
-use serde_json::{Value as Json, json};
 
 fn main() -> Result<()> {
     let conn = Connection::open_in_memory()?;
@@ -57,7 +57,8 @@ fn main() -> Result<()> {
             "A".into(),
             json!({
                 "notes": "some notes here",
-            }).into(),
+            })
+            .into(),
             NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
         ])
         .build(SqliteQueryBuilder);

--- a/examples/sqlx_mysql/Cargo.toml
+++ b/examples/sqlx_mysql/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+chrono = "^0"
+uuid = { version = "^0", features = ["serde", "v4"] }
+serde_json = "^1"
+rust_decimal = { version = "^1" }
+bigdecimal = { version = "^0" }
 async-std = { version = "1.8", features = [ "attributes" ] }
 sea-query = { path = "../../", features = [
     "sqlx-mysql",
@@ -34,4 +39,9 @@ features = [
     "macros",
     "mysql",
     "tls",
+    "chrono",
+    "json",
+    "decimal",
+    "bigdecimal",
+    "uuid",
 ]

--- a/examples/sqlx_mysql/Cargo.toml
+++ b/examples/sqlx_mysql/Cargo.toml
@@ -5,9 +5,23 @@ edition = "2018"
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes" ] }
-sea-query = { path = "../../", features = ["sqlx-mysql"] }
+sea-query = { path = "../../", features = [
+    "sqlx-mysql",
+    "with-chrono",
+    "with-json",
+    "with-rust_decimal",
+    "with-bigdecimal",
+    "with-uuid",
+] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0.12", features = ["sqlx-mysql"] }
+# sea-query = { version = "^0", features = [
+#     "sqlx-mysql",
+#     "with-chrono",
+#     "with-json",
+#     "with-rust_decimal",
+#     "with-bigdecimal",
+#     "with-uuid",
+# ] }
 
 # To fix sqlx on unstable Rust:
 # lexical-core = { version = "0.7.5" }

--- a/examples/sqlx_mysql/src/main.rs
+++ b/examples/sqlx_mysql/src/main.rs
@@ -2,12 +2,12 @@ use bigdecimal::{BigDecimal, FromPrimitive};
 use chrono::NaiveDate;
 use rust_decimal::Decimal;
 use sea_query::{ColumnDef, Expr, Func, Iden, MysqlQueryBuilder, Order, Query, Table};
-use sqlx::{MySqlPool, Row, types::chrono::NaiveDateTime};
+use sqlx::{types::chrono::NaiveDateTime, MySqlPool, Row};
 
 sea_query::sea_query_driver_mysql!();
 use sea_query_driver_mysql::{bind_query, bind_query_as};
+use serde_json::{json, Value as Json};
 use uuid::Uuid;
-use serde_json::{Value as Json, json};
 
 #[async_std::main]
 async fn main() {
@@ -59,9 +59,13 @@ async fn main() {
             "A".into(),
             json!({
                 "notes": "some notes here",
-            }).into(),
+            })
+            .into(),
             Decimal::from_i128_with_scale(3141i128, 3).into(),
-            BigDecimal::from_i128(3141i128).unwrap().with_scale(3).into(),
+            BigDecimal::from_i128(3141i128)
+                .unwrap()
+                .with_scale(3)
+                .into(),
             NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
         ])
         .build(MysqlQueryBuilder);

--- a/examples/sqlx_mysql/src/main.rs
+++ b/examples/sqlx_mysql/src/main.rs
@@ -1,8 +1,13 @@
+use bigdecimal::{BigDecimal, FromPrimitive};
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
 use sea_query::{ColumnDef, Expr, Func, Iden, MysqlQueryBuilder, Order, Query, Table};
-use sqlx::{MySqlPool, Row};
+use sqlx::{MySqlPool, Row, types::chrono::NaiveDateTime};
 
 sea_query::sea_query_driver_mysql!();
 use sea_query_driver_mysql::{bind_query, bind_query_as};
+use uuid::Uuid;
+use serde_json::{Value as Json, json};
 
 #[async_std::main]
 async fn main() {
@@ -23,8 +28,13 @@ async fn main() {
                 .auto_increment()
                 .primary_key(),
         )
+        .col(ColumnDef::new(Character::Uuid).uuid())
         .col(ColumnDef::new(Character::FontSize).integer())
         .col(ColumnDef::new(Character::Character).string())
+        .col(ColumnDef::new(Character::Meta).json())
+        .col(ColumnDef::new(Character::Decimal).decimal())
+        .col(ColumnDef::new(Character::BigDecimal).decimal())
+        .col(ColumnDef::new(Character::Created).date_time())
         .build(MysqlQueryBuilder);
 
     let result = sqlx::query(&sql).execute(&mut pool).await;
@@ -34,8 +44,26 @@ async fn main() {
 
     let (sql, values) = Query::insert()
         .into_table(Character::Table)
-        .columns(vec![Character::Character, Character::FontSize])
-        .values_panic(vec!["A".into(), 12.into()])
+        .columns(vec![
+            Character::Uuid,
+            Character::FontSize,
+            Character::Character,
+            Character::Meta,
+            Character::Decimal,
+            Character::BigDecimal,
+            Character::Created,
+        ])
+        .values_panic(vec![
+            Uuid::new_v4().into(),
+            12.into(),
+            "A".into(),
+            json!({
+                "notes": "some notes here",
+            }).into(),
+            Decimal::from_i128_with_scale(3141i128, 3).into(),
+            BigDecimal::from_i128(3141i128).unwrap().with_scale(3).into(),
+            NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
+        ])
         .build(MysqlQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values)
@@ -49,8 +77,13 @@ async fn main() {
     let (sql, values) = Query::select()
         .columns(vec![
             Character::Id,
+            Character::Uuid,
             Character::Character,
             Character::FontSize,
+            Character::Meta,
+            Character::Decimal,
+            Character::BigDecimal,
+            Character::Created,
         ])
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
@@ -85,8 +118,13 @@ async fn main() {
     let (sql, values) = Query::select()
         .columns(vec![
             Character::Id,
+            Character::Uuid,
             Character::Character,
             Character::FontSize,
+            Character::Meta,
+            Character::Decimal,
+            Character::BigDecimal,
+            Character::Created,
         ])
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
@@ -136,13 +174,23 @@ async fn main() {
 enum Character {
     Table,
     Id,
+    Uuid,
     Character,
     FontSize,
+    Meta,
+    Decimal,
+    BigDecimal,
+    Created,
 }
 
 #[derive(sqlx::FromRow, Debug)]
 struct CharacterStruct {
     id: i32,
+    uuid: Uuid,
     character: String,
     font_size: i32,
+    meta: Json,
+    decimal: Decimal,
+    big_decimal: BigDecimal,
+    created: NaiveDateTime,
 }

--- a/examples/sqlx_postgres/Cargo.toml
+++ b/examples/sqlx_postgres/Cargo.toml
@@ -5,9 +5,23 @@ edition = "2018"
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes" ] }
-sea-query = { path = "../../", features = ["sqlx-postgres"] }
+sea-query = { path = "../../", features = [
+    "sqlx-postgres",
+    "with-chrono",
+    "with-json",
+    "with-rust_decimal",
+    "with-bigdecimal",
+    "with-uuid",
+] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0.12", features = ["sqlx-postgres"] }
+# sea-query = { version = "^0", features = [
+#     "sqlx-postgres",
+#     "with-chrono",
+#     "with-json",
+#     "with-rust_decimal",
+#     "with-bigdecimal",
+#     "with-uuid",
+# ] }
 
 [dependencies.sqlx]
 version = "^0.5"

--- a/examples/sqlx_postgres/Cargo.toml
+++ b/examples/sqlx_postgres/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+chrono = "^0"
+uuid = { version = "^0", features = ["serde", "v4"] }
+serde_json = "^1"
+rust_decimal = { version = "^1" }
+bigdecimal = { version = "^0" }
 async-std = { version = "1.8", features = [ "attributes" ] }
 sea-query = { path = "../../", features = [
     "sqlx-postgres",
@@ -31,4 +36,9 @@ features = [
     "macros",
     "postgres",
     "tls",
+    "chrono",
+    "json",
+    "decimal",
+    "bigdecimal",
+    "uuid",
 ]

--- a/examples/sqlx_postgres/src/main.rs
+++ b/examples/sqlx_postgres/src/main.rs
@@ -6,8 +6,8 @@ use sqlx::{PgPool, Row};
 
 sea_query::sea_query_driver_postgres!();
 use sea_query_driver_postgres::{bind_query, bind_query_as};
+use serde_json::{json, Value as Json};
 use uuid::Uuid;
-use serde_json::{Value as Json, json};
 
 #[async_std::main]
 async fn main() {
@@ -59,9 +59,13 @@ async fn main() {
             "A".into(),
             json!({
                 "notes": "some notes here",
-            }).into(),
+            })
+            .into(),
             Decimal::from_i128_with_scale(3141i128, 3).into(),
-            BigDecimal::from_i128(3141i128).unwrap().with_scale(3).into(),
+            BigDecimal::from_i128(3141i128)
+                .unwrap()
+                .with_scale(3)
+                .into(),
             NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
         ])
         .returning_col(Character::Id)

--- a/examples/sqlx_sqlite/Cargo.toml
+++ b/examples/sqlx_sqlite/Cargo.toml
@@ -5,9 +5,23 @@ edition = "2018"
 
 [dependencies]
 async-std = { version = "1.8", features = [ "attributes" ] }
-sea-query = { path = "../../", features = ["sqlx-sqlite"] }
+sea-query = { path = "../../", features = [
+    "sqlx-sqlite",
+    "with-chrono",
+    "with-json",
+    "with-rust_decimal",
+    "with-bigdecimal",
+    "with-uuid",
+] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0.11", features = ["sqlx-sqlite"] }
+# sea-query = { version = "^0", features = [
+#     "sqlx-sqlite",
+#     "with-chrono",
+#     "with-json",
+#     "with-rust_decimal",
+#     "with-bigdecimal",
+#     "with-uuid",
+# ] }
 
 [dependencies.sqlx]
 version = "^0.5"

--- a/examples/sqlx_sqlite/Cargo.toml
+++ b/examples/sqlx_sqlite/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+chrono = "^0"
+uuid = { version = "^0", features = ["serde", "v4"] }
+serde_json = "^1"
 async-std = { version = "1.8", features = [ "attributes" ] }
 sea-query = { path = "../../", features = [
     "sqlx-sqlite",
     "with-chrono",
     "with-json",
-    "with-rust_decimal",
-    "with-bigdecimal",
     "with-uuid",
 ] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
@@ -18,8 +19,6 @@ sea-query = { path = "../../", features = [
 #     "sqlx-sqlite",
 #     "with-chrono",
 #     "with-json",
-#     "with-rust_decimal",
-#     "with-bigdecimal",
 #     "with-uuid",
 # ] }
 
@@ -30,4 +29,7 @@ features = [
     "runtime-async-std-native-tls",
     "macros",
     "sqlite",
+    "chrono",
+    "json",
+    "uuid",
 ]

--- a/examples/sqlx_sqlite/src/main.rs
+++ b/examples/sqlx_sqlite/src/main.rs
@@ -4,8 +4,8 @@ use sqlx::{Row, SqlitePool};
 
 sea_query::sea_query_driver_sqlite!();
 use sea_query_driver_sqlite::{bind_query, bind_query_as};
+use serde_json::{json, Value as Json};
 use uuid::Uuid;
-use serde_json::{Value as Json, json};
 
 #[async_std::main]
 async fn main() {
@@ -48,7 +48,8 @@ async fn main() {
             "A".into(),
             json!({
                 "notes": "some notes here",
-            }).into(),
+            })
+            .into(),
             NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
         ])
         .build(SqliteQueryBuilder);

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -38,7 +38,12 @@ impl QueryBuilder for PostgresQueryBuilder {
         write!(buffer, "{}", string).unwrap()
     }
 
-    fn prepare_bin_oper(&self, bin_oper: &BinOper, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value)) {
+    fn prepare_bin_oper(
+        &self,
+        bin_oper: &BinOper,
+        sql: &mut SqlWriter,
+        collector: &mut dyn FnMut(Value),
+    ) {
         match bin_oper {
             BinOper::Matches => write!(sql, "{}", "@@").unwrap(),
             BinOper::Contains => write!(sql, "{}", "@>").unwrap(),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -648,11 +648,17 @@ pub trait QueryBuilder: QuotedBuilder {
             #[cfg(feature = "with-json")]
             Value::Json(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
+            Value::Date(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::Time(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
             Value::DateTime(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::DateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-bigdecimal")]
+            Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(None) => write!(s, "NULL").unwrap(),
             Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
@@ -676,6 +682,10 @@ pub trait QueryBuilder: QuotedBuilder {
             #[cfg(feature = "with-json")]
             Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), &mut s),
             #[cfg(feature = "with-chrono")]
+            Value::Date(Some(v)) => write!(s, "\'{}\'", v.format("%Y-%m-%d").to_string()).unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::Time(Some(v)) => write!(s, "\'{}\'", v.format("%H:%M:%S").to_string()).unwrap(),
+            #[cfg(feature = "with-chrono")]
             Value::DateTime(Some(v)) => {
                 write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S").to_string()).unwrap()
             }
@@ -685,6 +695,8 @@ pub trait QueryBuilder: QuotedBuilder {
             }
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(Some(v)) => write!(s, "{}", v).unwrap(),
+            #[cfg(feature = "with-bigdecimal")]
+            Value::BigDecimal(Some(v)) => write!(s, "{}", v).unwrap(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(Some(v)) => write!(s, "\'{}\'", v.to_string()).unwrap(),
         };

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -632,39 +632,61 @@ pub trait QueryBuilder: QuotedBuilder {
     fn value_to_string(&self, v: &Value) -> String {
         let mut s = String::new();
         match v {
-            Value::Null => write!(s, "NULL").unwrap(),
-            Value::Bool(b) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
-            Value::TinyInt(v) => write!(s, "{}", v).unwrap(),
-            Value::SmallInt(v) => write!(s, "{}", v).unwrap(),
-            Value::Int(v) => write!(s, "{}", v).unwrap(),
-            Value::BigInt(v) => write!(s, "{}", v).unwrap(),
-            Value::TinyUnsigned(v) => write!(s, "{}", v).unwrap(),
-            Value::SmallUnsigned(v) => write!(s, "{}", v).unwrap(),
-            Value::Unsigned(v) => write!(s, "{}", v).unwrap(),
-            Value::BigUnsigned(v) => write!(s, "{}", v).unwrap(),
-            Value::Float(v) => write!(s, "{}", v).unwrap(),
-            Value::Double(v) => write!(s, "{}", v).unwrap(),
-            Value::String(v) => self.write_string_quoted(v, &mut s),
-            Value::Bytes(v) => write!(
+            Value::Bool(None)
+            | Value::TinyInt(None)
+            | Value::SmallInt(None)
+            | Value::Int(None)
+            | Value::BigInt(None)
+            | Value::TinyUnsigned(None)
+            | Value::SmallUnsigned(None)
+            | Value::Unsigned(None)
+            | Value::BigUnsigned(None)
+            | Value::Float(None)
+            | Value::Double(None)
+            | Value::String(None)
+            | Value::Bytes(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-json")]
+            Value::Json(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::DateTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::DateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-rust_decimal")]
+            Value::Decimal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-uuid")]
+            Value::Uuid(None) => write!(s, "NULL").unwrap(),
+            Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
+            Value::TinyInt(Some(v)) => write!(s, "{}", v).unwrap(),
+            Value::SmallInt(Some(v)) => write!(s, "{}", v).unwrap(),
+            Value::Int(Some(v)) => write!(s, "{}", v).unwrap(),
+            Value::BigInt(Some(v)) => write!(s, "{}", v).unwrap(),
+            Value::TinyUnsigned(Some(v)) => write!(s, "{}", v).unwrap(),
+            Value::SmallUnsigned(Some(v)) => write!(s, "{}", v).unwrap(),
+            Value::Unsigned(Some(v)) => write!(s, "{}", v).unwrap(),
+            Value::BigUnsigned(Some(v)) => write!(s, "{}", v).unwrap(),
+            Value::Float(Some(v)) => write!(s, "{}", v).unwrap(),
+            Value::Double(Some(v)) => write!(s, "{}", v).unwrap(),
+            Value::String(Some(v)) => self.write_string_quoted(v, &mut s),
+            Value::Bytes(Some(v)) => write!(
                 s,
                 "x\'{}\'",
                 v.iter().map(|b| format!("{:02X}", b)).collect::<String>()
             )
             .unwrap(),
             #[cfg(feature = "with-json")]
-            Value::Json(v) => self.write_string_quoted(&v.to_string(), &mut s),
+            Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), &mut s),
             #[cfg(feature = "with-chrono")]
-            Value::DateTime(v) => {
+            Value::DateTime(Some(v)) => {
                 write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S").to_string()).unwrap()
             }
             #[cfg(feature = "with-chrono")]
-            Value::DateTimeWithTimeZone(v) => {
+            Value::DateTimeWithTimeZone(Some(v)) => {
                 write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S %:z").to_string()).unwrap()
             }
             #[cfg(feature = "with-rust_decimal")]
-            Value::Decimal(v) => write!(s, "{}", v).unwrap(),
+            Value::Decimal(Some(v)) => write!(s, "{}", v).unwrap(),
             #[cfg(feature = "with-uuid")]
-            Value::Uuid(v) => write!(s, "\'{}\'", v.to_string()).unwrap(),
+            Value::Uuid(Some(v)) => write!(s, "\'{}\'", v.to_string()).unwrap(),
         };
         s
     }

--- a/src/driver/postgres.rs
+++ b/src/driver/postgres.rs
@@ -46,11 +46,17 @@ impl ToSql for Value {
             #[cfg(feature = "postgres-json")]
             Value::Json(v) => box_to_sql!(v, serde_json::Value),
             #[cfg(feature = "postgres-chrono")]
+            Value::Date(v) => box_to_sql!(v, chrono::NaiveDate),
+            #[cfg(feature = "postgres-chrono")]
+            Value::Time(v) => box_to_sql!(v, chrono::NaiveTime),
+            #[cfg(feature = "postgres-chrono")]
             Value::DateTime(v) => box_to_sql!(v, chrono::NaiveDateTime),
             #[cfg(feature = "postgres-chrono")]
             Value::DateTimeWithTimeZone(v) => box_to_sql!(v, chrono::DateTime<chrono::FixedOffset>),
             #[cfg(feature = "postgres-rust_decimal")]
             Value::Decimal(v) => box_to_sql!(v, rust_decimal::Decimal),
+            #[cfg(feature = "postgres-bigdecimal")]
+            Value::BigDecimal(v) => unimplemented!("Not supported"),
             #[cfg(feature = "postgres-uuid")]
             Value::Uuid(v) => box_to_sql!(v, uuid::Uuid),
         }

--- a/src/driver/postgres.rs
+++ b/src/driver/postgres.rs
@@ -56,7 +56,7 @@ impl ToSql for Value {
             #[cfg(feature = "postgres-rust_decimal")]
             Value::Decimal(v) => box_to_sql!(v, rust_decimal::Decimal),
             #[cfg(feature = "postgres-bigdecimal")]
-            Value::BigDecimal(v) => unimplemented!("Not supported"),
+            Value::BigDecimal(_) => unimplemented!("Not supported"),
             #[cfg(feature = "postgres-uuid")]
             Value::Uuid(v) => box_to_sql!(v, uuid::Uuid),
         }

--- a/src/driver/rusqlite.rs
+++ b/src/driver/rusqlite.rs
@@ -66,6 +66,8 @@ macro_rules! sea_query_driver_rusqlite {
                                 (*self.0.as_ref_date_time()).to_sql()
                             } else if self.0.is_decimal() {
                                 unimplemented!("Not supported");
+                            } else if self.0.is_big_decimal() {
+                                (*self.0.as_ref_big_decimal()).to_sql()
                             } else if self.0.is_uuid() {
                                 (*self.0.as_ref_uuid()).to_sql()
                             } else {

--- a/src/driver/rusqlite.rs
+++ b/src/driver/rusqlite.rs
@@ -29,21 +29,36 @@ macro_rules! sea_query_driver_rusqlite {
 
             impl ToSql for RusqliteValue {
                 fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+                    macro_rules! to_sql {
+                        ( $v: expr, $ty: ty ) => {
+                            match $v {
+                                Some(v) => v.to_sql(),
+                                None => None::<$ty>.to_sql(),
+                            }
+                        };
+                    }
+                    macro_rules! box_to_sql {
+                        ( $v: expr, $ty: ty ) => {
+                            match $v {
+                                Some(v) => v.as_ref().to_sql(),
+                                None => None::<$ty>.to_sql(),
+                            }
+                        };
+                    }
                     match &self.0 {
-                        Value::Null => None::<bool>.to_sql(),
-                        Value::Bool(v) => v.to_sql(),
-                        Value::TinyInt(v) => v.to_sql(),
-                        Value::SmallInt(v) => v.to_sql(),
-                        Value::Int(v) => v.to_sql(),
-                        Value::BigInt(v) => v.to_sql(),
-                        Value::TinyUnsigned(v) => v.to_sql(),
-                        Value::SmallUnsigned(v) => v.to_sql(),
-                        Value::Unsigned(v) => v.to_sql(),
-                        Value::BigUnsigned(v) => v.to_sql(),
-                        Value::Float(v) => v.to_sql(),
-                        Value::Double(v) => v.to_sql(),
-                        Value::String(v) => v.as_str().to_sql(),
-                        Value::Bytes(v) => v.as_ref().to_sql(),
+                        Value::Bool(v) => to_sql!(v, bool),
+                        Value::TinyInt(v) => to_sql!(v, i8),
+                        Value::SmallInt(v) => to_sql!(v, i16),
+                        Value::Int(v) => to_sql!(v, i32),
+                        Value::BigInt(v) => to_sql!(v, i64),
+                        Value::TinyUnsigned(v) => to_sql!(v, u32),
+                        Value::SmallUnsigned(v) => to_sql!(v, u32),
+                        Value::Unsigned(v) => to_sql!(v, u32),
+                        Value::BigUnsigned(v) => to_sql!(v, i64),
+                        Value::Float(v) => to_sql!(v, f32),
+                        Value::Double(v) => to_sql!(v, f64),
+                        Value::String(v) => box_to_sql!(v, String),
+                        Value::Bytes(v) => box_to_sql!(v, Vec<u8>),
                         _ => {
                             if self.0.is_json() {
                                 (*self.0.as_ref_json()).to_sql()

--- a/src/driver/rusqlite.rs
+++ b/src/driver/rusqlite.rs
@@ -62,12 +62,14 @@ macro_rules! sea_query_driver_rusqlite {
                         _ => {
                             if self.0.is_json() {
                                 (*self.0.as_ref_json()).to_sql()
+                            } else if self.0.is_date() {
+                                (*self.0.as_ref_date()).to_sql()
+                            } else if self.0.is_time() {
+                                (*self.0.as_ref_time()).to_sql()
                             } else if self.0.is_date_time() {
                                 (*self.0.as_ref_date_time()).to_sql()
-                            } else if self.0.is_decimal() {
-                                unimplemented!("Not supported");
-                            } else if self.0.is_big_decimal() {
-                                (*self.0.as_ref_big_decimal()).to_sql()
+                            } else if self.0.is_date_time_with_time_zone() {
+                                (*self.0.as_ref_date_time_with_time_zone()).to_sql()
                             } else if self.0.is_uuid() {
                                 (*self.0.as_ref_uuid()).to_sql()
                             } else {

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -40,6 +40,8 @@ macro_rules! bind_params_sqlx_mysql {
                         query.bind(value.as_ref_date_time())
                     } else if value.is_decimal() {
                         query.bind(value.as_ref_decimal())
+                    } else if value.is_big_decimal() {
+                        query.bind(value.as_ref_big_decimal())
                     } else if value.is_uuid() {
                         query.bind(value.as_ref_uuid())
                     } else {

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -36,6 +36,10 @@ macro_rules! bind_params_sqlx_mysql {
                 _ => {
                     if value.is_json() {
                         query.bind(value.as_ref_json())
+                    } else if value.is_date() {
+                        query.bind(value.as_ref_date())
+                    } else if value.is_time() {
+                        query.bind(value.as_ref_time())
                     } else if value.is_date_time() {
                         query.bind(value.as_ref_date_time())
                     } else if value.is_decimal() {

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -42,6 +42,8 @@ macro_rules! bind_params_sqlx_postgres {
                         query.bind(value.as_ref_date_time_with_time_zone())
                     } else if value.is_decimal() {
                         query.bind(value.as_ref_decimal())
+                    } else if value.is_big_decimal() {
+                        query.bind(value.as_ref_big_decimal())
                     } else if value.is_uuid() {
                         query.bind(value.as_ref_uuid())
                     } else {

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -3,21 +3,36 @@ macro_rules! bind_params_sqlx_postgres {
     ( $query:expr, $params:expr ) => {{
         let mut query = $query;
         for value in $params.iter() {
+            macro_rules! bind {
+                ( $v: expr, $ty: ty ) => {
+                    match $v {
+                        Some(v) => query.bind((*v as $ty)),
+                        None => query.bind(None::<$ty>),
+                    }
+                };
+            }
+            macro_rules! bind_box {
+                ( $v: expr, $ty: ty ) => {
+                    match $v {
+                        Some(v) => query.bind(v.as_ref()),
+                        None => query.bind(None::<$ty>),
+                    }
+                };
+            }
             query = match value {
-                Value::Null => query.bind(None::<bool>),
-                Value::Bool(v) => query.bind(v),
-                Value::TinyInt(v) => query.bind(v),
-                Value::SmallInt(v) => query.bind(v),
-                Value::Int(v) => query.bind(v),
-                Value::BigInt(v) => query.bind(v),
-                Value::TinyUnsigned(v) => query.bind(*v as u32),
-                Value::SmallUnsigned(v) => query.bind(*v as u32),
-                Value::Unsigned(v) => query.bind(v),
-                Value::BigUnsigned(v) => query.bind(*v as i64),
-                Value::Float(v) => query.bind(v),
-                Value::Double(v) => query.bind(v),
-                Value::String(v) => query.bind(v.as_str()),
-                Value::Bytes(v) => query.bind(v.as_ref()),
+                Value::Bool(v) => bind!(v, bool),
+                Value::TinyInt(v) => bind!(v, i8),
+                Value::SmallInt(v) => bind!(v, i16),
+                Value::Int(v) => bind!(v, i32),
+                Value::BigInt(v) => bind!(v, i64),
+                Value::TinyUnsigned(v) => bind!(v, u32),
+                Value::SmallUnsigned(v) => bind!(v, u32),
+                Value::Unsigned(v) => bind!(v, u32),
+                Value::BigUnsigned(v) => bind!(v, i64),
+                Value::Float(v) => bind!(v, f32),
+                Value::Double(v) => bind!(v, f64),
+                Value::String(v) => bind_box!(v, String),
+                Value::Bytes(v) => bind_box!(v, Vec<u8>),
                 _ => {
                     if value.is_json() {
                         query.bind(value.as_ref_json())

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -36,10 +36,12 @@ macro_rules! bind_params_sqlx_postgres {
                 _ => {
                     if value.is_json() {
                         query.bind(value.as_ref_json())
+                    } else if value.is_date() {
+                        query.bind(value.as_ref_date())
+                    } else if value.is_time() {
+                        query.bind(value.as_ref_time())
                     } else if value.is_date_time() {
                         query.bind(value.as_ref_date_time())
-                    } else if value.is_date_time_with_time_zone() {
-                        query.bind(value.as_ref_date_time_with_time_zone())
                     } else if value.is_decimal() {
                         query.bind(value.as_ref_decimal())
                     } else if value.is_big_decimal() {

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -40,6 +40,8 @@ macro_rules! bind_params_sqlx_sqlite {
                         query.bind(value.as_ref_date_time())
                     } else if value.is_decimal() {
                         query.bind(value.decimal_to_f64())
+                    } else if value.is_big_decimal() {
+                        query.bind(value.big_decimal_to_f64())
                     } else if value.is_uuid() {
                         query.bind(value.as_ref_uuid())
                     } else {

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -3,21 +3,36 @@ macro_rules! bind_params_sqlx_sqlite {
     ( $query:expr, $params:expr ) => {{
         let mut query = $query;
         for value in $params.iter() {
+            macro_rules! bind {
+                ( $v: expr, $ty: ty ) => {
+                    match $v {
+                        Some(v) => query.bind((*v as $ty)),
+                        None => query.bind(None::<$ty>),
+                    }
+                };
+            }
+            macro_rules! bind_box {
+                ( $v: expr, $ty: ty ) => {
+                    match $v {
+                        Some(v) => query.bind(v.as_ref()),
+                        None => query.bind(None::<$ty>),
+                    }
+                };
+            }
             query = match value {
-                Value::Null => query.bind(None::<bool>),
-                Value::Bool(v) => query.bind(v),
-                Value::TinyInt(v) => query.bind(v),
-                Value::SmallInt(v) => query.bind(v),
-                Value::Int(v) => query.bind(v),
-                Value::BigInt(v) => query.bind(v),
-                Value::TinyUnsigned(v) => query.bind(v),
-                Value::SmallUnsigned(v) => query.bind(v),
-                Value::Unsigned(v) => query.bind(v),
-                Value::BigUnsigned(v) => query.bind(*v as i64),
-                Value::Float(v) => query.bind(v),
-                Value::Double(v) => query.bind(v),
-                Value::String(v) => query.bind(v.as_str()),
-                Value::Bytes(v) => query.bind(v.as_ref()),
+                Value::Bool(v) => bind!(v, bool),
+                Value::TinyInt(v) => bind!(v, i8),
+                Value::SmallInt(v) => bind!(v, i16),
+                Value::Int(v) => bind!(v, i32),
+                Value::BigInt(v) => bind!(v, i64),
+                Value::TinyUnsigned(v) => bind!(v, u32),
+                Value::SmallUnsigned(v) => bind!(v, u32),
+                Value::Unsigned(v) => bind!(v, u32),
+                Value::BigUnsigned(v) => bind!(v, i64),
+                Value::Float(v) => bind!(v, f32),
+                Value::Double(v) => bind!(v, f64),
+                Value::String(v) => bind_box!(v, String),
+                Value::Bytes(v) => bind_box!(v, Vec<u8>),
                 _ => {
                     if value.is_json() {
                         query.bind(value.as_ref_json())

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -36,12 +36,12 @@ macro_rules! bind_params_sqlx_sqlite {
                 _ => {
                     if value.is_json() {
                         query.bind(value.as_ref_json())
+                    } else if value.is_date() {
+                        query.bind(value.as_ref_date())
+                    } else if value.is_time() {
+                        query.bind(value.as_ref_time())
                     } else if value.is_date_time() {
                         query.bind(value.as_ref_date_time())
-                    } else if value.is_decimal() {
-                        query.bind(value.decimal_to_f64())
-                    } else if value.is_big_decimal() {
-                        query.bind(value.big_decimal_to_f64())
                     } else if value.is_uuid() {
                         query.bind(value.as_ref_uuid())
                     } else {

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -42,6 +42,10 @@ macro_rules! bind_params_sqlx_sqlite {
                         query.bind(value.as_ref_time())
                     } else if value.is_date_time() {
                         query.bind(value.as_ref_date_time())
+                    } else if value.is_decimal() {
+                        query.bind(value.decimal_to_f64())
+                    } else if value.is_big_decimal() {
+                        query.bind(value.big_decimal_to_f64())
                     } else if value.is_uuid() {
                         query.bind(value.as_ref_uuid())
                     } else {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -834,14 +834,14 @@ impl Expr {
     pub fn like(self, v: &str) -> SimpleExpr {
         self.bin_oper(
             BinOper::Like,
-            SimpleExpr::Value(Value::String(Box::new(v.to_owned()))),
+            SimpleExpr::Value(Value::String(Some(Box::new(v.to_owned())))),
         )
     }
 
     pub fn not_like(self, v: &str) -> SimpleExpr {
         self.bin_oper(
             BinOper::NotLike,
-            SimpleExpr::Value(Value::String(Box::new(v.to_owned()))),
+            SimpleExpr::Value(Value::String(Some(Box::new(v.to_owned())))),
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 //!         .and_where(Expr::col(Glyph::Id).is_in(vec![1, 2, 3]))
 //!         .build(PostgresQueryBuilder),
 //!     (r#"SELECT "image" FROM "glyph" WHERE "image" LIKE $1 AND "id" IN ($2, $3, $4)"#.to_owned(),
-//!      Values(vec![Value::String(Box::new("A".to_owned())), Value::Int(1), Value::Int(2), Value::Int(3)]))
+//!      Values(vec![Value::String(Some(Box::new("A".to_owned()))), Value::Int(Some(1)), Value::Int(Some(2)), Value::Int(Some(3))]))
 //! );
 //! ```
 //!
@@ -405,7 +405,7 @@
 //!     .col(ColumnDef::new(Char::Character).string().not_null())
 //!     .col(ColumnDef::new(Char::SizeW).integer().not_null())
 //!     .col(ColumnDef::new(Char::SizeH).integer().not_null())
-//!     .col(ColumnDef::new(Char::FontId).integer().default(Value::Null))
+//!     .col(ColumnDef::new(Char::FontId).integer().default(Value::Int(None)))
 //!     .foreign_key(
 //!         ForeignKey::create()
 //!             .name("FK_2e303c3a712662f1fc2a4d0aad6")

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -94,7 +94,7 @@ impl DeleteStatement {
 
     /// Limit number of updated rows.
     pub fn limit(&mut self, limit: u64) -> &mut Self {
-        self.limit = Some(Value::BigUnsigned(limit));
+        self.limit = Some(Value::BigUnsigned(Some(limit)));
         self
     }
 }
@@ -127,7 +127,7 @@ impl QueryStatementBuilder for DeleteStatement {
     /// assert_eq!(
     ///     params,
     ///     vec![
-    ///         Value::Int(1),
+    ///         Value::Int(Some(1)),
     ///     ]
     /// );
     /// ```

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1221,7 +1221,7 @@ impl SelectStatement {
     /// );
     /// ```
     pub fn limit(&mut self, limit: u64) -> &mut Self {
-        self.limit = Some(Value::BigUnsigned(limit));
+        self.limit = Some(Value::BigUnsigned(Some(limit)));
         self
     }
 
@@ -1259,7 +1259,7 @@ impl SelectStatement {
     /// );
     /// ```
     pub fn offset(&mut self, offset: u64) -> &mut Self {
-        self.offset = Some(Value::BigUnsigned(offset));
+        self.offset = Some(Value::BigUnsigned(Some(offset)));
         self
     }
 
@@ -1300,7 +1300,7 @@ impl QueryStatementBuilder for SelectStatement {
     /// );
     /// assert_eq!(
     ///     params,
-    ///     vec![Value::Int(0), Value::Int(2)]
+    ///     vec![Value::Int(Some(0)), Value::Int(Some(2))]
     /// );
     /// ```
     fn build_collect<T: QueryBuilder>(

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -51,7 +51,7 @@ pub trait QueryStatementBuilder {
     /// );
     /// assert_eq!(
     ///     params,
-    ///     Values(vec![Value::Int(0), Value::Int(2)])
+    ///     Values(vec![Value::Int(Some(0)), Value::Int(Some(2))])
     /// );
     /// ```
     fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
@@ -98,7 +98,7 @@ pub trait QueryStatementBuilder {
     /// );
     /// assert_eq!(
     ///     params,
-    ///     vec![Value::Int(0), Value::Int(2)]
+    ///     vec![Value::Int(Some(0)), Value::Int(Some(2))]
     /// );
     /// ```
     fn build_collect<T: QueryBuilder>(

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -18,7 +18,7 @@ use crate::{
 ///     .col(ColumnDef::new(Char::Character).string().not_null())
 ///     .col(ColumnDef::new(Char::SizeW).integer().not_null())
 ///     .col(ColumnDef::new(Char::SizeH).integer().not_null())
-///     .col(ColumnDef::new(Char::FontId).integer().default(Value::Null))
+///     .col(ColumnDef::new(Char::FontId).integer().default(Value::Int(None)))
 ///     .foreign_key(
 ///         ForeignKey::create()
 ///             .name("FK_2e303c3a712662f1fc2a4d0aad6")

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,10 +3,10 @@
 use crate::{expr::*, query::*};
 use std::fmt;
 
-#[cfg(feature = "thread-safe")]
-pub use std::sync::Arc as SeaRc;
 #[cfg(not(feature = "thread-safe"))]
 pub use std::rc::Rc as SeaRc;
+#[cfg(feature = "thread-safe")]
+pub use std::sync::Arc as SeaRc;
 
 macro_rules! iden_trait {
     ($($bounds:ident),*) => {

--- a/src/value.rs
+++ b/src/value.rs
@@ -269,7 +269,21 @@ mod with_chrono {
     use super::*;
     use chrono::{Offset, TimeZone};
 
+    type_to_box_value!(NaiveDate, Date);
+    type_to_box_value!(NaiveTime, Time);
     type_to_box_value!(NaiveDateTime, DateTime);
+
+    impl ValueTypeDefault for NaiveDate {
+        fn default() -> Self {
+            NaiveDate::from_num_days_from_ce(0)
+        }
+    }
+
+    impl ValueTypeDefault for NaiveTime {
+        fn default() -> Self {
+            NaiveTime::from_hms(0, 0, 0)
+        }
+    }
 
     impl ValueTypeDefault for NaiveDateTime {
         fn default() -> Self {

--- a/src/value.rs
+++ b/src/value.rs
@@ -18,37 +18,36 @@ use uuid::Uuid;
 /// Value variants
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value {
-    Null,
-    Bool(bool),
-    TinyInt(i8),
-    SmallInt(i16),
-    Int(i32),
-    BigInt(i64),
-    TinyUnsigned(u8),
-    SmallUnsigned(u16),
-    Unsigned(u32),
-    BigUnsigned(u64),
-    Float(f32),
-    Double(f64),
+    Bool(Option<bool>),
+    TinyInt(Option<i8>),
+    SmallInt(Option<i16>),
+    Int(Option<i32>),
+    BigInt(Option<i64>),
+    TinyUnsigned(Option<u8>),
+    SmallUnsigned(Option<u16>),
+    Unsigned(Option<u32>),
+    BigUnsigned(Option<u64>),
+    Float(Option<f32>),
+    Double(Option<f64>),
     // we want Value to be exactly 1 pointer sized, so anything larger should be boxed
-    String(Box<String>),
+    String(Option<Box<String>>),
     #[allow(clippy::box_vec)]
-    Bytes(Box<Vec<u8>>),
+    Bytes(Option<Box<Vec<u8>>>),
     #[cfg(feature = "with-json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-json")))]
-    Json(Box<Json>),
+    Json(Option<Box<Json>>),
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
-    DateTime(Box<NaiveDateTime>),
+    DateTime(Option<Box<NaiveDateTime>>),
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
-    DateTimeWithTimeZone(Box<DateTime<FixedOffset>>),
+    DateTimeWithTimeZone(Option<Box<DateTime<FixedOffset>>>),
     #[cfg(feature = "with-uuid")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
-    Uuid(Box<Uuid>),
+    Uuid(Option<Box<Uuid>>),
     #[cfg(feature = "with-rust_decimal")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-rust_decimal")))]
-    Decimal(Box<Decimal>),
+    Decimal(Option<Box<Decimal>>),
 }
 
 pub trait ValueType: ValueTypeDefault {
@@ -84,33 +83,24 @@ impl Value {
     }
 }
 
-impl Default for Value {
-    fn default() -> Self {
-        Self::Null
-    }
-}
-
 macro_rules! type_to_value {
     ( $type: ty, $name: ident ) => {
         impl From<$type> for Value {
             fn from(x: $type) -> Value {
-                Value::$name(x)
+                Value::$name(Some(x))
             }
         }
 
         impl From<Option<$type>> for Value {
             fn from(x: Option<$type>) -> Value {
-                match x {
-                    Some(v) => Value::$name(v),
-                    None => Value::Null,
-                }
+                Value::$name(x)
             }
         }
 
         impl ValueType for $type {
             fn unwrap(v: Value) -> Self {
                 match v {
-                    Value::$name(x) => x,
+                    Value::$name(Some(x)) => x,
                     _ => panic!("type error"),
                 }
             }
@@ -120,7 +110,10 @@ macro_rules! type_to_value {
             }
         }
 
-        impl ValueTypeDefault for $type {
+        impl ValueTypeDefault for $type
+        where
+            $type: Default,
+        {
             fn default() -> Self {
                 Default::default()
             }
@@ -129,7 +122,7 @@ macro_rules! type_to_value {
         impl ValueType for Option<$type> {
             fn unwrap(v: Value) -> Self {
                 match v {
-                    Value::$name(x) => Some(x),
+                    Value::$name(x) => x,
                     _ => panic!("type error"),
                 }
             }
@@ -151,15 +144,15 @@ macro_rules! type_to_box_value {
     ( $type: ty, $name: ident ) => {
         impl From<$type> for Value {
             fn from(x: $type) -> Value {
-                Value::$name(Box::new(x))
+                Value::$name(Some(Box::new(x)))
             }
         }
 
         impl From<Option<$type>> for Value {
             fn from(x: Option<$type>) -> Value {
                 match x {
-                    Some(v) => Value::$name(Box::new(v)),
-                    None => Value::Null,
+                    Some(v) => Value::$name(Some(Box::new(v))),
+                    None => Value::$name(None),
                 }
             }
         }
@@ -167,7 +160,7 @@ macro_rules! type_to_box_value {
         impl ValueType for $type {
             fn unwrap(v: Value) -> Self {
                 match v {
-                    Value::$name(x) => *x,
+                    Value::$name(Some(x)) => *x,
                     _ => panic!("type error"),
                 }
             }
@@ -180,7 +173,8 @@ macro_rules! type_to_box_value {
         impl ValueType for Option<$type> {
             fn unwrap(v: Value) -> Self {
                 match v {
-                    Value::$name(x) => Some(*x),
+                    Value::$name(Some(x)) => Some(*x),
+                    Value::$name(None) => None,
                     _ => panic!("type error"),
                 }
             }
@@ -222,14 +216,14 @@ type_to_value!(f64, Double);
 
 impl<'a> From<&'a [u8]> for Value {
     fn from(x: &'a [u8]) -> Value {
-        Value::Bytes(Box::<Vec<u8>>::new(x.into()))
+        Value::Bytes(Some(Box::<Vec<u8>>::new(x.into())))
     }
 }
 
 impl<'a> From<&'a str> for Value {
     fn from(x: &'a str) -> Value {
         let string: String = x.into();
-        Value::String(Box::new(string))
+        Value::String(Some(Box::new(string)))
     }
 }
 
@@ -279,7 +273,7 @@ mod with_chrono {
     {
         fn from(x: DateTime<Tz>) -> Value {
             let v = DateTime::<FixedOffset>::from_utc(x.naive_utc(), x.offset().fix());
-            Value::DateTimeWithTimeZone(Box::new(v))
+            Value::DateTimeWithTimeZone(Some(Box::new(v)))
         }
     }
 
@@ -290,7 +284,7 @@ mod with_chrono {
         fn from(x: Option<DateTime<Tz>>) -> Value {
             match x {
                 Some(v) => From::<DateTime<Tz>>::from(v),
-                None => Value::Null,
+                None => Value::DateTimeWithTimeZone(None),
             }
         }
     }
@@ -298,7 +292,7 @@ mod with_chrono {
     impl ValueType for DateTime<FixedOffset> {
         fn unwrap(v: Value) -> Self {
             match v {
-                Value::DateTimeWithTimeZone(x) => *x,
+                Value::DateTimeWithTimeZone(Some(x)) => *x,
                 _ => panic!("type error"),
             }
         }
@@ -311,7 +305,7 @@ mod with_chrono {
     impl ValueType for Option<DateTime<FixedOffset>> {
         fn unwrap(v: Value) -> Self {
             match v {
-                Value::DateTimeWithTimeZone(x) => Some(*x),
+                Value::DateTimeWithTimeZone(Some(x)) => Some(*x),
                 _ => panic!("type error"),
             }
         }
@@ -350,7 +344,7 @@ impl Value {
     #[cfg(feature = "with-json")]
     pub fn as_ref_json(&self) -> &Json {
         match self {
-            Self::Json(v) => v.as_ref(),
+            Self::Json(Some(v)) => v.as_ref(),
             _ => panic!("not Value::Json"),
         }
     }
@@ -370,7 +364,7 @@ impl Value {
     #[cfg(feature = "with-chrono")]
     pub fn as_ref_date_time(&self) -> &NaiveDateTime {
         match self {
-            Self::DateTime(v) => v.as_ref(),
+            Self::DateTime(Some(v)) => v.as_ref(),
             _ => panic!("not Value::DateTime"),
         }
     }
@@ -390,7 +384,7 @@ impl Value {
     #[cfg(feature = "with-chrono")]
     pub fn as_ref_date_time_with_time_zone(&self) -> &DateTime<FixedOffset> {
         match self {
-            Self::DateTimeWithTimeZone(v) => v.as_ref(),
+            Self::DateTimeWithTimeZone(Some(v)) => v.as_ref(),
             _ => panic!("not Value::DateTimeWithTimeZone"),
         }
     }
@@ -410,7 +404,7 @@ impl Value {
     #[cfg(feature = "with-rust_decimal")]
     pub fn as_ref_decimal(&self) -> &Decimal {
         match self {
-            Self::Decimal(v) => v.as_ref(),
+            Self::Decimal(Some(v)) => v.as_ref(),
             _ => panic!("not Value::Decimal"),
         }
     }
@@ -439,7 +433,7 @@ impl Value {
     #[cfg(feature = "with-uuid")]
     pub fn as_ref_uuid(&self) -> &Uuid {
         match self {
-            Self::Uuid(v) => v.as_ref(),
+            Self::Uuid(Some(v)) => v.as_ref(),
             _ => panic!("not Value::Uuid"),
         }
     }
@@ -536,31 +530,6 @@ pub fn unescape_string(input: &str) -> String {
     output
 }
 
-/// Convert JSON value to Sea Value.
-/// `Json::Array` is not supported and will panic.
-#[cfg(feature = "with-json")]
-#[cfg_attr(docsrs, doc(cfg(feature = "with-json")))]
-pub fn json_value_to_sea_value(v: &Json) -> Value {
-    match v {
-        Json::Null => Value::Null,
-        Json::Bool(v) => Value::Int(v.to_owned().into()),
-        Json::Number(v) => {
-            if v.is_f64() {
-                Value::Double(v.as_f64().unwrap())
-            } else if v.is_i64() {
-                Value::BigInt(v.as_i64().unwrap())
-            } else if v.is_u64() {
-                Value::BigUnsigned(v.as_u64().unwrap())
-            } else {
-                unreachable!()
-            }
-        }
-        Json::String(v) => Value::String(Box::new(v.clone())),
-        Json::Array(_) => panic!("Json::Array is not supported"),
-        Json::Object(v) => Value::Json(Box::new(Json::Object(v.clone()))),
-    }
-}
-
 /// Convert value to json value
 #[allow(clippy::many_single_char_names)]
 #[cfg(feature = "with-json")]
@@ -569,32 +538,49 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
     use crate::{PostgresQueryBuilder, QueryBuilder};
 
     match value {
-        Value::Null => Json::Null,
-        Value::Bool(b) => Json::Bool(*b),
-        Value::TinyInt(v) => (*v).into(),
-        Value::SmallInt(v) => (*v).into(),
-        Value::Int(v) => (*v).into(),
-        Value::BigInt(v) => (*v).into(),
-        Value::TinyUnsigned(v) => (*v).into(),
-        Value::SmallUnsigned(v) => (*v).into(),
-        Value::Unsigned(v) => (*v).into(),
-        Value::BigUnsigned(v) => (*v).into(),
-        Value::Float(v) => (*v).into(),
-        Value::Double(v) => (*v).into(),
-        Value::String(s) => Json::String(s.as_ref().clone()),
-        Value::Bytes(s) => Json::String(from_utf8(s).unwrap().to_string()),
-        Value::Json(v) => v.as_ref().clone(),
+        Value::Bool(None)
+        | Value::TinyInt(None)
+        | Value::SmallInt(None)
+        | Value::Int(None)
+        | Value::BigInt(None)
+        | Value::TinyUnsigned(None)
+        | Value::SmallUnsigned(None)
+        | Value::Unsigned(None)
+        | Value::BigUnsigned(None)
+        | Value::Float(None)
+        | Value::Double(None)
+        | Value::String(None)
+        | Value::Bytes(None)
+        | Value::Json(None) => Json::Null,
+        #[cfg(feature = "with-rust_decimal")]
+        Value::Decimal(None) => Json::Null,
+        #[cfg(feature = "with-uuid")]
+        Value::Uuid(None) => Json::Null,
+        Value::Bool(Some(b)) => Json::Bool(*b),
+        Value::TinyInt(Some(v)) => (*v).into(),
+        Value::SmallInt(Some(v)) => (*v).into(),
+        Value::Int(Some(v)) => (*v).into(),
+        Value::BigInt(Some(v)) => (*v).into(),
+        Value::TinyUnsigned(Some(v)) => (*v).into(),
+        Value::SmallUnsigned(Some(v)) => (*v).into(),
+        Value::Unsigned(Some(v)) => (*v).into(),
+        Value::BigUnsigned(Some(v)) => (*v).into(),
+        Value::Float(Some(v)) => (*v).into(),
+        Value::Double(Some(v)) => (*v).into(),
+        Value::String(Some(s)) => Json::String(s.as_ref().clone()),
+        Value::Bytes(Some(s)) => Json::String(from_utf8(s).unwrap().to_string()),
+        Value::Json(Some(v)) => v.as_ref().clone(),
         #[cfg(feature = "with-chrono")]
         Value::DateTime(_) => PostgresQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::DateTimeWithTimeZone(_) => PostgresQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-rust_decimal")]
-        Value::Decimal(v) => {
+        Value::Decimal(Some(v)) => {
             use rust_decimal::prelude::ToPrimitive;
             v.as_ref().to_f64().unwrap().into()
         }
         #[cfg(feature = "with-uuid")]
-        Value::Uuid(v) => Json::String(v.to_string()),
+        Value::Uuid(Some(v)) => Json::String(v.to_string()),
     }
 }
 
@@ -667,10 +653,10 @@ mod tests {
         }
 
         macro_rules! test_none {
-            ( $type: ty ) => {
+            ( $type: ty, $name: ident ) => {
                 let val: Option<$type> = None;
                 let v: Value = val.into();
-                assert_eq!(v, Value::Null);
+                assert_eq!(v, Value::$name(None));
             };
         }
 
@@ -681,12 +667,12 @@ mod tests {
         test_some_value!(i32, 1073741824);
         test_some_value!(i64, 8589934592);
 
-        test_none!(u8);
-        test_none!(u16);
-        test_none!(i8);
-        test_none!(i16);
-        test_none!(i32);
-        test_none!(i64);
+        test_none!(u8, TinyUnsigned);
+        test_none!(u16, SmallUnsigned);
+        test_none!(i8, TinyInt);
+        test_none!(i16, SmallInt);
+        test_none!(i32, Int);
+        test_none!(i64, BigInt);
     }
 
     #[test]
@@ -699,21 +685,27 @@ mod tests {
 
     #[test]
     fn test_value_tuple() {
-        assert_eq!(1i32.into_value_tuple(), ValueTuple::One(Value::Int(1)));
+        assert_eq!(
+            1i32.into_value_tuple(),
+            ValueTuple::One(Value::Int(Some(1)))
+        );
         assert_eq!(
             "b".into_value_tuple(),
-            ValueTuple::One(Value::String(Box::new("b".to_owned())))
+            ValueTuple::One(Value::String(Some(Box::new("b".to_owned()))))
         );
         assert_eq!(
             (1i32, "b").into_value_tuple(),
-            ValueTuple::Two(Value::Int(1), Value::String(Box::new("b".to_owned())))
+            ValueTuple::Two(
+                Value::Int(Some(1)),
+                Value::String(Some(Box::new("b".to_owned())))
+            )
         );
         assert_eq!(
             (1i32, 2.4f64, "b").into_value_tuple(),
             ValueTuple::Three(
-                Value::Int(1),
-                Value::Double(2.4),
-                Value::String(Box::new("b".to_owned()))
+                Value::Int(Some(1)),
+                Value::Double(Some(2.4)),
+                Value::String(Some(Box::new("b".to_owned())))
             )
         );
     }
@@ -721,20 +713,20 @@ mod tests {
     #[test]
     fn test_value_tuple_iter() {
         let mut iter = (1i32).into_value_tuple().into_iter();
-        assert_eq!(iter.next().unwrap(), Value::Int(1));
+        assert_eq!(iter.next().unwrap(), Value::Int(Some(1)));
         assert_eq!(iter.next(), None);
 
         let mut iter = (1i32, 2.4f64).into_value_tuple().into_iter();
-        assert_eq!(iter.next().unwrap(), Value::Int(1));
-        assert_eq!(iter.next().unwrap(), Value::Double(2.4));
+        assert_eq!(iter.next().unwrap(), Value::Int(Some(1)));
+        assert_eq!(iter.next().unwrap(), Value::Double(Some(2.4)));
         assert_eq!(iter.next(), None);
 
         let mut iter = (1i32, 2.4f64, "b").into_value_tuple().into_iter();
-        assert_eq!(iter.next().unwrap(), Value::Int(1));
-        assert_eq!(iter.next().unwrap(), Value::Double(2.4));
+        assert_eq!(iter.next().unwrap(), Value::Int(Some(1)));
+        assert_eq!(iter.next().unwrap(), Value::Double(Some(2.4)));
         assert_eq!(
             iter.next().unwrap(),
-            Value::String(Box::new("b".to_owned()))
+            Value::String(Some(Box::new("b".to_owned())))
         );
         assert_eq!(iter.next(), None);
     }

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -696,22 +696,6 @@ fn select_43() {
 
 #[test]
 #[allow(clippy::approx_constant)]
-#[cfg(feature = "with-json")]
-fn insert_1() {
-    assert_eq!(
-        Query::insert()
-            .into_table(Glyph::Table)
-            .json(json!({
-                "image": "24B0E11951B03B07F8300FD003983F03F0780060",
-                "aspect": 2.1345,
-            }))
-            .to_string(MysqlQueryBuilder),
-        "INSERT INTO `glyph` (`aspect`, `image`) VALUES (2.1345, '24B0E11951B03B07F8300FD003983F03F0780060')"
-    );
-}
-
-#[test]
-#[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(
         Query::insert()
@@ -744,7 +728,7 @@ fn insert_3() {
                 3.1415.into(),
             ])
             .values_panic(vec![
-                Value::Null,
+                Value::String(None),
                 2.1345.into(),
             ])
             .to_string(MysqlQueryBuilder),
@@ -787,24 +771,6 @@ fn update_1() {
                 (Glyph::Aspect, 2.1345.into()),
                 (Glyph::Image, "24B0E11951B03B07F8300FD003983F03F0780060".into()),
             ])
-            .and_where(Expr::col(Glyph::Id).eq(1))
-            .order_by(Glyph::Id, Order::Asc)
-            .limit(1)
-            .to_string(MysqlQueryBuilder),
-        "UPDATE `glyph` SET `aspect` = 2.1345, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1 ORDER BY `id` ASC LIMIT 1"
-    );
-}
-
-#[test]
-#[cfg(feature = "with-json")]
-fn update_2() {
-    assert_eq!(
-        Query::update()
-            .table(Glyph::Table)
-            .json(json!({
-                "aspect": 2.1345,
-                "image": "24B0E11951B03B07F8300FD003983F03F0780060",
-            }))
             .and_where(Expr::col(Glyph::Id).eq(1))
             .order_by(Glyph::Id, Order::Asc)
             .limit(1)

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -80,7 +80,7 @@ fn create_3() {
             .col(
                 ColumnDef::new(Char::FontId)
                     .integer_len(11)
-                    .default(Value::Null)
+                    .default(Value::Int(None))
             )
             .foreign_key(
                 ForeignKey::create()

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -680,22 +680,6 @@ fn select_43() {
 
 #[test]
 #[allow(clippy::approx_constant)]
-#[cfg(feature = "with-json")]
-fn insert_1() {
-    assert_eq!(
-        Query::insert()
-            .into_table(Glyph::Table)
-            .json(json!({
-                "image": "24B0E11951B03B07F8300FD003983F03F0780060",
-                "aspect": 2.1345,
-            }))
-            .to_string(PostgresQueryBuilder),
-        r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2.1345, '24B0E11951B03B07F8300FD003983F03F0780060')"#
-    );
-}
-
-#[test]
-#[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(
         Query::insert()
@@ -721,7 +705,7 @@ fn insert_3() {
                 "04108048005887010020060000204E0180400400".into(),
                 3.1415.into(),
             ])
-            .values_panic(vec![Value::Null, 2.1345.into(),])
+            .values_panic(vec![Value::String(None), 2.1345.into(),])
             .to_string(PostgresQueryBuilder),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415), (NULL, 2.1345)"#
     );
@@ -765,22 +749,6 @@ fn update_1() {
                     "24B0E11951B03B07F8300FD003983F03F0780060".into()
                 ),
             ])
-            .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(PostgresQueryBuilder),
-        r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1"#
-    );
-}
-
-#[test]
-#[cfg(feature = "with-json")]
-fn update_2() {
-    assert_eq!(
-        Query::update()
-            .table(Glyph::Table)
-            .json(json!({
-                "aspect": 2.1345,
-                "image": "24B0E11951B03B07F8300FD003983F03F0780060",
-            }))
             .and_where(Expr::col(Glyph::Id).eq(1))
             .to_string(PostgresQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1"#

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -71,7 +71,11 @@ fn create_3() {
             .col(ColumnDef::new(Char::Character).string_len(255).not_null())
             .col(ColumnDef::new(Char::SizeW).integer().not_null())
             .col(ColumnDef::new(Char::SizeH).integer().not_null())
-            .col(ColumnDef::new(Char::FontId).integer().default(Value::Null))
+            .col(
+                ColumnDef::new(Char::FontId)
+                    .integer()
+                    .default(Value::Int(None))
+            )
             .foreign_key(
                 ForeignKey::create()
                     .name("FK_2e303c3a712662f1fc2a4d0aad6")

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -696,22 +696,6 @@ fn select_43() {
 
 #[test]
 #[allow(clippy::approx_constant)]
-#[cfg(feature = "with-json")]
-fn insert_1() {
-    assert_eq!(
-        Query::insert()
-            .into_table(Glyph::Table)
-            .json(json!({
-                "image": "24B0E11951B03B07F8300FD003983F03F0780060",
-                "aspect": 2.1345,
-            }))
-            .to_string(SqliteQueryBuilder),
-        "INSERT INTO `glyph` (`aspect`, `image`) VALUES (2.1345, '24B0E11951B03B07F8300FD003983F03F0780060')"
-    );
-}
-
-#[test]
-#[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(
         Query::insert()
@@ -744,7 +728,7 @@ fn insert_3() {
                 3.1415.into(),
             ])
             .values_panic(vec![
-                Value::Null,
+                Value::Double(None),
                 2.1345.into(),
             ])
             .to_string(SqliteQueryBuilder),
@@ -787,22 +771,6 @@ fn update_1() {
                 (Glyph::Aspect, 2.1345.into()),
                 (Glyph::Image, "24B0E11951B03B07F8300FD003983F03F0780060".into()),
             ])
-            .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(SqliteQueryBuilder),
-        "UPDATE `glyph` SET `aspect` = 2.1345, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1"
-    );
-}
-
-#[test]
-#[cfg(feature = "with-json")]
-fn update_2() {
-    assert_eq!(
-        Query::update()
-            .table(Glyph::Table)
-            .json(json!({
-                "aspect": 2.1345,
-                "image": "24B0E11951B03B07F8300FD003983F03F0780060",
-            }))
             .and_where(Expr::col(Glyph::Id).eq(1))
             .to_string(SqliteQueryBuilder),
         "UPDATE `glyph` SET `aspect` = 2.1345, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1"

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -71,7 +71,11 @@ fn create_3() {
             .col(ColumnDef::new(Char::Character).string().not_null())
             .col(ColumnDef::new(Char::SizeW).integer().not_null())
             .col(ColumnDef::new(Char::SizeH).integer().not_null())
-            .col(ColumnDef::new(Char::FontId).integer().default(Value::Null))
+            .col(
+                ColumnDef::new(Char::FontId)
+                    .integer()
+                    .default(Value::Int(None))
+            )
             .foreign_key(
                 ForeignKey::create()
                     .from(Char::Table, Char::FontId)


### PR DESCRIPTION
## The problem

When using a prepared statement, the parameter binding must be of the same type as when prepared. As such, `0i32` is not compatible with `None<bool>`, it has to be `None<i32>`. To mitigate this, we have to remove the generic `Null` variant, and users have to indicate the associated type of the `NULL`. 

## The changes

- Fix Postgres integration tests (SeaQL/sea-orm#91) with typed null value
- Rename and add new enum variants to `Value` for type better mapping #78 

It will be a rather big breaking change, but hopefully users would not have to change a lot of their existing code.
An upgrade guide will be provided afterwards.