### PR TITLE
cargo fmt doc comments

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+format_code_in_doc_comments=true


### PR DESCRIPTION
We can format all doc comments using the `cargo fmt` on nightly channel (rust-lang/rustfmt#3348)

1. Install nightly channel: `rustup toolchain install nightly`

1. Run cargo fmt nightly: `cargo +nightly fmt --all`