### PR TITLE
Initial lock support

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -343,7 +343,7 @@ pub trait QueryBuilder: QuotedBuilder {
         .unwrap();
     }
 
-    /// Translate [`SelectDistinct`] into SQL statement.
+    /// Translate [`LockType`] into SQL statement.
     fn prepare_select_lock(
         &self,
         select_lock: &LockType,

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -121,6 +121,11 @@ pub trait QueryBuilder: QuotedBuilder {
             write!(sql, " OFFSET ").unwrap();
             self.prepare_value(offset, sql, collector);
         }
+
+        if let Some(lock) = &select.lock {
+            write!(sql, " ").unwrap();
+            self.prepare_select_lock(lock, sql, collector);
+        }
     }
 
     /// Translate [`UpdateStatement`] into SQL statement.
@@ -333,6 +338,24 @@ pub trait QueryBuilder: QuotedBuilder {
                 SelectDistinct::All => "ALL",
                 SelectDistinct::Distinct => "DISTINCT",
                 SelectDistinct::DistinctRow => "DISTINCTROW",
+            }
+        )
+        .unwrap();
+    }
+
+    /// Translate [`SelectDistinct`] into SQL statement.
+    fn prepare_select_lock(
+        &self,
+        select_lock: &LockType,
+        sql: &mut SqlWriter,
+        _collector: &mut dyn FnMut(Value),
+    ) {
+        write!(
+            sql,
+            "{}",
+            match select_lock {
+                LockType::Shared => "FOR SHARE",
+                LockType::Exclusive => "FOR UPDATE",
             }
         )
         .unwrap();

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -12,6 +12,6 @@ impl QueryBuilder for SqliteQueryBuilder {
         _sql: &mut SqlWriter,
         _collector: &mut dyn FnMut(Value),
     ) {
-         panic!("Unsupported")
+         // SQLite doesn't supports row locking
     }
 }

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -4,4 +4,14 @@ impl QueryBuilder for SqliteQueryBuilder {
     fn char_length_function(&self) -> &str {
         "LENGTH"
     }
+
+    /// Translate [`LockType`] into SQL statement.
+    fn prepare_select_lock(
+        &self,
+        _select_lock: &LockType,
+        _sql: &mut SqlWriter,
+        _collector: &mut dyn FnMut(Value),
+    ) {
+         panic!("Unsupported")
+    }
 }

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -5,7 +5,6 @@ impl QueryBuilder for SqliteQueryBuilder {
         "LENGTH"
     }
 
-    /// Translate [`LockType`] into SQL statement.
     fn prepare_select_lock(
         &self,
         _select_lock: &LockType,

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1272,19 +1272,97 @@ impl SelectStatement {
         self
     }
 
-    /// Select lock
+    /// Row locking (if supported).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Char::Character)
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::col(Char::FontId).eq(5))
+    ///     .lock(LockType::Exclusive)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 FOR UPDATE"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 FOR UPDATE"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 "#
+    /// );
+    /// ```
     pub fn lock(&mut self, lock_type: LockType) -> &mut Self {
         self.lock = Some(lock_type);
         self
     }
 
-    /// Select lock shared
+    /// Shared row locking (if supported).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Char::Character)
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::col(Char::FontId).eq(5))
+    ///     .lock_shared()
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 FOR SHARE"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 FOR SHARE"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 "#
+    /// );
+    /// ```
     pub fn lock_shared(&mut self) -> &mut Self {
         self.lock = Some(LockType::Shared);
         self
     }
 
-    /// Select lock exclusive
+    /// Exclusive row locking (if supported).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Char::Character)
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::col(Char::FontId).eq(5))
+    ///     .lock_exclusive()
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 FOR UPDATE"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 FOR UPDATE"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 "#
+    /// );
+    /// ```
     pub fn lock_exclusive(&mut self) -> &mut Self {
         self.lock = Some(LockType::Exclusive);
         self

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -50,6 +50,7 @@ pub struct SelectStatement {
     pub(crate) orders: Vec<OrderExpr>,
     pub(crate) limit: Option<Value>,
     pub(crate) offset: Option<Value>,
+    pub(crate) lock: Option<LockType>,
 }
 
 /// List of distinct keywords that can be used in select statement
@@ -104,6 +105,7 @@ impl SelectStatement {
             orders: Vec::new(),
             limit: None,
             offset: None,
+            lock: None,
         }
     }
 
@@ -120,6 +122,7 @@ impl SelectStatement {
             orders: std::mem::take(&mut self.orders),
             limit: self.limit.take(),
             offset: self.offset.take(),
+            lock: self.lock.take(),
         }
     }
 
@@ -1268,6 +1271,24 @@ impl SelectStatement {
         self.offset = None;
         self
     }
+
+    /// Select lock
+    pub fn lock(&mut self, lock_type: LockType) -> &mut Self {
+        self.lock = Some(lock_type);
+        self
+    }
+
+    /// Select lock shared
+    pub fn lock_shared(&mut self) -> &mut Self {
+        self.lock = Some(LockType::Shared);
+        self
+    }
+
+    /// Select lock exclusive
+    pub fn lock_exclusive(&mut self) -> &mut Self {
+        self.lock = Some(LockType::Exclusive);
+        self
+    }
 }
 
 impl QueryStatementBuilder for SelectStatement {
@@ -1344,4 +1365,11 @@ impl ConditionalStatement for SelectStatement {
         self.wherei.add_condition(condition.into_condition());
         self
     }
+}
+
+/// List of lock types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockType {
+    Shared,
+    Exclusive,
 }

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1367,7 +1367,7 @@ impl ConditionalStatement for SelectStatement {
     }
 }
 
-/// List of lock types
+/// List of lock types that can be used in select statement
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LockType {
     Shared,


### PR DESCRIPTION
As discussed in https://github.com/SeaQL/sea-orm/issues/111, this PR adds the basis for row locking support.

As always, I'm open for discussion and improvement