### PR TITLE
MySql `ColumnType::Binary(None)` maps to "blob"

### DIFF
--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -76,7 +76,7 @@ impl TableBuilder for MysqlQueryBuilder {
                 ColumnType::Date => "date".into(),
                 ColumnType::Binary(length) => match length {
                     Some(length) => format!("binary({})", length),
-                    None => "binary".into(),
+                    None => "blob".into(),
                 },
                 ColumnType::Boolean => "bool".into(),
                 ColumnType::Money(precision) => match precision {


### PR DESCRIPTION
Related to SeaQL/sea-orm#140