### PR TITLE
Postgres concatenate operator

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -48,6 +48,7 @@ impl QueryBuilder for PostgresQueryBuilder {
             BinOper::Matches => write!(sql, "@@").unwrap(),
             BinOper::Contains => write!(sql, "@>").unwrap(),
             BinOper::Contained => write!(sql, "<@").unwrap(),
+            BinOper::Concatenate => write!(sql, "||").unwrap(),
             _ => self.prepare_bin_oper_common(bin_oper, sql, collector),
         }
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1373,6 +1373,32 @@ impl Expr {
         self.bin_oper(BinOper::Contained, expr.into())
     }
 
+    /// Express an postgres concatenate (`||`) expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .columns(vec![Font::Name, Font::Variant, Font::Language])
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::val("a").concatenate(Expr::val("b")))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a' || 'b'"#
+    /// );
+    /// ```
+    #[cfg(feature = "backend-postgres")]
+    pub fn concatenate<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.bin_oper(BinOper::Concatenate, expr.into())
+    }
+
     pub(crate) fn func(func: Function) -> Self {
         let mut expr = Expr::new();
         expr.func = Some(func);

--- a/src/types.rs
+++ b/src/types.rs
@@ -118,6 +118,8 @@ pub enum BinOper {
     Contains,
     #[cfg(feature = "backend-postgres")]
     Contained,
+    #[cfg(feature = "backend-postgres")]
+    Concatenate,
 }
 
 /// Logical chain operator


### PR DESCRIPTION
- Adds concatenate operator `||` to binary operators.
- Adds `concatenate` method to `Expr` helper.

The new operator is restricted to feature `backend-postgres`.