### PR TITLE
Introduce Nullable trait to permit custom Option<T>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bytes = { version = "^1", optional = true }
 chrono = { version = "^0", optional = true }
 postgres-types = { version = "^0", optional = true }
 rust_decimal = { version = "^1", optional = true }
-bigdecimal = { version = "^0", optional = true }
+bigdecimal = { version = "^0.2", optional = true }
 uuid = { version = "^0", optional = true }
 thiserror = { version = "^1" }
 

--- a/examples/sqlx_mysql/Cargo.toml
+++ b/examples/sqlx_mysql/Cargo.toml
@@ -8,7 +8,7 @@ chrono = "^0"
 uuid = { version = "^0", features = ["serde", "v4"] }
 serde_json = "^1"
 rust_decimal = { version = "^1" }
-bigdecimal = { version = "^0" }
+bigdecimal = { version = "^0.2" }
 async-std = { version = "1.8", features = [ "attributes" ] }
 sea-query = { path = "../../", features = [
     "sqlx-mysql",

--- a/examples/sqlx_postgres/Cargo.toml
+++ b/examples/sqlx_postgres/Cargo.toml
@@ -8,7 +8,7 @@ chrono = "^0"
 uuid = { version = "^0", features = ["serde", "v4"] }
 serde_json = "^1"
 rust_decimal = { version = "^1" }
-bigdecimal = { version = "^0" }
+bigdecimal = { version = "^0.2" }
 async-std = { version = "1.8", features = [ "attributes" ] }
 sea-query = { path = "../../", features = [
     "sqlx-postgres",

--- a/src/value.rs
+++ b/src/value.rs
@@ -144,25 +144,6 @@ macro_rules! type_to_value {
                 Default::default()
             }
         }
-
-        impl ValueType for Option<$type> {
-            fn unwrap(v: Value) -> Self {
-                match v {
-                    Value::$name(x) => x,
-                    _ => panic!("type error"),
-                }
-            }
-
-            fn type_name() -> &'static str {
-                concat!("Option<", stringify!($type), ">")
-            }
-        }
-
-        impl ValueTypeDefault for Option<$type> {
-            fn default() -> Self {
-                Default::default()
-            }
-        }
     };
 }
 
@@ -190,26 +171,6 @@ macro_rules! type_to_box_value {
 
             fn type_name() -> &'static str {
                 stringify!($type)
-            }
-        }
-
-        impl ValueType for Option<$type> {
-            fn unwrap(v: Value) -> Self {
-                match v {
-                    Value::$name(Some(x)) => Some(*x),
-                    Value::$name(None) => None,
-                    _ => panic!("type error"),
-                }
-            }
-
-            fn type_name() -> &'static str {
-                concat!("Option<", stringify!($type), ">")
-            }
-        }
-
-        impl ValueTypeDefault for Option<$type> {
-            fn default() -> Self {
-                Default::default()
             }
         }
     };
@@ -265,6 +226,28 @@ impl<T: Into<Value> + Nullable> From<Option<T>> for Value {
     }
 }
 
+impl<T: ValueType + Nullable> ValueType for Option<T> {
+    fn unwrap(v: Value) -> Self {
+        if v == T::null() {
+            None
+        }
+        else {
+            Some(v.unwrap())
+        }
+    }
+
+    fn type_name() -> &'static str {
+        //concat!("Option<", T::type_name(), ">")
+        T::type_name()
+    }
+}
+
+impl<T: ValueType + Nullable> ValueTypeDefault for Option<T> {
+    fn default() -> Self {
+        Default::default()
+    }
+}
+
 type_to_box_value!(Vec<u8>, Bytes);
 impl_value_type_default!(Vec<u8>);
 type_to_box_value!(String, String);
@@ -313,12 +296,6 @@ mod with_chrono {
         }
     }
 
-    impl ValueTypeDefault for Option<DateTime<FixedOffset>> {
-        fn default() -> Self {
-            Default::default()
-        }
-    }
-
     impl<Tz> From<DateTime<Tz>> for Value
     where
         Tz: TimeZone,
@@ -345,19 +322,6 @@ mod with_chrono {
 
         fn type_name() -> &'static str {
             stringify!(DateTime<FixedOffset>)
-        }
-    }
-
-    impl ValueType for Option<DateTime<FixedOffset>> {
-        fn unwrap(v: Value) -> Self {
-            match v {
-                Value::DateTimeWithTimeZone(Some(x)) => Some(*x),
-                _ => panic!("type error"),
-            }
-        }
-
-        fn type_name() -> &'static str {
-            stringify!(Option<DateTime<FixedOffset>>)
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -217,7 +217,8 @@ impl<'a> Nullable for &'a str {
     }
 }
 
-impl<T: Into<Value> + Nullable> From<Option<T>> for Value {
+impl<T> From<Option<T>> for Value
+where T: Into<Value> + Nullable {
     fn from(x: Option<T>) -> Value {
         match x {
             Some(v) => v.into(),
@@ -226,7 +227,8 @@ impl<T: Into<Value> + Nullable> From<Option<T>> for Value {
     }
 }
 
-impl<T: ValueType + Nullable> ValueType for Option<T> {
+impl<T> ValueType for Option<T>
+where T: ValueType + Nullable {
     fn unwrap(v: Value) -> Self {
         if v == T::null() {
             None
@@ -242,7 +244,8 @@ impl<T: ValueType + Nullable> ValueType for Option<T> {
     }
 }
 
-impl<T: ValueType + Nullable> ValueTypeDefault for Option<T> {
+impl<T> ValueTypeDefault for Option<T>
+where T: ValueType + Nullable {
     fn default() -> Self {
         Default::default()
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -250,6 +250,12 @@ impl<'a> From<&'a str> for Value {
     }
 }
 
+impl<'a> Nullable for &'a str {
+    fn null() -> Value {
+        Value::String(None)
+    }
+}
+
 impl<T: Into<Value> + Nullable> From<Option<T>> for Value {
     fn from(x: Option<T>) -> Value {
         match x {


### PR DESCRIPTION
As discussed in [Issue 107](https://github.com/SeaQL/sea-orm/issues/107), the introduction of a Nullable trait permits to retrive the correct Value variant for the Null type, therefore to add a generic `impl From<Option<T>> for Value where T: Into<Value> + Nullable`, permitting to use optional custom types inside Models