### PR TITLE
Union proposal

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -101,6 +101,16 @@ pub trait QueryBuilder: QuotedBuilder {
 
         self.prepare_condition(&select.having, "HAVING", sql, collector);
 
+        if !select.unions.is_empty() {
+            select.unions.iter().for_each(|(union_type, query)| {
+                match union_type {
+                    UnionType::Distinct => write!(sql, " UNION ").unwrap(),
+                    UnionType::All => write!(sql, " UNION ALL ").unwrap(),
+                }
+                self.prepare_select_statement(query, sql, collector);
+            });
+        }
+
         if !select.orders.is_empty() {
             write!(sql, " ORDER BY ").unwrap();
             select.orders.iter().fold(true, |first, expr| {

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1494,7 +1494,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 UNION ALL SELECT `character` FROM `character` WHERE `font_id` = 4"#
+    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 UNION ALL SELECT "character" FROM "character" WHERE "font_id" = 4"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
@@ -1537,7 +1537,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 UNION ALL SELECT `character` FROM `character` WHERE `font_id` = 4 UNION ALL SELECT `character` FROM `character` WHERE `font_id` = 3"#
+    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 UNION ALL SELECT "character" FROM "character" WHERE "font_id" = 4 UNION ALL SELECT "character" FROM "character" WHERE "font_id" = 3"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),


### PR DESCRIPTION
This PR is to discuss an union implementation.
Unions are supported equally by MySQL, PostgreSQL and SQLite, with the same syntax.
Unions are by default distinct, MySQL has an optional UNION DISTINCT but it has no differences from a simple UNION.
Instead, UNION ALL doesn't filter results.

In this quite simple implementation, I've put the union(s) before the order by statement, because union queries supports ordering of union-ed data.
To obtain a more complex behavior, users can use union-ed queries as sub-queries of a parent query.