### PR TITLE
Add `QueryValue<DB>` trait for dynamic types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
     <strong>🌊 A dynamic query builder for MySQL, Postgres and SQLite</strong>
   </p>
 
-  [![crate](https://img.shields.io/crates/v/sea-query.svg)](https://crates.io/crates/sea-query)
-  [![docs](https://docs.rs/sea-query/badge.svg)](https://docs.rs/sea-query)
-  [![build status](https://github.com/SeaQL/sea-query/actions/workflows/rust.yml/badge.svg)](https://github.com/SeaQL/sea-query/actions/workflows/rust.yml)
+[![crate](https://img.shields.io/crates/v/sea-query.svg)](https://crates.io/crates/sea-query)
+[![docs](https://docs.rs/sea-query/badge.svg)](https://docs.rs/sea-query)
+[![build status](https://github.com/SeaQL/sea-query/actions/workflows/rust.yml/badge.svg)](https://github.com/SeaQL/sea-query/actions/workflows/rust.yml)
 
-  <sub>Built with 🔥 by 🌊🦀🐚</sub>
+<sub>Built with 🔥 by 🌊🦀🐚</sub>
 
 </div>
 
@@ -42,29 +42,29 @@ Table of Content
 
 1. Basics
 
-    1. [Iden](#iden)
-    1. [Expression](#expression)
-    1. [Condition](#condition)
-    1. [Statement Builders](#statement-builders)
+   1. [Iden](#iden)
+   1. [Expression](#expression)
+   1. [Condition](#condition)
+   1. [Statement Builders](#statement-builders)
 
 1. Query Statement
 
-    1. [Query Select](#query-select)
-    1. [Query Insert](#query-insert)
-    1. [Query Update](#query-update)
-    1. [Query Delete](#query-delete)
+   1. [Query Select](#query-select)
+   1. [Query Insert](#query-insert)
+   1. [Query Update](#query-update)
+   1. [Query Delete](#query-delete)
 
 1. Schema Statement
 
-    1. [Table Create](#table-create)
-    1. [Table Alter](#table-alter)
-    1. [Table Drop](#table-drop)
-    1. [Table Rename](#table-rename)
-    1. [Table Truncate](#table-truncate)
-    1. [Foreign Key Create](#foreign-key-create)
-    1. [Foreign Key Drop](#foreign-key-drop)
-    1. [Index Create](#index-create)
-    1. [Index Drop](#index-drop)
+   1. [Table Create](#table-create)
+   1. [Table Alter](#table-alter)
+   1. [Table Drop](#table-drop)
+   1. [Table Rename](#table-rename)
+   1. [Table Truncate](#table-truncate)
+   1. [Foreign Key Create](#foreign-key-create)
+   1. [Foreign Key Drop](#foreign-key-drop)
+   1. [Index Create](#index-create)
+   1. [Index Drop](#index-drop)
 
 ### Motivation
 
@@ -79,8 +79,8 @@ assert_eq!(
     Query::select()
         .column(Glyph::Image)
         .from(Glyph::Table)
-        .and_where(Expr::col(Glyph::Image).like("A"))
-        .and_where(Expr::col(Glyph::Id).is_in(vec![1, 2, 3]))
+        .and_where(Expr::col(Glyph::Image).like(&"A"))
+        .and_where(Expr::col(Glyph::Id).is_in(vec![&1, &2, &3]))
         .build(PostgresQueryBuilder),
     (
         r#"SELECT "image" FROM "glyph" WHERE "image" LIKE $1 AND "id" IN ($2, $3, $4)"#
@@ -108,7 +108,7 @@ Query::select()
         true,
         // if condition is true then add the following condition
         |q| {
-            q.and_where(Expr::col(Char::Id).eq(1));
+            q.and_where(Expr::col(Char::Id).eq(&1));
         },
         // otherwise leave it as is
         |q| {},
@@ -185,9 +185,9 @@ assert_eq!(
         .column(Char::Character)
         .from(Char::Table)
         .and_where(
-            Expr::expr(Expr::col(Char::SizeW).add(1))
-                .mul(2)
-                .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+            Expr::expr(Expr::col(Char::SizeW).add(&1))
+                .mul(&2)
+                .equals(Expr::expr(Expr::col(Char::SizeH).div(&2)).sub(&1))
         )
         .and_where(
             Expr::col(Char::SizeW).in_subquery(
@@ -198,10 +198,10 @@ assert_eq!(
         )
         .and_where(
             Expr::col(Char::Character)
-                .like("D")
-                .and(Expr::col(Char::Character).like("E"))
+                .like(&"D")
+                .and(Expr::col(Char::Character).like(&"E"))
         )
-        .to_string(PostgresQueryBuilder),
+        .to_string(),
     [
         r#"SELECT "character" FROM "character""#,
         r#"WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#,
@@ -232,10 +232,10 @@ assert_eq!(
                 .add(
                     Cond::all()
                         .add(Expr::col(Glyph::Aspect).is_in(vec![3, 4]))
-                        .add(Expr::col(Glyph::Image).like("A%"))
+                        .add(Expr::col(Glyph::Image).like(&"A%"))
                 )
         )
-        .to_string(PostgresQueryBuilder),
+        .to_string(),
     [
         r#"SELECT "id" FROM "glyph""#,
         r#"WHERE"#,
@@ -254,7 +254,7 @@ Query::select().cond_where(any![
     Expr::col(Glyph::Aspect).is_in(vec![3, 4]),
     all![
         Expr::col(Glyph::Aspect).is_null(),
-        Expr::col(Glyph::Image).like("A%")
+        Expr::col(Glyph::Image).like(&"A%")
     ]
 ]);
 ```
@@ -293,7 +293,7 @@ let query = Query::select()
     .from(Char::Table)
     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
     .and_where(Expr::col(Char::SizeW).is_in(vec![3, 4]))
-    .and_where(Expr::col(Char::Character).like("A%"))
+    .and_where(Expr::col(Char::Character).like(&"A%"))
     .to_owned();
 
 assert_eq!(
@@ -301,7 +301,7 @@ assert_eq!(
     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` WHERE `size_w` IN (3, 4) AND `character` LIKE 'A%'"#
 );
 assert_eq!(
-    query.to_string(PostgresQueryBuilder),
+    query.to_string(),
     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" WHERE "size_w" IN (3, 4) AND "character" LIKE 'A%'"#
 );
 assert_eq!(
@@ -325,7 +325,7 @@ assert_eq!(
     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (5.15, '12A'), (4.21, '123')"#
 );
 assert_eq!(
-    query.to_string(PostgresQueryBuilder),
+    query.to_string(),
     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (5.15, '12A'), (4.21, '123')"#
 );
 assert_eq!(
@@ -343,7 +343,7 @@ let query = Query::update()
         (Glyph::Aspect, 1.23.into()),
         (Glyph::Image, "123".into()),
     ])
-    .and_where(Expr::col(Glyph::Id).eq(1))
+    .and_where(Expr::col(Glyph::Id).eq(&1))
     .to_owned();
 
 assert_eq!(
@@ -351,7 +351,7 @@ assert_eq!(
     r#"UPDATE `glyph` SET `aspect` = 1.23, `image` = '123' WHERE `id` = 1"#
 );
 assert_eq!(
-    query.to_string(PostgresQueryBuilder),
+    query.to_string(),
     r#"UPDATE "glyph" SET "aspect" = 1.23, "image" = '123' WHERE "id" = 1"#
 );
 assert_eq!(
@@ -367,8 +367,8 @@ let query = Query::delete()
     .from_table(Glyph::Table)
     .cond_where(
         Cond::any()
-            .add(Expr::col(Glyph::Id).lt(1))
-            .add(Expr::col(Glyph::Id).gt(10)),
+            .add(Expr::col(Glyph::Id).lt(&1))
+            .add(Expr::col(Glyph::Id).gt(&10)),
     )
     .to_owned();
 
@@ -377,7 +377,7 @@ assert_eq!(
     r#"DELETE FROM `glyph` WHERE `id` < 1 OR `id` > 10"#
 );
 assert_eq!(
-    query.to_string(PostgresQueryBuilder),
+    query.to_string(),
     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 );
 assert_eq!(
@@ -425,7 +425,7 @@ assert_eq!(
     ].join(" ")
 );
 assert_eq!(
-    table.to_string(PostgresQueryBuilder),
+    table.to_string(),
     vec![
         r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -474,7 +474,7 @@ assert_eq!(
     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
 );
 assert_eq!(
-    table.to_string(PostgresQueryBuilder),
+    table.to_string(),
     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
 );
 assert_eq!(
@@ -496,7 +496,7 @@ assert_eq!(
     r#"DROP TABLE `glyph`, `character`"#
 );
 assert_eq!(
-    table.to_string(PostgresQueryBuilder),
+    table.to_string(),
     r#"DROP TABLE "glyph", "character""#
 );
 assert_eq!(
@@ -517,7 +517,7 @@ assert_eq!(
     r#"RENAME TABLE `font` TO `font_new`"#
 );
 assert_eq!(
-    table.to_string(PostgresQueryBuilder),
+    table.to_string(),
     r#"ALTER TABLE "font" RENAME TO "font_new""#
 );
 assert_eq!(
@@ -536,7 +536,7 @@ assert_eq!(
     r#"TRUNCATE TABLE `font`"#
 );
 assert_eq!(
-    table.to_string(PostgresQueryBuilder),
+    table.to_string(),
     r#"TRUNCATE TABLE "font""#
 );
 assert_eq!(
@@ -567,7 +567,7 @@ assert_eq!(
     .join(" ")
 );
 assert_eq!(
-    foreign_key.to_string(PostgresQueryBuilder),
+    foreign_key.to_string(),
     vec![
         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_font""#,
         r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
@@ -591,7 +591,7 @@ assert_eq!(
     r#"ALTER TABLE `character` DROP FOREIGN KEY `FK_character_font`"#
 );
 assert_eq!(
-    foreign_key.to_string(PostgresQueryBuilder),
+    foreign_key.to_string(),
     r#"ALTER TABLE "character" DROP CONSTRAINT "FK_character_font""#
 );
 // Sqlite does not support modification of foreign key constraints to existing tables
@@ -611,7 +611,7 @@ assert_eq!(
     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"#
 );
 assert_eq!(
-    index.to_string(PostgresQueryBuilder),
+    index.to_string(),
     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
 );
 assert_eq!(
@@ -633,7 +633,7 @@ assert_eq!(
     r#"DROP INDEX `idx-glyph-aspect` ON `glyph`"#
 );
 assert_eq!(
-    index.to_string(PostgresQueryBuilder),
+    index.to_string(),
     r#"DROP INDEX "idx-glyph-aspect""#
 );
 assert_eq!(
@@ -646,10 +646,10 @@ assert_eq!(
 
 Licensed under either of
 
--   Apache License, Version 2.0
-    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
--   MIT license
-    ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0
+  ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license
+  ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -21,7 +21,7 @@ pub use sqlite::*;
 
 mod foreign_key_builder;
 mod index_builder;
-mod query_builder;
+pub(crate) mod query_builder;
 mod table_builder;
 
 pub use self::foreign_key_builder::*;
@@ -29,9 +29,13 @@ pub use self::index_builder::*;
 pub use self::query_builder::*;
 pub use self::table_builder::*;
 
-pub trait GenericBuilder: QueryBuilder + SchemaBuilder {}
+pub trait GenericBuilder<DB>: QueryBuilder<DB> + SchemaBuilder
+where
+    DB: QueryBuilder<DB>,
+{
+}
 
-pub trait SchemaBuilder: TableBuilder + IndexBuilder + ForeignKeyBuilder {}
+pub trait SchemaBuilder: TableBuilder + IndexBuilder + ForeignKeyBuilder + Default {}
 
 pub trait QuotedBuilder {
     /// The type of quote the builder uses.

--- a/src/backend/mysql/mod.rs
+++ b/src/backend/mysql/mod.rs
@@ -6,18 +6,12 @@ pub(crate) mod table;
 use super::*;
 
 /// Mysql query builder.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct MysqlQueryBuilder;
 
 pub type MySqlQueryBuilder = MysqlQueryBuilder;
 
-impl Default for MysqlQueryBuilder {
-    fn default() -> Self {
-        Self
-    }
-}
-
-impl GenericBuilder for MysqlQueryBuilder {}
+impl GenericBuilder<MysqlQueryBuilder> for MysqlQueryBuilder {}
 
 impl SchemaBuilder for MysqlQueryBuilder {}
 

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -1,3 +1,3 @@
 use super::*;
 
-impl QueryBuilder for MysqlQueryBuilder {}
+impl QueryBuilder<MysqlQueryBuilder> for MysqlQueryBuilder {}

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -96,7 +96,11 @@ impl TableBuilder for MysqlQueryBuilder {
         match column_spec {
             ColumnSpec::Null => write!(sql, "NULL"),
             ColumnSpec::NotNull => write!(sql, "NOT NULL"),
-            ColumnSpec::Default(value) => write!(sql, "DEFAULT {}", self.value_to_string(value)),
+            ColumnSpec::Default(value) => write!(
+                sql,
+                "DEFAULT {}",
+                QueryValue::<MySqlQueryBuilder>::query_value(value)
+            ),
             ColumnSpec::AutoIncrement => write!(sql, "AUTO_INCREMENT"),
             ColumnSpec::UniqueKey => write!(sql, "UNIQUE"),
             ColumnSpec::PrimaryKey => write!(sql, "PRIMARY KEY"),

--- a/src/backend/postgres/mod.rs
+++ b/src/backend/postgres/mod.rs
@@ -7,16 +7,10 @@ pub(crate) mod types;
 use super::*;
 
 /// Postgres query builder.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PostgresQueryBuilder;
 
-impl Default for PostgresQueryBuilder {
-    fn default() -> Self {
-        Self
-    }
-}
-
-impl GenericBuilder for PostgresQueryBuilder {}
+impl GenericBuilder<PostgresQueryBuilder> for PostgresQueryBuilder {}
 
 impl SchemaBuilder for PostgresQueryBuilder {}
 

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -24,11 +24,11 @@ impl QueryBuilder<PostgresQueryBuilder> for PostgresQueryBuilder {
         }
     }
 
-    fn if_null_function() -> &'static str {
+    fn if_null_function(&self) -> &'static str {
         "COALESCE"
     }
 
-    fn write_string_quoted(string: &str, buffer: &mut String) {
+    fn write_string_quoted(&self, string: &str, buffer: &mut String) {
         let escaped = escape_string(string);
         let string = if escaped.find('\\').is_some() {
             "E'".to_owned() + &escaped + "'"

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -95,7 +95,11 @@ impl TableBuilder for PostgresQueryBuilder {
         match column_spec {
             ColumnSpec::Null => write!(sql, "NULL"),
             ColumnSpec::NotNull => write!(sql, "NOT NULL"),
-            ColumnSpec::Default(value) => write!(sql, "DEFAULT {}", self.value_to_string(value)),
+            ColumnSpec::Default(value) => write!(
+                sql,
+                "DEFAULT {}",
+                QueryValue::<PostgresQueryBuilder>::query_value(value)
+            ),
             ColumnSpec::AutoIncrement => write!(sql, ""),
             ColumnSpec::UniqueKey => write!(sql, "UNIQUE"),
             ColumnSpec::PrimaryKey => write!(sql, "PRIMARY KEY"),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -554,8 +554,8 @@ pub trait QueryBuilder<DB: QueryBuilder<DB>>: QuotedBuilder {
                     Function::Sum => "SUM",
                     Function::Avg => "AVG",
                     Function::Count => "COUNT",
-                    Function::IfNull => Self::if_null_function(),
-                    Function::CharLength => Self::char_length_function(),
+                    Function::IfNull => self.if_null_function(),
+                    Function::CharLength => self.char_length_function(),
                     Function::Cast => "CAST",
                     Function::Custom(_) => "",
                     #[cfg(feature = "backend-postgres")]
@@ -790,23 +790,24 @@ pub trait QueryBuilder<DB: QueryBuilder<DB>>: QuotedBuilder {
 
     #[doc(hidden)]
     /// Write a string surrounded by escaped quotes.
-    fn write_string_quoted(string: &str, buffer: &mut String) {
+    fn write_string_quoted(&self, string: &str, buffer: &mut String) {
         write!(buffer, "\'{}\'", escape_string(string)).unwrap()
     }
 
     #[doc(hidden)]
     /// The name of the function that represents the "if null" condition.
-    fn if_null_function() -> &'static str {
+    fn if_null_function(&self) -> &'static str {
         "IFNULL"
     }
 
     #[doc(hidden)]
     /// The name of the function that returns the char length.
-    fn char_length_function() -> &'static str {
+    fn char_length_function(&self) -> &'static str {
         "CHAR_LENGTH"
     }
 }
 
+#[derive(Default)]
 pub(crate) struct CommonSqlQueryBuilder;
 
 impl QueryBuilder<CommonSqlQueryBuilder> for CommonSqlQueryBuilder {}

--- a/src/backend/sqlite/mod.rs
+++ b/src/backend/sqlite/mod.rs
@@ -6,16 +6,10 @@ pub(crate) mod table;
 use super::*;
 
 /// Sqlite query builder.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct SqliteQueryBuilder;
 
-impl Default for SqliteQueryBuilder {
-    fn default() -> Self {
-        Self
-    }
-}
-
-impl GenericBuilder for SqliteQueryBuilder {}
+impl GenericBuilder<SqliteQueryBuilder> for SqliteQueryBuilder {}
 
 impl SchemaBuilder for SqliteQueryBuilder {}
 

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl QueryBuilder<SqliteQueryBuilder> for SqliteQueryBuilder {
-    fn char_length_function() -> &'static str {
+    fn char_length_function(&self) -> &'static str {
         "LENGTH"
     }
 

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -1,15 +1,15 @@
 use super::*;
 
-impl QueryBuilder for SqliteQueryBuilder {
-    fn char_length_function(&self) -> &str {
+impl QueryBuilder<SqliteQueryBuilder> for SqliteQueryBuilder {
+    fn char_length_function() -> &'static str {
         "LENGTH"
     }
 
-    fn prepare_select_lock(
+    fn prepare_select_lock<'a>(
         &self,
         _select_lock: &LockType,
         _sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
+        _collector: &mut dyn FnMut(&'a dyn QueryValue<SqliteQueryBuilder>),
     ) {
         // SQLite doesn't supports row locking
     }

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -116,7 +116,11 @@ impl TableBuilder for SqliteQueryBuilder {
         match column_spec {
             ColumnSpec::Null => write!(sql, "NULL"),
             ColumnSpec::NotNull => write!(sql, "NOT NULL"),
-            ColumnSpec::Default(value) => write!(sql, "DEFAULT {}", self.value_to_string(value)),
+            ColumnSpec::Default(value) => write!(
+                sql,
+                "DEFAULT {}",
+                QueryValue::<SqliteQueryBuilder>::query_value(value)
+            ),
             ColumnSpec::AutoIncrement => write!(sql, "AUTOINCREMENT"),
             ColumnSpec::UniqueKey => write!(sql, "UNIQUE"),
             ColumnSpec::PrimaryKey => write!(sql, "PRIMARY KEY"),

--- a/src/driver/postgres.rs
+++ b/src/driver/postgres.rs
@@ -55,7 +55,7 @@ impl ToSql for Value {
             Value::DateTimeWithTimeZone(v) => box_to_sql!(v, chrono::DateTime<chrono::FixedOffset>),
             #[cfg(feature = "postgres-rust_decimal")]
             Value::Decimal(v) => box_to_sql!(v, rust_decimal::Decimal),
-            #[cfg(feature = "postgres-bigdecimal")]
+            #[cfg(feature = "with-bigdecimal")]
             Value::BigDecimal(_) => unimplemented!("Not supported"),
             #[cfg(feature = "postgres-uuid")]
             Value::Uuid(v) => box_to_sql!(v, uuid::Uuid),

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -1,6 +1,6 @@
 //! For calling built-in Postgres SQL functions.
 
-use crate::{expr::*, func::Function};
+use crate::{expr::*, func::Function, PostgresQueryBuilder, QueryValue};
 
 /// Functions
 #[derive(Debug, Clone)]
@@ -18,7 +18,7 @@ pub enum PgFunction {
 #[derive(Debug, Clone)]
 pub struct PgFunc;
 
-impl PgFunc {
+impl<'a> PgFunc {
     /// Call `TO_TSQUERY` function. Postgres only.
     ///
     /// The parameter `regconfig` represents the OID of the text search configuration.
@@ -34,17 +34,20 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT TO_TSQUERY('a & b')"#
     /// );
     /// ```
-    pub fn to_tsquery<T>(expr: T, regconfig: Option<u32>) -> SimpleExpr
+    pub fn to_tsquery<T>(
+        expr: T,
+        regconfig: Option<&'a dyn QueryValue<PostgresQueryBuilder>>,
+    ) -> SimpleExpr<'a, PostgresQueryBuilder>
     where
-        T: Into<SimpleExpr>,
+        T: Into<SimpleExpr<'a, PostgresQueryBuilder>>,
     {
         match regconfig {
             Some(config) => {
-                let config = SimpleExpr::Value(config.into());
+                let config = SimpleExpr::Value(config);
                 Expr::func(Function::PgFunction(PgFunction::ToTsquery))
                     .args(vec![config, expr.into()])
             }
@@ -67,17 +70,20 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT TO_TSVECTOR('a b')"#
     /// );
     /// ```
-    pub fn to_tsvector<T>(expr: T, regconfig: Option<u32>) -> SimpleExpr
+    pub fn to_tsvector<T>(
+        expr: T,
+        regconfig: Option<&'a dyn QueryValue<PostgresQueryBuilder>>,
+    ) -> SimpleExpr<'a, PostgresQueryBuilder>
     where
-        T: Into<SimpleExpr>,
+        T: Into<SimpleExpr<'a, PostgresQueryBuilder>>,
     {
         match regconfig {
             Some(config) => {
-                let config = SimpleExpr::Value(config.into());
+                let config = SimpleExpr::Value(config);
                 Expr::func(Function::PgFunction(PgFunction::ToTsvector))
                     .args(vec![config, expr.into()])
             }
@@ -100,17 +106,20 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT PHRASETO_TSQUERY('a b')"#
     /// );
     /// ```
-    pub fn phraseto_tsquery<T>(expr: T, regconfig: Option<u32>) -> SimpleExpr
+    pub fn phraseto_tsquery<T>(
+        expr: T,
+        regconfig: Option<&'a dyn QueryValue<PostgresQueryBuilder>>,
+    ) -> SimpleExpr<'a, PostgresQueryBuilder>
     where
-        T: Into<SimpleExpr>,
+        T: Into<SimpleExpr<'a, PostgresQueryBuilder>>,
     {
         match regconfig {
             Some(config) => {
-                let config = SimpleExpr::Value(config.into());
+                let config = SimpleExpr::Value(config);
                 Expr::func(Function::PgFunction(PgFunction::PhrasetoTsquery))
                     .args(vec![config, expr.into()])
             }
@@ -133,17 +142,20 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT PLAINTO_TSQUERY('a b')"#
     /// );
     /// ```
-    pub fn plainto_tsquery<T>(expr: T, regconfig: Option<u32>) -> SimpleExpr
+    pub fn plainto_tsquery<T>(
+        expr: T,
+        regconfig: Option<&'a dyn QueryValue<PostgresQueryBuilder>>,
+    ) -> SimpleExpr<'a, PostgresQueryBuilder>
     where
-        T: Into<SimpleExpr>,
+        T: Into<SimpleExpr<'a, PostgresQueryBuilder>>,
     {
         match regconfig {
             Some(config) => {
-                let config = SimpleExpr::Value(config.into());
+                let config = SimpleExpr::Value(config);
                 Expr::func(Function::PgFunction(PgFunction::PlaintoTsquery))
                     .args(vec![config, expr.into()])
             }
@@ -166,17 +178,20 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT WEBSEARCH_TO_TSQUERY('a b')"#
     /// );
     /// ```
-    pub fn websearch_to_tsquery<T>(expr: T, regconfig: Option<u32>) -> SimpleExpr
+    pub fn websearch_to_tsquery<T>(
+        expr: T,
+        regconfig: Option<&'a dyn QueryValue<PostgresQueryBuilder>>,
+    ) -> SimpleExpr<'a, PostgresQueryBuilder>
     where
-        T: Into<SimpleExpr>,
+        T: Into<SimpleExpr<'a, PostgresQueryBuilder>>,
     {
         match regconfig {
             Some(config) => {
-                let config = SimpleExpr::Value(config.into());
+                let config = SimpleExpr::Value(config);
                 Expr::func(Function::PgFunction(PgFunction::WebsearchToTsquery))
                     .args(vec![config, expr.into()])
             }
@@ -196,13 +211,13 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT TS_RANK('a b', 'a&b')"#
     /// );
     /// ```
-    pub fn ts_rank<T>(vector: T, query: T) -> SimpleExpr
+    pub fn ts_rank<T>(vector: T, query: T) -> SimpleExpr<'a, PostgresQueryBuilder>
     where
-        T: Into<SimpleExpr>,
+        T: Into<SimpleExpr<'a, PostgresQueryBuilder>>,
     {
         Expr::func(Function::PgFunction(PgFunction::TsRank)).args(vec![vector, query])
     }
@@ -219,13 +234,13 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT TS_RANK_CD('a b', 'a&b')"#
     /// );
     /// ```
-    pub fn ts_rank_cd<T>(vector: T, query: T) -> SimpleExpr
+    pub fn ts_rank_cd<T>(vector: T, query: T) -> SimpleExpr<'a, PostgresQueryBuilder>
     where
-        T: Into<SimpleExpr>,
+        T: Into<SimpleExpr<'a, PostgresQueryBuilder>>,
     {
         Expr::func(Function::PgFunction(PgFunction::TsRankCd)).args(vec![vector, query])
     }

--- a/src/foreign_key/create.rs
+++ b/src/foreign_key/create.rs
@@ -29,7 +29,7 @@ use crate::{
 ///     .join(" ")
 /// );
 /// assert_eq!(
-///     foreign_key.to_string(PostgresQueryBuilder),
+///     foreign_key.to_string(),
 ///     vec![
 ///         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_font""#,
 ///         r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
@@ -62,7 +62,7 @@ use crate::{
 ///     .join(" ")
 /// );
 /// assert_eq!(
-///     foreign_key.to_string(PostgresQueryBuilder),
+///     foreign_key.to_string(),
 ///     vec![
 ///         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_glyph""#,
 ///         r#"FOREIGN KEY ("font_id", "id") REFERENCES "glyph" ("font_id", "id")"#,
@@ -212,13 +212,8 @@ impl ForeignKeyCreateStatement {
 }
 
 impl SchemaStatementBuilder for ForeignKeyCreateStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
-        schema_builder.prepare_foreign_key_create_statement(self, &mut sql);
-        sql.result()
-    }
-
-    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
+    fn build<T: SchemaBuilder>(&self) -> String {
+        let schema_builder = T::default();
         let mut sql = SqlWriter::new();
         schema_builder.prepare_foreign_key_create_statement(self, &mut sql);
         sql.result()

--- a/src/foreign_key/drop.rs
+++ b/src/foreign_key/drop.rs
@@ -19,7 +19,7 @@ use crate::{
 ///     r#"ALTER TABLE `character` DROP FOREIGN KEY `FK_character_font`"#
 /// );
 /// assert_eq!(
-///     foreign_key.to_string(PostgresQueryBuilder),
+///     foreign_key.to_string(),
 ///     r#"ALTER TABLE "character" DROP CONSTRAINT "FK_character_font""#
 /// );
 /// // Sqlite does not support modification of foreign key constraints to existing tables
@@ -62,13 +62,8 @@ impl ForeignKeyDropStatement {
 }
 
 impl SchemaStatementBuilder for ForeignKeyDropStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
-        schema_builder.prepare_foreign_key_drop_statement(self, &mut sql);
-        sql.result()
-    }
-
-    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
+    fn build<T: SchemaBuilder>(&self) -> String {
+        let schema_builder = T::default();
         let mut sql = SqlWriter::new();
         schema_builder.prepare_foreign_key_drop_statement(self, &mut sql);
         sql.result()

--- a/src/func.rs
+++ b/src/func.rs
@@ -1,6 +1,6 @@
 //! For calling built-in SQL functions.
 
-use crate::{expr::*, types::*, Value};
+use crate::{expr::*, types::*, QueryBuilder};
 
 #[cfg(feature = "backend-postgres")]
 pub use crate::extension::postgres::{PgFunc, PgFunction};
@@ -50,7 +50,7 @@ impl Func {
     ///     r#"SELECT MY_FUNCTION('hello')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT MY_FUNCTION('hello')"#
     /// );
     /// assert_eq!(
@@ -58,8 +58,9 @@ impl Func {
     ///     r#"SELECT MY_FUNCTION('hello')"#
     /// );
     /// ```
-    pub fn cust<T>(func: T) -> Expr
+    pub fn cust<'a, DB, T>(func: T) -> Expr<'a, DB>
     where
+        DB: QueryBuilder<DB> + Default,
         T: IntoIden,
     {
         Expr::func(Function::Custom(func.into_iden()))
@@ -82,7 +83,7 @@ impl Func {
     ///     r#"SELECT MAX(`character`.`size_w`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT MAX("character"."size_w") FROM "character""#
     /// );
     /// assert_eq!(
@@ -90,9 +91,10 @@ impl Func {
     ///     r#"SELECT MAX(`character`.`size_w`) FROM `character`"#
     /// );
     /// ```
-    pub fn max<T>(expr: T) -> SimpleExpr
+    pub fn max<'a, DB, T>(expr: T) -> SimpleExpr<'a, DB>
     where
-        T: Into<SimpleExpr>,
+        DB: QueryBuilder<DB> + Default,
+        T: Into<SimpleExpr<'a, DB>>,
     {
         Expr::func(Function::Max).arg(expr)
     }
@@ -114,7 +116,7 @@ impl Func {
     ///     r#"SELECT MIN(`character`.`size_h`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT MIN("character"."size_h") FROM "character""#
     /// );
     /// assert_eq!(
@@ -122,9 +124,10 @@ impl Func {
     ///     r#"SELECT MIN(`character`.`size_h`) FROM `character`"#
     /// );
     /// ```
-    pub fn min<T>(expr: T) -> SimpleExpr
+    pub fn min<'a, DB, T>(expr: T) -> SimpleExpr<'a, DB>
     where
-        T: Into<SimpleExpr>,
+        DB: QueryBuilder<DB> + Default,
+        T: Into<SimpleExpr<'a, DB>>,
     {
         Expr::func(Function::Min).arg(expr)
     }
@@ -146,7 +149,7 @@ impl Func {
     ///     r#"SELECT SUM(`character`.`size_h`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT SUM("character"."size_h") FROM "character""#
     /// );
     /// assert_eq!(
@@ -154,9 +157,10 @@ impl Func {
     ///     r#"SELECT SUM(`character`.`size_h`) FROM `character`"#
     /// );
     /// ```
-    pub fn sum<T>(expr: T) -> SimpleExpr
+    pub fn sum<'a, DB, T>(expr: T) -> SimpleExpr<'a, DB>
     where
-        T: Into<SimpleExpr>,
+        DB: QueryBuilder<DB> + Default,
+        T: Into<SimpleExpr<'a, DB>>,
     {
         Expr::func(Function::Sum).arg(expr)
     }
@@ -178,7 +182,7 @@ impl Func {
     ///     r#"SELECT AVG(`character`.`size_h`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT AVG("character"."size_h") FROM "character""#
     /// );
     /// assert_eq!(
@@ -186,9 +190,10 @@ impl Func {
     ///     r#"SELECT AVG(`character`.`size_h`) FROM `character`"#
     /// );
     /// ```
-    pub fn avg<T>(expr: T) -> SimpleExpr
+    pub fn avg<'a, DB, T>(expr: T) -> SimpleExpr<'a, DB>
     where
-        T: Into<SimpleExpr>,
+        DB: QueryBuilder<DB> + Default,
+        T: Into<SimpleExpr<'a, DB>>,
     {
         Expr::func(Function::Avg).arg(expr)
     }
@@ -210,7 +215,7 @@ impl Func {
     ///     r#"SELECT COUNT(`character`.`id`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT COUNT("character"."id") FROM "character""#
     /// );
     /// assert_eq!(
@@ -218,9 +223,10 @@ impl Func {
     ///     r#"SELECT COUNT(`character`.`id`) FROM `character`"#
     /// );
     /// ```
-    pub fn count<T>(expr: T) -> SimpleExpr
+    pub fn count<'a, DB, T>(expr: T) -> SimpleExpr<'a, DB>
     where
-        T: Into<SimpleExpr>,
+        DB: QueryBuilder<DB> + Default,
+        T: Into<SimpleExpr<'a, DB>>,
     {
         Expr::func(Function::Count).arg(expr)
     }
@@ -242,7 +248,7 @@ impl Func {
     ///     r#"SELECT CHAR_LENGTH(`character`.`character`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT CHAR_LENGTH("character"."character") FROM "character""#
     /// );
     /// assert_eq!(
@@ -250,9 +256,10 @@ impl Func {
     ///     r#"SELECT LENGTH(`character`.`character`) FROM `character`"#
     /// );
     /// ```
-    pub fn char_length<T>(expr: T) -> SimpleExpr
+    pub fn char_length<'a, DB, T>(expr: T) -> SimpleExpr<'a, DB>
     where
-        T: Into<SimpleExpr>,
+        DB: QueryBuilder<DB> + Default,
+        T: Into<SimpleExpr<'a, DB>>,
     {
         Expr::func(Function::CharLength).arg(expr)
     }
@@ -277,7 +284,7 @@ impl Func {
     ///     r#"SELECT IFNULL(`size_w`, `size_h`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT COALESCE("size_w", "size_h") FROM "character""#
     /// );
     /// assert_eq!(
@@ -285,10 +292,11 @@ impl Func {
     ///     r#"SELECT IFNULL(`size_w`, `size_h`) FROM `character`"#
     /// );
     /// ```
-    pub fn if_null<A, B>(a: A, b: B) -> SimpleExpr
+    pub fn if_null<'a, DB, A, B>(a: A, b: B) -> SimpleExpr<'a, DB>
     where
-        A: Into<SimpleExpr>,
-        B: Into<SimpleExpr>,
+        DB: QueryBuilder<DB> + Default,
+        A: Into<SimpleExpr<'a, DB>>,
+        B: Into<SimpleExpr<'a, DB>>,
     {
         Expr::func(Function::IfNull).args(vec![a.into(), b.into()])
     }
@@ -309,7 +317,7 @@ impl Func {
     ///     r#"SELECT CAST('hello' AS MyType)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT CAST('hello' AS MyType)"#
     /// );
     /// assert_eq!(
@@ -317,12 +325,13 @@ impl Func {
     ///     r#"SELECT CAST('hello' AS MyType)"#
     /// );
     /// ```
-    pub fn cast_as<V, I>(value: V, iden: I) -> SimpleExpr
+    pub fn cast_as<'a, DB, V, I>(value: &'a V, iden: I) -> SimpleExpr<'a, DB>
     where
-        V: Into<Value>,
+        DB: QueryBuilder<DB> + Default,
+        V: QueryValue<DB>,
         I: IntoIden,
     {
-        Expr::func(Function::Cast).arg(Expr::val(value.into()).bin_oper(
+        Expr::func(Function::Cast).arg(Expr::val(value).bin_oper(
             BinOper::As,
             Expr::cust(iden.into_iden().to_string().as_str()),
         ))

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -19,7 +19,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
 /// );
 /// assert_eq!(
@@ -42,7 +42,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect` (128))"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect" (128))"#
 /// );
 /// assert_eq!(
@@ -65,7 +65,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect` DESC)"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect" DESC)"#
 /// );
 /// assert_eq!(
@@ -88,7 +88,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect` (64) ASC)"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect" (64) ASC)"#
 /// );
 /// assert_eq!(
@@ -201,13 +201,8 @@ impl IndexCreateStatement {
 }
 
 impl SchemaStatementBuilder for IndexCreateStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
-        schema_builder.prepare_index_create_statement(self, &mut sql);
-        sql.result()
-    }
-
-    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
+    fn build<T: SchemaBuilder>(&self) -> String {
+        let schema_builder = T::default();
         let mut sql = SqlWriter::new();
         schema_builder.prepare_index_create_statement(self, &mut sql);
         sql.result()

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -17,7 +17,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"DROP INDEX `idx-glyph-aspect` ON `glyph`"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(),
 ///     r#"DROP INDEX "idx-glyph-aspect""#
 /// );
 /// assert_eq!(
@@ -63,13 +63,8 @@ impl IndexDropStatement {
 }
 
 impl SchemaStatementBuilder for IndexDropStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
-        schema_builder.prepare_index_drop_statement(self, &mut sql);
-        sql.result()
-    }
-
-    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
+    fn build<T: SchemaBuilder>(&self) -> String {
+        let schema_builder = T::default();
         let mut sql = SqlWriter::new();
         schema_builder.prepare_index_drop_statement(self, &mut sql);
         sql.result()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 //!     Query::select()
 //!         .column(Glyph::Image)
 //!         .from(Glyph::Table)
-//!         .and_where(Expr::col(Glyph::Image).like("A"))
+//!         .and_where(Expr::col(Glyph::Image).like(&"A"))
 //!         .and_where(Expr::col(Glyph::Id).is_in(vec![1, 2, 3]))
 //!         .build(PostgresQueryBuilder),
 //!     (
@@ -113,7 +113,7 @@
 //!         true,
 //!         // if condition is true then add the following condition
 //!         |q| {
-//!             q.and_where(Expr::col(Char::Id).eq(1));
+//!             q.and_where(Expr::col(Char::Id).eq(&1));
 //!         },
 //!         // otherwise leave it as is
 //!         |q| {},
@@ -192,9 +192,9 @@
 //!         .column(Char::Character)
 //!         .from(Char::Table)
 //!         .and_where(
-//!             Expr::expr(Expr::col(Char::SizeW).add(1))
-//!                 .mul(2)
-//!                 .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+//!             Expr::expr(Expr::col(Char::SizeW).add(&1))
+//!                 .mul(&2)
+//!                 .equals(Expr::expr(Expr::col(Char::SizeH).div(&2)).sub(&1))
 //!         )
 //!         .and_where(
 //!             Expr::col(Char::SizeW).in_subquery(
@@ -205,10 +205,10 @@
 //!         )
 //!         .and_where(
 //!             Expr::col(Char::Character)
-//!                 .like("D")
-//!                 .and(Expr::col(Char::Character).like("E"))
+//!                 .like(&"D")
+//!                 .and(Expr::col(Char::Character).like(&"E"))
 //!         )
-//!         .to_string(PostgresQueryBuilder),
+//!         .to_string(),
 //!     [
 //!         r#"SELECT "character" FROM "character""#,
 //!         r#"WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#,
@@ -240,10 +240,10 @@
 //!                 .add(
 //!                     Cond::all()
 //!                         .add(Expr::col(Glyph::Aspect).is_in(vec![3, 4]))
-//!                         .add(Expr::col(Glyph::Image).like("A%"))
+//!                         .add(Expr::col(Glyph::Image).like(&"A%"))
 //!                 )
 //!         )
-//!         .to_string(PostgresQueryBuilder),
+//!         .to_string(),
 //!     [
 //!         r#"SELECT "id" FROM "glyph""#,
 //!         r#"WHERE"#,
@@ -263,7 +263,7 @@
 //!     Expr::col(Glyph::Aspect).is_in(vec![3, 4]),
 //!     all![
 //!         Expr::col(Glyph::Aspect).is_null(),
-//!         Expr::col(Glyph::Image).like("A%")
+//!         Expr::col(Glyph::Image).like(&"A%")
 //!     ]
 //! ]);
 //! ```
@@ -309,7 +309,7 @@
 //!     .from(Char::Table)
 //!     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
 //!     .and_where(Expr::col(Char::SizeW).is_in(vec![3, 4]))
-//!     .and_where(Expr::col(Char::Character).like("A%"))
+//!     .and_where(Expr::col(Char::Character).like(&"A%"))
 //!     .to_owned();
 //!
 //! assert_eq!(
@@ -317,7 +317,7 @@
 //!     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` WHERE `size_w` IN (3, 4) AND `character` LIKE 'A%'"#
 //! );
 //! assert_eq!(
-//!     query.to_string(PostgresQueryBuilder),
+//!     query.to_string(),
 //!     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" WHERE "size_w" IN (3, 4) AND "character" LIKE 'A%'"#
 //! );
 //! assert_eq!(
@@ -342,7 +342,7 @@
 //!     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (5.15, '12A'), (4.21, '123')"#
 //! );
 //! assert_eq!(
-//!     query.to_string(PostgresQueryBuilder),
+//!     query.to_string(),
 //!     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (5.15, '12A'), (4.21, '123')"#
 //! );
 //! assert_eq!(
@@ -361,7 +361,7 @@
 //!         (Glyph::Aspect, 1.23.into()),
 //!         (Glyph::Image, "123".into()),
 //!     ])
-//!     .and_where(Expr::col(Glyph::Id).eq(1))
+//!     .and_where(Expr::col(Glyph::Id).eq(&1))
 //!     .to_owned();
 //!
 //! assert_eq!(
@@ -369,7 +369,7 @@
 //!     r#"UPDATE `glyph` SET `aspect` = 1.23, `image` = '123' WHERE `id` = 1"#
 //! );
 //! assert_eq!(
-//!     query.to_string(PostgresQueryBuilder),
+//!     query.to_string(),
 //!     r#"UPDATE "glyph" SET "aspect" = 1.23, "image" = '123' WHERE "id" = 1"#
 //! );
 //! assert_eq!(
@@ -386,8 +386,8 @@
 //!     .from_table(Glyph::Table)
 //!     .cond_where(
 //!         Cond::any()
-//!             .add(Expr::col(Glyph::Id).lt(1))
-//!             .add(Expr::col(Glyph::Id).gt(10)),
+//!             .add(Expr::col(Glyph::Id).lt(&1))
+//!             .add(Expr::col(Glyph::Id).gt(&10)),
 //!     )
 //!     .to_owned();
 //!
@@ -396,7 +396,7 @@
 //!     r#"DELETE FROM `glyph` WHERE `id` < 1 OR `id` > 10"#
 //! );
 //! assert_eq!(
-//!     query.to_string(PostgresQueryBuilder),
+//!     query.to_string(),
 //!     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 //! );
 //! assert_eq!(
@@ -445,7 +445,7 @@
 //!     ].join(" ")
 //! );
 //! assert_eq!(
-//!     table.to_string(PostgresQueryBuilder),
+//!     table.to_string(),
 //!     vec![
 //!         r#"CREATE TABLE IF NOT EXISTS "character" ("#,
 //!             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -495,7 +495,7 @@
 //!     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
 //! );
 //! assert_eq!(
-//!     table.to_string(PostgresQueryBuilder),
+//!     table.to_string(),
 //!     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
 //! );
 //! assert_eq!(
@@ -518,7 +518,7 @@
 //!     r#"DROP TABLE `glyph`, `character`"#
 //! );
 //! assert_eq!(
-//!     table.to_string(PostgresQueryBuilder),
+//!     table.to_string(),
 //!     r#"DROP TABLE "glyph", "character""#
 //! );
 //! assert_eq!(
@@ -540,7 +540,7 @@
 //!     r#"RENAME TABLE `font` TO `font_new`"#
 //! );
 //! assert_eq!(
-//!     table.to_string(PostgresQueryBuilder),
+//!     table.to_string(),
 //!     r#"ALTER TABLE "font" RENAME TO "font_new""#
 //! );
 //! assert_eq!(
@@ -560,7 +560,7 @@
 //!     r#"TRUNCATE TABLE `font`"#
 //! );
 //! assert_eq!(
-//!     table.to_string(PostgresQueryBuilder),
+//!     table.to_string(),
 //!     r#"TRUNCATE TABLE "font""#
 //! );
 //! assert_eq!(
@@ -592,7 +592,7 @@
 //!     .join(" ")
 //! );
 //! assert_eq!(
-//!     foreign_key.to_string(PostgresQueryBuilder),
+//!     foreign_key.to_string(),
 //!     vec![
 //!         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_font""#,
 //!         r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
@@ -617,7 +617,7 @@
 //!     r#"ALTER TABLE `character` DROP FOREIGN KEY `FK_character_font`"#
 //! );
 //! assert_eq!(
-//!     foreign_key.to_string(PostgresQueryBuilder),
+//!     foreign_key.to_string(),
 //!     r#"ALTER TABLE "character" DROP CONSTRAINT "FK_character_font""#
 //! );
 //! // Sqlite does not support modification of foreign key constraints to existing tables
@@ -638,7 +638,7 @@
 //!     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"#
 //! );
 //! assert_eq!(
-//!     index.to_string(PostgresQueryBuilder),
+//!     index.to_string(),
 //!     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
 //! );
 //! assert_eq!(
@@ -661,7 +661,7 @@
 //!     r#"DROP INDEX `idx-glyph-aspect` ON `glyph`"#
 //! );
 //! assert_eq!(
-//!     index.to_string(PostgresQueryBuilder),
+//!     index.to_string(),
 //!     r#"DROP INDEX "idx-glyph-aspect""#
 //! );
 //! assert_eq!(

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -9,13 +9,13 @@ pub struct SqlWriter {
     pub(crate) string: String,
 }
 
-pub fn inject_parameters<I>(sql: &str, params: I, query_builder: &dyn QueryBuilder) -> String
+pub fn inject_parameters<DB, V>(sql: &str, params: &[&V], query_builder: DB) -> String
 where
-    I: IntoIterator<Item = Value>,
+    DB: QueryBuilder<DB>,
+    V: QueryValue<DB> + ?Sized,
 {
-    let params: Vec<Value> = params.into_iter().collect();
     let tokenizer = Tokenizer::new(sql);
-    let tokens: Vec<Token> = tokenizer.iter().collect();
+    let tokens: Vec<_> = tokenizer.into_iter().collect();
     let mut counter = 0;
     let mut output = Vec::new();
     let mut i = 0;
@@ -24,7 +24,7 @@ where
         match token {
             Token::Punctuation(mark) => {
                 if (mark.as_ref(), false) == query_builder.placeholder() {
-                    output.push(query_builder.value_to_string(&params[counter]));
+                    output.push(params[counter].query_value());
                     counter += 1;
                     i += 1;
                     continue;
@@ -33,7 +33,7 @@ where
                 {
                     if let Token::Unquoted(next) = &tokens[i + 1] {
                         if let Ok(num) = next.parse::<usize>() {
-                            output.push(query_builder.value_to_string(&params[num - 1]));
+                            output.push(params[num - 1].query_value());
                             i += 2;
                             continue;
                         }
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn inject_parameters_1() {
         assert_eq!(
-            inject_parameters("WHERE A = ?", vec!["B".into()], &MysqlQueryBuilder),
+            inject_parameters("WHERE A = ?", &[&"B"], MysqlQueryBuilder),
             "WHERE A = 'B'"
         );
     }
@@ -106,11 +106,7 @@ mod tests {
     #[test]
     fn inject_parameters_2() {
         assert_eq!(
-            inject_parameters(
-                "WHERE A = '?' AND B = ?",
-                vec!["C".into()],
-                &MysqlQueryBuilder
-            ),
+            inject_parameters("WHERE A = '?' AND B = ?", &[&"C"], MysqlQueryBuilder),
             "WHERE A = '?' AND B = 'C'"
         );
     }
@@ -118,11 +114,7 @@ mod tests {
     #[test]
     fn inject_parameters_3() {
         assert_eq!(
-            inject_parameters(
-                "WHERE A = ? AND C = ?",
-                vec!["B".into(), "D".into()],
-                &MysqlQueryBuilder
-            ),
+            inject_parameters("WHERE A = ? AND C = ?", &[&"B", &"D"], MysqlQueryBuilder),
             "WHERE A = 'B' AND C = 'D'"
         );
     }
@@ -132,8 +124,8 @@ mod tests {
         assert_eq!(
             inject_parameters(
                 "WHERE A = $1 AND C = $2",
-                vec!["B".into(), "D".into()],
-                &PostgresQueryBuilder
+                &[&"B", &"D"],
+                PostgresQueryBuilder
             ),
             "WHERE A = 'B' AND C = 'D'"
         );
@@ -144,8 +136,8 @@ mod tests {
         assert_eq!(
             inject_parameters(
                 "WHERE A = $2 AND C = $1",
-                vec!["B".into(), "D".into()],
-                &PostgresQueryBuilder
+                &[&"B", &"D"],
+                PostgresQueryBuilder
             ),
             "WHERE A = 'D' AND C = 'B'"
         );
@@ -154,7 +146,7 @@ mod tests {
     #[test]
     fn inject_parameters_6() {
         assert_eq!(
-            inject_parameters("WHERE A = $1", vec!["B'C".into()], &PostgresQueryBuilder),
+            inject_parameters("WHERE A = $1", &[&"B'C"], PostgresQueryBuilder),
             "WHERE A = E'B\\'C'"
         );
     }
@@ -162,11 +154,7 @@ mod tests {
     #[test]
     fn inject_parameters_7() {
         assert_eq!(
-            inject_parameters(
-                "?",
-                vec![vec![0xABu8, 0xCD, 0xEF].into()],
-                &MysqlQueryBuilder
-            ),
+            inject_parameters("?", &[&vec![0xABu8, 0xCD, 0xEF]], MysqlQueryBuilder),
             "x'ABCDEF'"
         );
     }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -24,37 +24,64 @@ pub use select::*;
 pub use traits::*;
 pub use update::*;
 
+use crate::{MySqlQueryBuilder, PostgresQueryBuilder, QueryBuilder, SqliteQueryBuilder};
+
+pub trait Queryable<DB: QueryBuilder<DB> + Default> {
+    /// Construct table [`SelectStatement`]
+    fn select<'a>() -> SelectStatement<'a, DB> {
+        SelectStatement::<'a, DB>::new()
+    }
+
+    /// Construct table [`InsertStatement`]
+    fn insert<'a>() -> InsertStatement<'a, DB> {
+        InsertStatement::<'a, DB>::new()
+    }
+
+    /// Construct table [`UpdateStatement`]
+    fn update<'a>() -> UpdateStatement<'a, DB> {
+        UpdateStatement::<'a, DB>::new()
+    }
+
+    /// Construct table [`DeleteStatement`]
+    fn delete<'a>() -> DeleteStatement<'a, DB> {
+        DeleteStatement::<'a, DB>::new()
+    }
+}
+
+/// All available types of table query
+#[derive(Debug, Clone)]
+pub enum QueryStatement<'a, DB> {
+    Select(SelectStatement<'a, DB>),
+    Insert(InsertStatement<'a, DB>),
+    Update(UpdateStatement<'a, DB>),
+    Delete(DeleteStatement<'a, DB>),
+}
+
 /// Shorthand for constructing any table query
 #[derive(Debug, Clone)]
 pub struct Query;
 
-/// All available types of table query
+impl Queryable<MySqlQueryBuilder> for Query {}
+impl Queryable<PostgresQueryBuilder> for Query {}
+impl Queryable<SqliteQueryBuilder> for Query {}
+
 #[derive(Debug, Clone)]
-pub enum QueryStatement {
-    Select(SelectStatement),
-    Insert(InsertStatement),
-    Update(UpdateStatement),
-    Delete(DeleteStatement),
-}
+#[cfg(feature = "backend-mysql")]
+pub struct MySqlQuery;
 
-impl Query {
-    /// Construct table [`SelectStatement`]
-    pub fn select() -> SelectStatement {
-        SelectStatement::new()
-    }
+#[cfg(feature = "backend-mysql")]
+impl Queryable<MySqlQueryBuilder> for MySqlQuery {}
 
-    /// Construct table [`InsertStatement`]
-    pub fn insert() -> InsertStatement {
-        InsertStatement::new()
-    }
+#[derive(Debug, Clone)]
+#[cfg(feature = "backend-postgres")]
+pub struct PgQuery;
 
-    /// Construct table [`UpdateStatement`]
-    pub fn update() -> UpdateStatement {
-        UpdateStatement::new()
-    }
+#[cfg(feature = "backend-postgres")]
+impl Queryable<PostgresQueryBuilder> for PgQuery {}
 
-    /// Construct table [`DeleteStatement`]
-    pub fn delete() -> DeleteStatement {
-        DeleteStatement::new()
-    }
-}
+#[derive(Debug, Clone)]
+#[cfg(feature = "backend-sqlite")]
+pub struct SqliteQuery;
+
+#[cfg(feature = "backend-sqlite")]
+impl Queryable<SqliteQueryBuilder> for SqliteQuery {}

--- a/src/query/ordered.rs
+++ b/src/query/ordered.rs
@@ -1,9 +1,12 @@
 use crate::{expr::*, types::*};
 
-pub trait OrderedStatement {
+pub trait OrderedStatement<'a, DB>
+where
+    DB: 'a,
+{
     #[doc(hidden)]
     // Implementation for the trait.
-    fn add_order_by(&mut self, order: OrderExpr) -> &mut Self;
+    fn add_order_by(&mut self, order: OrderExpr<'a, DB>) -> &mut Self;
 
     /// Order by column.
     ///
@@ -15,13 +18,13 @@ pub trait OrderedStatement {
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
     /// ```
@@ -48,7 +51,7 @@ pub trait OrderedStatement {
     }
 
     /// Order by [`SimpleExpr`].
-    fn order_by_expr(&mut self, expr: SimpleExpr, order: Order) -> &mut Self {
+    fn order_by_expr(&mut self, expr: SimpleExpr<'a, DB>, order: Order) -> &mut Self {
         self.add_order_by(OrderExpr { expr, order })
     }
 

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -1,10 +1,9 @@
-use crate::{
-    backend::QueryBuilder,
-    prepare::inject_parameters,
-    value::{Value, Values},
-};
+use crate::{backend::QueryBuilder, prepare::inject_parameters, QueryValue};
 
-pub trait QueryStatementBuilder {
+pub trait QueryStatementBuilder<'a, DB>
+where
+    DB: 'a + QueryBuilder<DB> + Default,
+{
     /// Build corresponding SQL statement for certain database backend and return SQL string
     ///
     /// # Examples
@@ -15,19 +14,19 @@ pub trait QueryStatementBuilder {
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by_tbl(Glyph::Table, Glyph::Aspect, Order::Asc)
-    ///     .to_string(MysqlQueryBuilder);
+    ///     .to_string();
     ///
     /// assert_eq!(
     ///     query,
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
     /// ```
-    fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
-        let (sql, values) = self.build_any(&query_builder);
-        inject_parameters(&sql, values.0, &query_builder)
+    fn to_string(&'a self) -> String {
+        let (sql, values) = self.build();
+        inject_parameters(&sql, &values, DB::default())
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
@@ -40,10 +39,10 @@ pub trait QueryStatementBuilder {
     /// let (query, params) = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by_tbl(Glyph::Table, Glyph::Aspect, Order::Asc)
-    ///     .build(MysqlQueryBuilder);
+    ///     .build();
     ///
     /// assert_eq!(
     ///     query,
@@ -54,19 +53,11 @@ pub trait QueryStatementBuilder {
     ///     Values(vec![Value::Int(Some(0)), Value::Int(Some(2))])
     /// );
     /// ```
-    fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
+    fn build(&'a self) -> (String, Vec<&'a dyn QueryValue<DB>>) {
         let mut values = Vec::new();
         let mut collector = |v| values.push(v);
-        let sql = self.build_collect(query_builder, &mut collector);
-        (sql, Values(values))
-    }
-
-    /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
-    fn build_any(&self, query_builder: &dyn QueryBuilder) -> (String, Values) {
-        let mut values = Vec::new();
-        let mut collector = |v| values.push(v);
-        let sql = self.build_collect_any(query_builder, &mut collector);
-        (sql, Values(values))
+        let sql = self.build_collect(&mut collector);
+        (sql, values)
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters
@@ -79,13 +70,13 @@ pub trait QueryStatementBuilder {
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by_tbl(Glyph::Table, Glyph::Aspect, Order::Asc)
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(),
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
     ///
@@ -93,7 +84,7 @@ pub trait QueryStatementBuilder {
     /// let mut collector = |v| params.push(v);
     ///
     /// assert_eq!(
-    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
+    ///     query.build_collect(&mut collector),
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, ?) > ? ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
     /// assert_eq!(
@@ -101,16 +92,5 @@ pub trait QueryStatementBuilder {
     ///     vec![Value::Int(Some(0)), Value::Int(Some(2))]
     /// );
     /// ```
-    fn build_collect<T: QueryBuilder>(
-        &self,
-        query_builder: T,
-        collector: &mut dyn FnMut(Value),
-    ) -> String;
-
-    /// Build corresponding SQL statement for certain database backend and collect query parameters
-    fn build_collect_any(
-        &self,
-        query_builder: &dyn QueryBuilder,
-        collector: &mut dyn FnMut(Value),
-    ) -> String;
+    fn build_collect(&'a self, collector: &mut dyn FnMut(&'a dyn QueryValue<DB>)) -> String;
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -11,13 +11,10 @@ pub enum SchemaStatement {
 
 pub trait SchemaStatementBuilder {
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String;
+    fn build<T: SchemaBuilder>(&self) -> String;
 
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String;
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        self.build(schema_builder)
+    fn to_string<T: SchemaBuilder>(&self) -> String {
+        self.build::<T>()
     }
 }

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -22,7 +22,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, ColumnDef, SchemaState
 ///     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
 /// );
 /// assert_eq!(
-///     table.to_string(PostgresQueryBuilder),
+///     table.to_string(),
 ///     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
 /// );
 /// assert_eq!(
@@ -91,7 +91,7 @@ impl TableAlterStatement {
     ///     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(),
     ///     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
     /// );
     /// assert_eq!(
@@ -124,7 +124,7 @@ impl TableAlterStatement {
     ///     r#"ALTER TABLE `font` MODIFY COLUMN `new_col` bigint DEFAULT 999"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(),
     ///     vec![
     ///         r#"ALTER TABLE "font""#,
     ///         r#"ALTER COLUMN "new_col" TYPE bigint,"#,
@@ -155,7 +155,7 @@ impl TableAlterStatement {
     ///     r#"ALTER TABLE `font` RENAME COLUMN `new_col` TO `new_column`"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(),
     ///     r#"ALTER TABLE "font" RENAME COLUMN "new_col" TO "new_column""#
     /// );
     /// assert_eq!(
@@ -191,7 +191,7 @@ impl TableAlterStatement {
     ///     r#"ALTER TABLE `font` DROP COLUMN `new_column`"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(),
     ///     r#"ALTER TABLE "font" DROP COLUMN "new_column""#
     /// );
     /// // Sqlite not support modifying table column
@@ -217,13 +217,8 @@ impl TableAlterStatement {
 }
 
 impl SchemaStatementBuilder for TableAlterStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
-        schema_builder.prepare_table_alter_statement(self, &mut sql);
-        sql.result()
-    }
-
-    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
+    fn build<T: SchemaBuilder>(&self) -> String {
+        let schema_builder = T::default();
         let mut sql = SqlWriter::new();
         schema_builder.prepare_table_alter_statement(self, &mut sql);
         sql.result()

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -46,7 +46,7 @@ use crate::{
 ///     ].join(" ")
 /// );
 /// assert_eq!(
-///     table.to_string(PostgresQueryBuilder),
+///     table.to_string(),
 ///     vec![
 ///         r#"CREATE TABLE IF NOT EXISTS "character" ("#,
 ///             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -203,7 +203,7 @@ impl TableCreateStatement {
     ///     .join(" ")
     /// );
     /// assert_eq!(
-    ///     statement.to_string(PostgresQueryBuilder),
+    ///     statement.to_string(),
     ///     vec![
     ///         "CREATE TABLE \"glyph\" (",
     ///         "\"id\" integer NOT NULL,",
@@ -297,13 +297,8 @@ impl TableCreateStatement {
 }
 
 impl SchemaStatementBuilder for TableCreateStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
-        schema_builder.prepare_table_create_statement(self, &mut sql);
-        sql.result()
-    }
-
-    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
+    fn build<T: SchemaBuilder>(&self) -> String {
+        let schema_builder = T::default();
         let mut sql = SqlWriter::new();
         schema_builder.prepare_table_create_statement(self, &mut sql);
         sql.result()

--- a/src/table/drop.rs
+++ b/src/table/drop.rs
@@ -17,7 +17,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"DROP TABLE `glyph`, `character`"#
 /// );
 /// assert_eq!(
-///     table.to_string(PostgresQueryBuilder),
+///     table.to_string(),
 ///     r#"DROP TABLE "glyph", "character""#
 /// );
 /// assert_eq!(
@@ -92,13 +92,8 @@ impl TableDropStatement {
 }
 
 impl SchemaStatementBuilder for TableDropStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
-        schema_builder.prepare_table_drop_statement(self, &mut sql);
-        sql.result()
-    }
-
-    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
+    fn build<T: SchemaBuilder>(&self) -> String {
+        let schema_builder = T::default();
         let mut sql = SqlWriter::new();
         schema_builder.prepare_table_drop_statement(self, &mut sql);
         sql.result()

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -68,35 +68,24 @@ impl Table {
 
 impl TableStatement {
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: SchemaBuilder>(&self, table_builder: T) -> String {
+    pub fn build<T: SchemaBuilder>(&self) -> String {
         match self {
-            Self::Create(stat) => stat.build(table_builder),
-            Self::Alter(stat) => stat.build(table_builder),
-            Self::Drop(stat) => stat.build(table_builder),
-            Self::Rename(stat) => stat.build(table_builder),
-            Self::Truncate(stat) => stat.build(table_builder),
+            Self::Create(stat) => stat.build::<T>(),
+            Self::Alter(stat) => stat.build::<T>(),
+            Self::Drop(stat) => stat.build::<T>(),
+            Self::Rename(stat) => stat.build::<T>(),
+            Self::Truncate(stat) => stat.build::<T>(),
         }
     }
 
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build_any(&self, table_builder: &dyn SchemaBuilder) -> String {
+    pub fn to_string<T: SchemaBuilder>(&self) -> String {
         match self {
-            Self::Create(stat) => stat.build_any(table_builder),
-            Self::Alter(stat) => stat.build_any(table_builder),
-            Self::Drop(stat) => stat.build_any(table_builder),
-            Self::Rename(stat) => stat.build_any(table_builder),
-            Self::Truncate(stat) => stat.build_any(table_builder),
-        }
-    }
-
-    /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: SchemaBuilder>(&self, table_builder: T) -> String {
-        match self {
-            Self::Create(stat) => stat.to_string(table_builder),
-            Self::Alter(stat) => stat.to_string(table_builder),
-            Self::Drop(stat) => stat.to_string(table_builder),
-            Self::Rename(stat) => stat.to_string(table_builder),
-            Self::Truncate(stat) => stat.to_string(table_builder),
+            Self::Create(stat) => stat.to_string::<T>(),
+            Self::Alter(stat) => stat.to_string::<T>(),
+            Self::Drop(stat) => stat.to_string::<T>(),
+            Self::Rename(stat) => stat.to_string::<T>(),
+            Self::Truncate(stat) => stat.to_string::<T>(),
         }
     }
 }

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -16,7 +16,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"RENAME TABLE `font` TO `font_new`"#
 /// );
 /// assert_eq!(
-///     table.to_string(PostgresQueryBuilder),
+///     table.to_string(),
 ///     r#"ALTER TABLE "font" RENAME TO "font_new""#
 /// );
 /// assert_eq!(
@@ -65,13 +65,8 @@ impl TableRenameStatement {
 }
 
 impl SchemaStatementBuilder for TableRenameStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
-        schema_builder.prepare_table_rename_statement(self, &mut sql);
-        sql.result()
-    }
-
-    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
+    fn build<T: SchemaBuilder>(&self) -> String {
+        let schema_builder = T::default();
         let mut sql = SqlWriter::new();
         schema_builder.prepare_table_rename_statement(self, &mut sql);
         sql.result()

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -14,7 +14,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"TRUNCATE TABLE `font`"#
 /// );
 /// assert_eq!(
-///     table.to_string(PostgresQueryBuilder),
+///     table.to_string(),
 ///     r#"TRUNCATE TABLE "font""#
 /// );
 /// assert_eq!(
@@ -56,13 +56,8 @@ impl TableTruncateStatement {
 }
 
 impl SchemaStatementBuilder for TableTruncateStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
-        schema_builder.prepare_table_truncate_statement(self, &mut sql);
-        sql.result()
-    }
-
-    fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
+    fn build<T: SchemaBuilder>(&self) -> String {
+        let schema_builder = T::default();
         let mut sql = SqlWriter::new();
         schema_builder.prepare_table_truncate_statement(self, &mut sql);
         sql.result()

--- a/src/token.rs
+++ b/src/token.rs
@@ -25,10 +25,6 @@ impl Tokenizer {
         }
     }
 
-    pub fn iter(self) -> impl Iterator<Item = Token> {
-        self
-    }
-
     fn get(&self) -> char {
         self.chars[self.p]
     }
@@ -297,7 +293,7 @@ mod tests {
     #[test]
     fn test_0() {
         let tokenizer = Tokenizer::new("");
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(tokens, vec![]);
     }
 
@@ -305,7 +301,7 @@ mod tests {
     fn test_1() {
         let string = "SELECT * FROM `character`";
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -328,7 +324,7 @@ mod tests {
     fn test_2() {
         let string = "SELECT * FROM `character` WHERE id = ?";
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -359,7 +355,7 @@ mod tests {
     fn test_3() {
         let string = r#"? = "?" "#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -381,7 +377,7 @@ mod tests {
     fn test_4() {
         let string = r#""a\"bc""#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(tokens, vec![Token::Quoted("\"a\\\"bc\"".to_string()),]);
         assert_eq!(
             string,
@@ -393,7 +389,7 @@ mod tests {
     fn test_5() {
         let string = "abc123";
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(tokens, vec![Token::Unquoted(string.to_string()),]);
         assert_eq!(
             string,
@@ -405,7 +401,7 @@ mod tests {
     fn test_6() {
         let string = "2.3*4";
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -426,7 +422,7 @@ mod tests {
     fn test_7() {
         let string = r#""a\\" B"#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -445,7 +441,7 @@ mod tests {
     fn test_8() {
         let string = r#"`a"b` "#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -463,7 +459,7 @@ mod tests {
     fn test_9() {
         let string = r#"[ab] "#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -481,7 +477,7 @@ mod tests {
     fn test_10() {
         let string = r#" 'a"b' "#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -500,7 +496,7 @@ mod tests {
     fn test_11() {
         let string = r#" `a``b` "#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -519,7 +515,7 @@ mod tests {
     fn test_12() {
         let string = r#" 'a''b' "#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -538,7 +534,7 @@ mod tests {
     fn test_13() {
         let string = r#"(?)"#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -557,7 +553,7 @@ mod tests {
     fn test_14() {
         let string = r#"($1 = $2)"#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -582,7 +578,7 @@ mod tests {
     fn test_15() {
         let string = r#" "Hello World" "#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -601,7 +597,7 @@ mod tests {
     fn test_16() {
         let string = "abc_$123";
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(tokens, vec![Token::Unquoted(string.to_string()),]);
         assert_eq!(
             string,
@@ -613,7 +609,7 @@ mod tests {
     fn test_17() {
         let string = "$abc$123";
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -631,7 +627,7 @@ mod tests {
     fn test_18() {
         let string = "_$abc_123$";
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![
@@ -672,7 +668,7 @@ mod tests {
     fn test_22() {
         let string = r#" "Hello\nWorld" "#;
         let tokenizer = Tokenizer::new(string);
-        let tokens: Vec<Token> = tokenizer.iter().collect();
+        let tokens: Vec<Token> = tokenizer.into_iter().collect();
         assert_eq!(
             tokens,
             vec![

--- a/src/types.rs
+++ b/src/types.rs
@@ -86,12 +86,12 @@ macro_rules! query_value_all {
     ( $ty: ty, |$self: ident| $query_value: block, quoted ) => {
         impl<DB> QueryValue<DB> for $ty
         where
-            DB: QueryBuilder<DB>,
+            DB: QueryBuilder<DB> + Default,
         {
             fn query_value(& $self) -> String {
                 let mut buf = String::new();
                 let string = { $query_value };
-                DB::write_string_quoted(string, &mut buf);
+                DB::default().write_string_quoted(string, &mut buf);
                 buf
             }
         }
@@ -100,7 +100,7 @@ macro_rules! query_value_all {
     ( $ty: ty, |$self: ident| $query_value: block, wrapped ) => {
         impl<DB> QueryValue<DB> for $ty
         where
-            DB: QueryBuilder<DB>,
+            DB: QueryBuilder<DB> + Default,
         {
             fn query_value(& $self) -> String {
                 QueryValue::<DB>::query_value({ $query_value })

--- a/src/value.rs
+++ b/src/value.rs
@@ -76,7 +76,7 @@ pub enum Value {
 
 impl<DB> QueryValue<DB> for Value
 where
-    DB: QueryBuilder<DB>,
+    DB: QueryBuilder<DB> + Default,
 {
     fn query_value(&self) -> String {
         let mut s = String::new();
@@ -121,7 +121,7 @@ where
             Value::BigUnsigned(Some(v)) => write!(s, "{}", v).unwrap(),
             Value::Float(Some(v)) => write!(s, "{}", v).unwrap(),
             Value::Double(Some(v)) => write!(s, "{}", v).unwrap(),
-            Value::String(Some(v)) => DB::write_string_quoted(v, &mut s),
+            Value::String(Some(v)) => DB::default().write_string_quoted(v, &mut s),
             Value::Bytes(Some(v)) => write!(
                 s,
                 "x\'{}\'",
@@ -129,7 +129,7 @@ where
             )
             .unwrap(),
             #[cfg(feature = "with-json")]
-            Value::Json(Some(v)) => DB::write_string_quoted(&v.to_string(), &mut s),
+            Value::Json(Some(v)) => DB::default().write_string_quoted(&v.to_string(), &mut s),
             #[cfg(feature = "with-chrono")]
             Value::Date(Some(v)) => write!(s, "\'{}\'", v.format("%Y-%m-%d").to_string()).unwrap(),
             #[cfg(feature = "with-chrono")]

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -2,11 +2,11 @@ use sea_query::{error::*, tests_cfg::*, *};
 
 #[test]
 fn insert_values_1() {
-    let mut insert = Query::insert();
+    let mut insert = MySqlQuery::insert();
     let result = insert
         .into_table(Glyph::Table)
         .columns(vec![Glyph::Image, Glyph::Aspect])
-        .values(vec![String::from("").into()]);
+        .values(&[&""]);
 
     assert!(result.is_err());
     assert_eq!(

--- a/tests/mysql/foreign_key.rs
+++ b/tests/mysql/foreign_key.rs
@@ -9,7 +9,7 @@ fn create_1() {
             .to(Font::Table, Font::Id)
             .on_delete(ForeignKeyAction::Cascade)
             .on_update(ForeignKeyAction::Cascade)
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         vec![
             "ALTER TABLE `character`",
             "ADD CONSTRAINT `FK_2e303c3a712662f1fc2a4d0aad6`",
@@ -26,7 +26,7 @@ fn drop_1() {
         ForeignKey::drop()
             .name("FK_2e303c3a712662f1fc2a4d0aad6")
             .table(Char::Table)
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "ALTER TABLE `character` DROP FOREIGN KEY `FK_2e303c3a712662f1fc2a4d0aad6`"
     );
 }

--- a/tests/mysql/index.rs
+++ b/tests/mysql/index.rs
@@ -7,7 +7,7 @@ fn create_1() {
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
             .col(Glyph::Aspect)
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"
     );
 }
@@ -21,7 +21,7 @@ fn create_2() {
             .table(Glyph::Table)
             .col(Glyph::Aspect)
             .col(Glyph::Image)
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "CREATE UNIQUE INDEX `idx-glyph-aspect-image` ON `glyph` (`aspect`, `image`)"
     );
 }
@@ -34,7 +34,7 @@ fn create_3() {
             .name("idx-glyph-image")
             .table(Glyph::Table)
             .col(Glyph::Image)
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "CREATE FULLTEXT INDEX `idx-glyph-image` ON `glyph` (`image`)"
     );
 }
@@ -47,7 +47,7 @@ fn create_4() {
             .name("idx-glyph-image")
             .table(Glyph::Table)
             .col(Glyph::Image)
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "CREATE INDEX `idx-glyph-image` ON `glyph` USING HASH (`image`)"
     );
 }
@@ -58,7 +58,7 @@ fn drop_1() {
         Index::drop()
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "DROP INDEX `idx-glyph-aspect` ON `glyph`"
     );
 }

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -3,12 +3,12 @@ use super::*;
 #[test]
 fn select_1() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
             .limit(10)
             .offset(100)
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` LIMIT 10 OFFSET 100"
     );
 }
@@ -16,11 +16,11 @@ fn select_1() {
 #[test]
 fn select_2() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .to_string(MysqlQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3"
     );
 }
@@ -28,14 +28,14 @@ fn select_2() {
 #[test]
 fn select_3() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Char::Character, Char::SizeW, Char::SizeH
             ])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .and_where(Expr::col(Char::SizeH).eq(4))
-            .to_string(MysqlQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .and_where(Expr::col(Char::SizeH).eq(&4))
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 AND `size_h` = 4"
     );
 }
@@ -43,16 +43,16 @@ fn select_3() {
 #[test]
 fn select_4() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![Glyph::Image])
             .from_subquery(
-                Query::select()
+                MySqlQuery::select()
                     .columns(vec![Glyph::Image, Glyph::Aspect])
                     .from(Glyph::Table)
                     .take(),
                 Alias::new("subglyph")
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `image` FROM (SELECT `image`, `aspect` FROM `glyph`) AS `subglyph`"
     );
 }
@@ -60,11 +60,11 @@ fn select_4() {
 #[test]
 fn select_5() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .column((Glyph::Table, Glyph::Image))
             .from(Glyph::Table)
-            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
-            .to_string(MysqlQueryBuilder),
+            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![&3, &4]))
+            .to_string(),
         "SELECT `glyph`.`image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4)"
     );
 }
@@ -72,13 +72,13 @@ fn select_5() {
 #[test]
 fn select_6() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![Glyph::Aspect,])
             .exprs(vec![Expr::col(Glyph::Image).max(),])
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
-            .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(MysqlQueryBuilder),
+            .and_having(Expr::col(Glyph::Aspect).gt(&2))
+            .to_string(),
         "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` > 2"
     );
 }
@@ -86,11 +86,11 @@ fn select_6() {
 #[test]
 fn select_7() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![Glyph::Aspect,])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .to_string(MysqlQueryBuilder),
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
+            .to_string(),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2"
     );
 }
@@ -98,13 +98,13 @@ fn select_7() {
 #[test]
 fn select_8() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Char::Character,
             ])
             .from(Char::Table)
             .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id`"
     );
 }
@@ -112,14 +112,14 @@ fn select_8() {
 #[test]
 fn select_9() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Char::Character,
             ])
             .from(Char::Table)
             .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
             .inner_join(Glyph::Table, Expr::tbl(Char::Table, Char::Character).equals(Glyph::Table, Glyph::Image))
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` INNER JOIN `glyph` ON `character`.`character` = `glyph`.`image`"
     );
 }
@@ -127,7 +127,7 @@ fn select_9() {
 #[test]
 fn select_10() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Char::Character,
             ])
@@ -136,7 +136,7 @@ fn select_10() {
                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
                 .and(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON (`character`.`font_id` = `font`.`id`) AND (`character`.`font_id` = `font`.`id`)"
     );
 }
@@ -144,15 +144,15 @@ fn select_10() {
 #[test]
 fn select_11() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
             .order_by(Glyph::Image, Order::Desc)
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"
     );
 }
@@ -160,17 +160,17 @@ fn select_11() {
 #[test]
 fn select_12() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
             .order_by_columns(vec![
                 (Glyph::Id, Order::Asc),
                 (Glyph::Aspect, Order::Desc),
             ])
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `id` ASC, `aspect` DESC"
     );
 }
@@ -178,17 +178,17 @@ fn select_12() {
 #[test]
 fn select_13() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
             .order_by_columns(vec![
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
             ])
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `glyph`.`id` ASC, `glyph`.`aspect` DESC"
     );
 }
@@ -196,7 +196,7 @@ fn select_13() {
 #[test]
 fn select_14() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Glyph::Id,
                 Glyph::Aspect,
@@ -207,8 +207,8 @@ fn select_14() {
                 (Glyph::Table, Glyph::Id),
                 (Glyph::Table, Glyph::Aspect),
             ])
-            .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(MysqlQueryBuilder),
+            .and_having(Expr::col(Glyph::Aspect).gt(&2))
+            .to_string(),
         "SELECT `id`, `aspect`, MAX(`image`) FROM `glyph` GROUP BY `glyph`.`id`, `glyph`.`aspect` HAVING `aspect` > 2"
     );
 }
@@ -216,11 +216,11 @@ fn select_14() {
 #[test]
 fn select_15() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `font_id` IS NULL"
     );
 }
@@ -228,12 +228,12 @@ fn select_15() {
 #[test]
 fn select_16() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
             .and_where(Expr::col(Char::Character).is_not_null())
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `font_id` IS NULL AND `character` IS NOT NULL"
     );
 }
@@ -241,11 +241,11 @@ fn select_16() {
 #[test]
 fn select_17() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![(Glyph::Table, Glyph::Image),])
             .from(Glyph::Table)
-            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).between(3, 5))
-            .to_string(MysqlQueryBuilder),
+            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).between(&3, &5))
+            .to_string(),
         "SELECT `glyph`.`image` FROM `glyph` WHERE `glyph`.`aspect` BETWEEN 3 AND 5"
     );
 }
@@ -253,14 +253,14 @@ fn select_17() {
 #[test]
 fn select_18() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::col(Glyph::Aspect).between(3, 5))
-            .and_where(Expr::col(Glyph::Aspect).not_between(8, 10))
-            .to_string(MysqlQueryBuilder),
+            .and_where(Expr::col(Glyph::Aspect).between(&3, &5))
+            .and_where(Expr::col(Glyph::Aspect).not_between(&8, &10))
+            .to_string(),
         "SELECT `aspect` FROM `glyph` WHERE (`aspect` BETWEEN 3 AND 5) AND (`aspect` NOT BETWEEN 8 AND 10)"
     );
 }
@@ -268,11 +268,11 @@ fn select_18() {
 #[test]
 fn select_19() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![Char::Character])
             .from(Char::Table)
-            .and_where(Expr::col(Char::Character).eq("A"))
-            .to_string(MysqlQueryBuilder),
+            .and_where(Expr::col(Char::Character).eq(&"A"))
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `character` = 'A'"
     );
 }
@@ -280,11 +280,11 @@ fn select_19() {
 #[test]
 fn select_20() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .column(Char::Character)
             .from(Char::Table)
-            .and_where(Expr::col(Char::Character).like("A"))
-            .to_string(MysqlQueryBuilder),
+            .and_where(Expr::col(Char::Character).like(&"A"))
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `character` LIKE 'A'"
     );
 }
@@ -292,15 +292,15 @@ fn select_20() {
 #[test]
 fn select_21() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Char::Character
             ])
             .from(Char::Table)
-            .or_where(Expr::col(Char::Character).like("A%"))
-            .or_where(Expr::col(Char::Character).like("%B"))
-            .or_where(Expr::col(Char::Character).like("%C%"))
-            .to_string(MysqlQueryBuilder),
+            .or_where(Expr::col(Char::Character).like(&"A%"))
+            .or_where(Expr::col(Char::Character).like(&"%B"))
+            .or_where(Expr::col(Char::Character).like(&"%C%"))
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `character` LIKE 'A%' OR `character` LIKE '%B' OR `character` LIKE '%C%'"
     );
 }
@@ -308,21 +308,21 @@ fn select_21() {
 #[test]
 fn select_22() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .cond_where(
                 Cond::all()
                 .add(
                     Cond::any()
-                    .add(Expr::col(Char::Character).like("C"))
-                    .add(Expr::col(Char::Character).like("D").and(Expr::col(Char::Character).like("E")))
+                    .add(Expr::col(Char::Character).like(&"C"))
+                    .add(Expr::col(Char::Character).like(&"D").and(Expr::col(Char::Character).like(&"E")))
                 )
                 .add(
-                    Expr::col(Char::Character).like("F").or(Expr::col(Char::Character).like("G"))
+                    Expr::col(Char::Character).like(&"F").or(Expr::col(Char::Character).like(&"G"))
                 )
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE (`character` LIKE 'C' OR ((`character` LIKE 'D') AND (`character` LIKE 'E'))) AND ((`character` LIKE 'F') OR (`character` LIKE 'G'))"
     );
 }
@@ -330,11 +330,11 @@ fn select_22() {
 #[test]
 fn select_23() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .and_where_option(None)
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character`"
     );
 }
@@ -342,17 +342,17 @@ fn select_23() {
 #[test]
 fn select_24() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .conditions(
                 true,
                 |x| {
-                    x.and_where(Expr::col(Char::FontId).eq(5));
+                    x.and_where(Expr::col(Char::FontId).eq(&5));
                 },
                 |_| ()
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `font_id` = 5"
     );
 }
@@ -360,15 +360,15 @@ fn select_24() {
 #[test]
 fn select_25() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .and_where(
                 Expr::col(Char::SizeW)
-                    .mul(2)
-                    .equals(Expr::col(Char::SizeH).div(2))
+                    .mul(&2)
+                    .equals(Expr::col(Char::SizeH).div(&2))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `size_w` * 2 = `size_h` / 2"
     );
 }
@@ -376,15 +376,15 @@ fn select_25() {
 #[test]
 fn select_26() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .and_where(
-                Expr::expr(Expr::col(Char::SizeW).add(1))
-                    .mul(2)
-                    .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+                Expr::expr(Expr::col(Char::SizeW).add(&1))
+                    .mul(&2)
+                    .equals(Expr::expr(Expr::col(Char::SizeH).div(&2)).sub(&1))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE (`size_w` + 1) * 2 = (`size_h` / 2) - 1"
     );
 }
@@ -392,15 +392,15 @@ fn select_26() {
 #[test]
 fn select_27() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Char::Character, Char::SizeW, Char::SizeH
             ])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .and_where(Expr::col(Char::SizeH).eq(4))
-            .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(MysqlQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .and_where(Expr::col(Char::SizeH).eq(&4))
+            .and_where(Expr::col(Char::SizeH).eq(&5))
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 AND `size_h` = 4 AND `size_h` = 5"
     );
 }
@@ -408,15 +408,15 @@ fn select_27() {
 #[test]
 fn select_28() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Char::Character, Char::SizeW, Char::SizeH
             ])
             .from(Char::Table)
-            .or_where(Expr::col(Char::SizeW).eq(3))
-            .or_where(Expr::col(Char::SizeH).eq(4))
-            .or_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(MysqlQueryBuilder),
+            .or_where(Expr::col(Char::SizeW).eq(&3))
+            .or_where(Expr::col(Char::SizeH).eq(&4))
+            .or_where(Expr::col(Char::SizeH).eq(&5))
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 OR `size_h` = 4 OR `size_h` = 5"
     );
 }
@@ -425,15 +425,15 @@ fn select_28() {
 #[should_panic]
 fn select_29() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Char::Character, Char::SizeW, Char::SizeH
             ])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .or_where(Expr::col(Char::SizeH).eq(4))
-            .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(MysqlQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .or_where(Expr::col(Char::SizeH).eq(&4))
+            .and_where(Expr::col(Char::SizeH).eq(&5))
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 OR `size_h` = 4 AND `size_h` = 5"
     );
 }
@@ -441,17 +441,17 @@ fn select_29() {
 #[test]
 fn select_30() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![
                 Char::Character, Char::SizeW, Char::SizeH
             ])
             .from(Char::Table)
             .and_where(
-                Expr::col(Char::SizeW).mul(2)
-                    .add(Expr::col(Char::SizeH).div(3))
-                    .equals(Expr::value(4))
+                Expr::col(Char::SizeW).mul(&2)
+                    .add(Expr::col(Char::SizeH).div(&3))
+                    .equals(Expr::value(&4))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE (`size_w` * 2) + (`size_h` / 3) = 4"
     );
 }
@@ -459,9 +459,15 @@ fn select_30() {
 #[test]
 fn select_31() {
     assert_eq!(
-        Query::select()
-            .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(Expr::value(i)) }))
-            .to_string(MysqlQueryBuilder),
+        MySqlQuery::select()
+            .expr(
+                (1..10_i32)
+                    .into_iter()
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .fold(Expr::value(&0), |expr, i| { expr.add(Expr::value(i)) })
+            )
+            .to_string(),
         "SELECT 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9"
     );
 }
@@ -469,10 +475,10 @@ fn select_31() {
 #[test]
 fn select_32() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .expr_as(Expr::col(Char::Character), Alias::new("C"))
             .from(Char::Table)
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `character` AS `C` FROM `character`"
     );
 }
@@ -480,14 +486,14 @@ fn select_32() {
 #[test]
 fn select_33() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .column(Glyph::Image)
             .from(Glyph::Table)
             .and_where(
                 Expr::col(Glyph::Aspect)
                     .in_subquery(Query::select().expr(Expr::cust("3 + 2 * 2")).take())
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "SELECT `image` FROM `glyph` WHERE `aspect` IN (SELECT 3 + 2 * 2)"
     );
 }
@@ -495,23 +501,23 @@ fn select_33() {
 #[test]
 fn select_34a() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .column(Glyph::Aspect)
             .expr(Expr::col(Glyph::Image).max())
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
             .or_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(2)
-                    .or(Expr::col(Glyph::Aspect).lt(8))
+                    .gt(&2)
+                    .or(Expr::col(Glyph::Aspect).lt(&8))
             )
             .or_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(12)
-                    .and(Expr::col(Glyph::Aspect).lt(18))
+                    .gt(&12)
+                    .and(Expr::col(Glyph::Aspect).lt(&18))
             )
-            .or_having(Expr::col(Glyph::Aspect).gt(32))
-            .to_string(MysqlQueryBuilder),
+            .or_having(Expr::col(Glyph::Aspect).gt(&32))
+            .to_string(),
         vec![
             "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect`",
             "HAVING ((`aspect` > 2) OR (`aspect` < 8))",
@@ -526,22 +532,22 @@ fn select_34a() {
 #[should_panic]
 fn select_34b() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .column(Glyph::Aspect)
             .expr(Expr::col(Glyph::Image).max())
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
             .or_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(2)
-                    .or(Expr::col(Glyph::Aspect).lt(8))
+                    .gt(&2)
+                    .or(Expr::col(Glyph::Aspect).lt(&8))
             )
             .and_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(22)
-                    .or(Expr::col(Glyph::Aspect).lt(28))
+                    .gt(&22)
+                    .or(Expr::col(Glyph::Aspect).lt(&28))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         vec![
             "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect`",
             "HAVING ((`aspect` > 2) OR (`aspect` < 8))",
@@ -553,49 +559,53 @@ fn select_34b() {
 
 #[test]
 fn select_35() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = MySqlQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .and_where(Expr::col(Glyph::Aspect).is_null())
-        .build(sea_query::MysqlQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT `id` FROM `glyph` WHERE `aspect` IS NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_36() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = MySqlQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Expr::col(Glyph::Aspect).is_null()))
-        .build(sea_query::MysqlQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT `id` FROM `glyph` WHERE `aspect` IS NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_37() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = MySqlQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
-        .build(sea_query::MysqlQueryBuilder);
+        .build();
 
     assert_eq!(statement, r#"SELECT `id` FROM `glyph`"#);
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_38() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = MySqlQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
@@ -603,18 +613,19 @@ fn select_38() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::MysqlQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT `id` FROM `glyph` WHERE `aspect` IS NULL OR `aspect` IS NOT NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_39() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = MySqlQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
@@ -622,28 +633,28 @@ fn select_39() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::MysqlQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT `id` FROM `glyph` WHERE `aspect` IS NULL AND `aspect` IS NOT NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_40() {
-    let statement = sea_query::Query::select()
+    let statement = MySqlQuery::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(any![
             Expr::col(Glyph::Aspect).is_null(),
             all![
                 Expr::col(Glyph::Aspect).is_not_null(),
-                Expr::col(Glyph::Aspect).lt(8)
+                Expr::col(Glyph::Aspect).lt(&8)
             ]
         ])
-        .to_string(sea_query::MysqlQueryBuilder);
+        .to_string();
 
     assert_eq!(
         statement,
@@ -654,28 +665,28 @@ fn select_40() {
 #[test]
 fn select_41() {
     assert_eq!(
-        Query::select()
+        MySqlQuery::select()
             .columns(vec![Glyph::Aspect])
             .exprs(vec![Expr::col(Glyph::Image).max()])
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect])
-            .cond_having(any![Expr::col(Glyph::Aspect).gt(2)])
-            .to_string(MysqlQueryBuilder),
+            .cond_having(any![Expr::col(Glyph::Aspect).gt(&2)])
+            .to_string(),
         "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` > 2"
     );
 }
 
 #[test]
 fn select_42() {
-    let statement = sea_query::Query::select()
+    let statement = MySqlQuery::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
             Cond::all()
-                .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
+                .add_option(Some(Expr::col(Glyph::Aspect).lt(&8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(MysqlQueryBuilder);
+        .to_string();
 
     assert_eq!(
         statement,
@@ -685,11 +696,11 @@ fn select_42() {
 
 #[test]
 fn select_43() {
-    let statement = sea_query::Query::select()
+    let statement = MySqlQuery::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
-        .cond_where(Cond::all().add_option::<SimpleExpr>(None))
-        .to_string(MysqlQueryBuilder);
+        .cond_where(Cond::all().add_option::<SimpleExpr<'_, _>>(None))
+        .to_string();
 
     assert_eq!(statement, "SELECT `id` FROM `glyph`");
 }
@@ -698,17 +709,17 @@ fn select_43() {
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(
-        Query::insert()
+        MySqlQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![
                 Glyph::Image,
                 Glyph::Aspect,
             ])
-            .values_panic(vec![
-                "04108048005887010020060000204E0180400400".into(),
-                3.1415.into(),
+            .values_panic(&[
+                &"04108048005887010020060000204E0180400400",
+                &3.1415,
             ])
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "INSERT INTO `glyph` (`image`, `aspect`) VALUES ('04108048005887010020060000204E0180400400', 3.1415)"
     );
 }
@@ -717,21 +728,21 @@ fn insert_2() {
 #[allow(clippy::approx_constant)]
 fn insert_3() {
     assert_eq!(
-        Query::insert()
+        MySqlQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![
                 Glyph::Image,
                 Glyph::Aspect,
             ])
-            .values_panic(vec![
-                "04108048005887010020060000204E0180400400".into(),
-                3.1415.into(),
+            .values_panic(&[
+                &"04108048005887010020060000204E0180400400",
+                &3.1415,
             ])
-            .values_panic(vec![
-                Value::String(None),
-                2.1345.into(),
+            .values_panic(&[
+                &Value::String(None),
+                &2.1345,
             ])
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "INSERT INTO `glyph` (`image`, `aspect`) VALUES ('04108048005887010020060000204E0180400400', 3.1415), (NULL, 2.1345)"
     );
 }
@@ -740,11 +751,11 @@ fn insert_3() {
 #[cfg(feature = "with-chrono")]
 fn insert_4() {
     assert_eq!(
-        Query::insert()
+        MySqlQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![Glyph::Image])
-            .values_panic(vec![chrono::NaiveDateTime::from_timestamp(0, 0).into()])
-            .to_string(MysqlQueryBuilder),
+            .values_panic(&[&chrono::NaiveDateTime::from_timestamp(0, 0)])
+            .to_string(),
         "INSERT INTO `glyph` (`image`) VALUES ('1970-01-01 00:00:00')"
     );
 }
@@ -753,45 +764,46 @@ fn insert_4() {
 #[cfg(feature = "with-uuid")]
 fn insert_5() {
     assert_eq!(
-        Query::insert()
+        MySqlQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![Glyph::Image])
-            .values_panic(vec![uuid::Uuid::nil().into()])
-            .to_string(MysqlQueryBuilder),
+            .values_panic(&[&uuid::Uuid::nil()])
+            .to_string(),
         "INSERT INTO `glyph` (`image`) VALUES ('00000000-0000-0000-0000-000000000000')"
     );
 }
 
 #[test]
 fn update_1() {
+    let values: Vec<(_, &dyn QueryValue<MySqlQueryBuilder>)> = vec![
+        (Glyph::Aspect, &2.1345),
+        (Glyph::Image, &"24B0E11951B03B07F8300FD003983F03F0780060"),
+    ];
     assert_eq!(
-        Query::update()
+        MySqlQuery::update()
             .table(Glyph::Table)
-            .values(vec![
-                (Glyph::Aspect, 2.1345.into()),
-                (Glyph::Image, "24B0E11951B03B07F8300FD003983F03F0780060".into()),
-            ])
-            .and_where(Expr::col(Glyph::Id).eq(1))
+            .values(values)
+            .and_where(Expr::col(Glyph::Id).eq(&1))
             .order_by(Glyph::Id, Order::Asc)
             .limit(1)
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "UPDATE `glyph` SET `aspect` = 2.1345, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1 ORDER BY `id` ASC LIMIT 1"
     );
 }
 
 #[test]
 fn update_3() {
+    let values: Vec<(_, &dyn QueryValue<MySqlQueryBuilder>)> =
+        vec![(Glyph::Image, &"24B0E11951B03B07F8300FD003983F03F0780060")];
     assert_eq!(
-        Query::update()
+        MySqlQuery::update()
             .table(Glyph::Table)
             .value_expr(Glyph::Aspect, Expr::cust("60 * 24 * 24"))
-            .values(vec![
-                (Glyph::Image, "24B0E11951B03B07F8300FD003983F03F0780060".into()),
-            ])
-            .and_where(Expr::col(Glyph::Id).eq(1))
+            .values(values)
+            .and_where(Expr::col(Glyph::Id).eq(&1))
             .order_by(Glyph::Id, Order::Asc)
             .limit(1)
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "UPDATE `glyph` SET `aspect` = 60 * 24 * 24, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1 ORDER BY `id` ASC LIMIT 1"
     );
 }
@@ -799,12 +811,12 @@ fn update_3() {
 #[test]
 fn delete_1() {
     assert_eq!(
-        Query::delete()
+        MySqlQuery::delete()
             .from_table(Glyph::Table)
-            .and_where(Expr::col(Glyph::Id).eq(1))
+            .and_where(Expr::col(Glyph::Id).eq(&1))
             .order_by(Glyph::Id, Order::Asc)
             .limit(1)
-            .to_string(MysqlQueryBuilder),
+            .to_string(),
         "DELETE FROM `glyph` WHERE `id` = 1 ORDER BY `id` ASC LIMIT 1"
     );
 }

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -17,7 +17,7 @@ fn create_1() {
             .engine("InnoDB")
             .character_set("utf8mb4")
             .collate("utf8mb4_unicode_ci")
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         vec![
             "CREATE TABLE `glyph` (",
             "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
@@ -47,7 +47,7 @@ fn create_2() {
             .engine("InnoDB")
             .character_set("utf8mb4")
             .collate("utf8mb4_unicode_ci")
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         vec![
             "CREATE TABLE `font` (",
             "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
@@ -93,7 +93,7 @@ fn create_3() {
             .engine("InnoDB")
             .character_set("utf8mb4")
             .collate("utf8mb4_unicode_ci")
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         vec![
             "CREATE TABLE IF NOT EXISTS `character` (",
             "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
@@ -122,7 +122,7 @@ fn create_4() {
                     .not_null()
                     .extra("ANYTHING I WANT TO SAY".to_owned())
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         vec![
             "CREATE TABLE `glyph` (",
             "`id` int NOT NULL ANYTHING I WANT TO SAY",
@@ -139,7 +139,7 @@ fn create_5() {
             .table(Glyph::Table)
             .col(ColumnDef::new(Glyph::Id).integer().not_null())
             .index(Index::create().unique().name("idx-glyph-id").col(Glyph::Id))
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         vec![
             "CREATE TABLE `glyph` (",
             "`id` int NOT NULL,",
@@ -157,7 +157,7 @@ fn drop_1() {
             .table(Glyph::Table)
             .table(Char::Table)
             .cascade()
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "DROP TABLE `glyph`, `character` CASCADE"
     );
 }
@@ -167,7 +167,7 @@ fn truncate_1() {
     assert_eq!(
         Table::truncate()
             .table(Font::Table)
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "TRUNCATE TABLE `font`"
     );
 }
@@ -183,7 +183,7 @@ fn alter_1() {
                     .not_null()
                     .default(100)
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"
     );
 }
@@ -198,7 +198,7 @@ fn alter_2() {
                     .big_integer()
                     .default(999)
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "ALTER TABLE `font` MODIFY COLUMN `new_col` bigint DEFAULT 999"
     );
 }
@@ -209,7 +209,7 @@ fn alter_3() {
         Table::alter()
             .table(Font::Table)
             .rename_column(Alias::new("new_col"), Alias::new("new_column"))
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "ALTER TABLE `font` RENAME COLUMN `new_col` TO `new_column`"
     );
 }
@@ -220,7 +220,7 @@ fn alter_4() {
         Table::alter()
             .table(Font::Table)
             .drop_column(Alias::new("new_column"))
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "ALTER TABLE `font` DROP COLUMN `new_column`"
     );
 }
@@ -230,7 +230,7 @@ fn alter_5() {
     assert_eq!(
         Table::rename()
             .table(Font::Table, Alias::new("font_new"))
-            .to_string(MysqlQueryBuilder),
+            .to_string::<MysqlQueryBuilder>(),
         "RENAME TABLE `font` TO `font_new`"
     );
 }
@@ -238,5 +238,5 @@ fn alter_5() {
 #[test]
 #[should_panic(expected = "No alter option found")]
 fn alter_6() {
-    Table::alter().to_string(MysqlQueryBuilder);
+    Table::alter().to_string::<MysqlQueryBuilder>();
 }

--- a/tests/postgres/foreign_key.rs
+++ b/tests/postgres/foreign_key.rs
@@ -9,7 +9,7 @@ fn create_1() {
             .to(Font::Table, Font::Id)
             .on_delete(ForeignKeyAction::Cascade)
             .on_update(ForeignKeyAction::Cascade)
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         vec![
             r#"ALTER TABLE "character" ADD CONSTRAINT "FK_2e303c3a712662f1fc2a4d0aad6""#,
             r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
@@ -25,7 +25,7 @@ fn drop_1() {
         ForeignKey::drop()
             .name("FK_2e303c3a712662f1fc2a4d0aad6")
             .table(Char::Table)
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"ALTER TABLE "character" DROP CONSTRAINT "FK_2e303c3a712662f1fc2a4d0aad6""#
     );
 }

--- a/tests/postgres/index.rs
+++ b/tests/postgres/index.rs
@@ -7,7 +7,7 @@ fn create_1() {
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
             .col(Glyph::Aspect)
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
     );
 }
@@ -21,7 +21,7 @@ fn create_2() {
             .table(Glyph::Table)
             .col(Glyph::Aspect)
             .col(Glyph::Image)
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"CREATE UNIQUE INDEX "idx-glyph-aspect-image" ON "glyph" ("aspect", "image")"#
     );
 }
@@ -34,7 +34,7 @@ fn create_3() {
             .name("idx-glyph-image")
             .table(Glyph::Table)
             .col(Glyph::Image)
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"CREATE INDEX "idx-glyph-image" ON "glyph" USING GIN ("image")"#
     );
 }
@@ -44,7 +44,7 @@ fn drop_1() {
     assert_eq!(
         Index::drop()
             .name("idx-glyph-aspect")
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"DROP INDEX "idx-glyph-aspect""#
     );
 }

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -3,12 +3,12 @@ use super::*;
 #[test]
 fn select_1() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
             .limit(10)
             .offset(100)
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character", "size_w", "size_h" FROM "character" LIMIT 10 OFFSET 100"#
     );
 }
@@ -16,11 +16,11 @@ fn select_1() {
 #[test]
 fn select_2() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .to_string(),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3"#
     );
 }
@@ -28,12 +28,12 @@ fn select_2() {
 #[test]
 fn select_3() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .and_where(Expr::col(Char::SizeH).eq(4))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .and_where(Expr::col(Char::SizeH).eq(&4))
+            .to_string(),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 AND "size_h" = 4"#
     );
 }
@@ -41,16 +41,16 @@ fn select_3() {
 #[test]
 fn select_4() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Glyph::Aspect])
             .from_subquery(
-                Query::select()
+                PgQuery::select()
                     .columns(vec![Glyph::Image, Glyph::Aspect])
                     .from(Glyph::Table)
                     .take(),
                 Alias::new("subglyph")
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "aspect" FROM (SELECT "image", "aspect" FROM "glyph") AS "subglyph""#
     );
 }
@@ -58,11 +58,11 @@ fn select_4() {
 #[test]
 fn select_5() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .column((Glyph::Table, Glyph::Image))
             .from(Glyph::Table)
-            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![&3, &4]))
+            .to_string(),
         r#"SELECT "glyph"."image" FROM "glyph" WHERE "glyph"."aspect" IN (3, 4)"#
     );
 }
@@ -70,13 +70,13 @@ fn select_5() {
 #[test]
 fn select_6() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Glyph::Aspect,])
             .exprs(vec![Expr::col(Glyph::Image).max(),])
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
-            .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(PostgresQueryBuilder),
+            .and_having(Expr::col(Glyph::Aspect).gt(&2))
+            .to_string(),
         r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2"#
     );
 }
@@ -84,11 +84,11 @@ fn select_6() {
 #[test]
 fn select_7() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Glyph::Aspect,])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
+            .to_string(),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2"#
     );
 }
@@ -96,14 +96,14 @@ fn select_7() {
 #[test]
 fn select_8() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character,])
             .from(Char::Table)
             .left_join(
                 Font::Table,
                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id""#
     );
 }
@@ -111,7 +111,7 @@ fn select_8() {
 #[test]
 fn select_9() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character,])
             .from(Char::Table)
             .left_join(
@@ -122,7 +122,7 @@ fn select_9() {
                 Glyph::Table,
                 Expr::tbl(Char::Table, Char::Character).equals(Glyph::Table, Glyph::Image)
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" INNER JOIN "glyph" ON "character"."character" = "glyph"."image""#
     );
 }
@@ -130,7 +130,7 @@ fn select_9() {
 #[test]
 fn select_10() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character,])
             .from(Char::Table)
             .left_join(
@@ -139,7 +139,7 @@ fn select_10() {
                     .equals(Font::Table, Font::Id)
                     .and(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON ("character"."font_id" = "font"."id") AND ("character"."font_id" = "font"."id")"#
     );
 }
@@ -147,13 +147,13 @@ fn select_10() {
 #[test]
 fn select_11() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Glyph::Aspect,])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
             .order_by(Glyph::Image, Order::Desc)
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2 ORDER BY "image" DESC, "glyph"."aspect" ASC"#
     );
 }
@@ -161,12 +161,12 @@ fn select_11() {
 #[test]
 fn select_12() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Glyph::Aspect,])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
             .order_by_columns(vec![(Glyph::Id, Order::Asc), (Glyph::Aspect, Order::Desc),])
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2 ORDER BY "id" ASC, "aspect" DESC"#
     );
 }
@@ -174,15 +174,15 @@ fn select_12() {
 #[test]
 fn select_13() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Glyph::Aspect,])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
             .order_by_columns(vec![
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
             ])
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2 ORDER BY "glyph"."id" ASC, "glyph"."aspect" DESC"#
     );
 }
@@ -190,7 +190,7 @@ fn select_13() {
 #[test]
 fn select_14() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Glyph::Id, Glyph::Aspect,])
             .expr(Expr::col(Glyph::Image).max())
             .from(Glyph::Table)
@@ -198,8 +198,8 @@ fn select_14() {
                 (Glyph::Table, Glyph::Id),
                 (Glyph::Table, Glyph::Aspect),
             ])
-            .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(PostgresQueryBuilder),
+            .and_having(Expr::col(Glyph::Aspect).gt(&2))
+            .to_string(),
         r#"SELECT "id", "aspect", MAX("image") FROM "glyph" GROUP BY "glyph"."id", "glyph"."aspect" HAVING "aspect" > 2"#
     );
 }
@@ -207,11 +207,11 @@ fn select_14() {
 #[test]
 fn select_15() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" FROM "character" WHERE "font_id" IS NULL"#
     );
 }
@@ -219,12 +219,12 @@ fn select_15() {
 #[test]
 fn select_16() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
             .and_where(Expr::col(Char::Character).is_not_null())
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" FROM "character" WHERE "font_id" IS NULL AND "character" IS NOT NULL"#
     );
 }
@@ -232,11 +232,11 @@ fn select_16() {
 #[test]
 fn select_17() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![(Glyph::Table, Glyph::Image),])
             .from(Glyph::Table)
-            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).between(3, 5))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).between(&3, &5))
+            .to_string(),
         r#"SELECT "glyph"."image" FROM "glyph" WHERE "glyph"."aspect" BETWEEN 3 AND 5"#
     );
 }
@@ -244,12 +244,12 @@ fn select_17() {
 #[test]
 fn select_18() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Glyph::Aspect,])
             .from(Glyph::Table)
-            .and_where(Expr::col(Glyph::Aspect).between(3, 5))
-            .and_where(Expr::col(Glyph::Aspect).not_between(8, 10))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::col(Glyph::Aspect).between(&3, &5))
+            .and_where(Expr::col(Glyph::Aspect).not_between(&8, &10))
+            .to_string(),
         r#"SELECT "aspect" FROM "glyph" WHERE ("aspect" BETWEEN 3 AND 5) AND ("aspect" NOT BETWEEN 8 AND 10)"#
     );
 }
@@ -257,11 +257,11 @@ fn select_18() {
 #[test]
 fn select_19() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character])
             .from(Char::Table)
-            .and_where(Expr::col(Char::Character).eq("A"))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::col(Char::Character).eq(&"A"))
+            .to_string(),
         r#"SELECT "character" FROM "character" WHERE "character" = 'A'"#
     );
 }
@@ -269,11 +269,11 @@ fn select_19() {
 #[test]
 fn select_20() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .column(Char::Character)
             .from(Char::Table)
-            .and_where(Expr::col(Char::Character).like("A"))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::col(Char::Character).like(&"A"))
+            .to_string(),
         r#"SELECT "character" FROM "character" WHERE "character" LIKE 'A'"#
     );
 }
@@ -281,13 +281,13 @@ fn select_20() {
 #[test]
 fn select_21() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character])
             .from(Char::Table)
-            .or_where(Expr::col(Char::Character).like("A%"))
-            .or_where(Expr::col(Char::Character).like("%B"))
-            .or_where(Expr::col(Char::Character).like("%C%"))
-            .to_string(PostgresQueryBuilder),
+            .or_where(Expr::col(Char::Character).like(&"A%"))
+            .or_where(Expr::col(Char::Character).like(&"%B"))
+            .or_where(Expr::col(Char::Character).like(&"%C%"))
+            .to_string(),
         r#"SELECT "character" FROM "character" WHERE "character" LIKE 'A%' OR "character" LIKE '%B' OR "character" LIKE '%C%'"#
     );
 }
@@ -295,25 +295,25 @@ fn select_21() {
 #[test]
 fn select_22() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .cond_where(
                 Cond::all()
                     .add(
-                        Cond::any().add(Expr::col(Char::Character).like("C")).add(
+                        Cond::any().add(Expr::col(Char::Character).like(&"C")).add(
                             Expr::col(Char::Character)
-                                .like("D")
-                                .and(Expr::col(Char::Character).like("E"))
+                                .like(&"D")
+                                .and(Expr::col(Char::Character).like(&"E"))
                         )
                     )
                     .add(
                         Expr::col(Char::Character)
-                            .like("F")
-                            .or(Expr::col(Char::Character).like("G"))
+                            .like(&"F")
+                            .or(Expr::col(Char::Character).like(&"G"))
                     )
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR (("character" LIKE 'D') AND ("character" LIKE 'E'))) AND (("character" LIKE 'F') OR ("character" LIKE 'G'))"#
     );
 }
@@ -321,11 +321,11 @@ fn select_22() {
 #[test]
 fn select_23() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .and_where_option(None)
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" FROM "character""#
     );
 }
@@ -333,17 +333,17 @@ fn select_23() {
 #[test]
 fn select_24() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .conditions(
                 true,
                 |x| {
-                    x.and_where(Expr::col(Char::FontId).eq(5));
+                    x.and_where(Expr::col(Char::FontId).eq(&5));
                 },
                 |_| ()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" FROM "character" WHERE "font_id" = 5"#
     );
 }
@@ -351,15 +351,15 @@ fn select_24() {
 #[test]
 fn select_25() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .and_where(
                 Expr::col(Char::SizeW)
-                    .mul(2)
-                    .equals(Expr::col(Char::SizeH).div(2))
+                    .mul(&2)
+                    .equals(Expr::col(Char::SizeH).div(&2))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" FROM "character" WHERE "size_w" * 2 = "size_h" / 2"#
     );
 }
@@ -367,15 +367,15 @@ fn select_25() {
 #[test]
 fn select_26() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .and_where(
-                Expr::expr(Expr::col(Char::SizeW).add(1))
-                    .mul(2)
-                    .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+                Expr::expr(Expr::col(Char::SizeW).add(&1))
+                    .mul(&2)
+                    .equals(Expr::expr(Expr::col(Char::SizeH).div(&2)).sub(&1))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" FROM "character" WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#
     );
 }
@@ -383,13 +383,13 @@ fn select_26() {
 #[test]
 fn select_27() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .and_where(Expr::col(Char::SizeH).eq(4))
-            .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .and_where(Expr::col(Char::SizeH).eq(&4))
+            .and_where(Expr::col(Char::SizeH).eq(&5))
+            .to_string(),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 AND "size_h" = 4 AND "size_h" = 5"#
     );
 }
@@ -397,13 +397,13 @@ fn select_27() {
 #[test]
 fn select_28() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
-            .or_where(Expr::col(Char::SizeW).eq(3))
-            .or_where(Expr::col(Char::SizeH).eq(4))
-            .or_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(PostgresQueryBuilder),
+            .or_where(Expr::col(Char::SizeW).eq(&3))
+            .or_where(Expr::col(Char::SizeH).eq(&4))
+            .or_where(Expr::col(Char::SizeH).eq(&5))
+            .to_string(),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 OR "size_h" = 4 OR "size_h" = 5"#
     );
 }
@@ -412,13 +412,13 @@ fn select_28() {
 #[should_panic]
 fn select_29() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .or_where(Expr::col(Char::SizeH).eq(4))
-            .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .or_where(Expr::col(Char::SizeH).eq(&4))
+            .and_where(Expr::col(Char::SizeH).eq(&5))
+            .to_string(),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 OR "size_h" = 4 AND "size_h" = 5"#
     );
 }
@@ -426,16 +426,16 @@ fn select_29() {
 #[test]
 fn select_30() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
             .and_where(
                 Expr::col(Char::SizeW)
-                    .mul(2)
-                    .add(Expr::col(Char::SizeH).div(3))
-                    .equals(Expr::value(4))
+                    .mul(&2)
+                    .add(Expr::col(Char::SizeH).div(&3))
+                    .equals(Expr::value(&4))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" * 2) + ("size_h" / 3) = 4"#
     );
 }
@@ -443,9 +443,15 @@ fn select_30() {
 #[test]
 fn select_31() {
     assert_eq!(
-        Query::select()
-            .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(Expr::value(i)) }))
-            .to_string(PostgresQueryBuilder),
+        PgQuery::select()
+            .expr(
+                (1..10_i32)
+                    .into_iter()
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .fold(Expr::value(&0), |expr, i| { expr.add(Expr::value(i)) })
+            )
+            .to_string(),
         r#"SELECT 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9"#
     );
 }
@@ -453,10 +459,10 @@ fn select_31() {
 #[test]
 fn select_32() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .expr_as(Expr::col(Char::Character), Alias::new("C"))
             .from(Char::Table)
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "character" AS "C" FROM "character""#
     );
 }
@@ -464,14 +470,14 @@ fn select_32() {
 #[test]
 fn select_33() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .column(Glyph::Image)
             .from(Glyph::Table)
             .and_where(
                 Expr::col(Glyph::Aspect)
-                    .in_subquery(Query::select().expr(Expr::cust("3 + 2 * 2")).take())
+                    .in_subquery(PgQuery::select().expr(Expr::cust("3 + 2 * 2")).take())
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"SELECT "image" FROM "glyph" WHERE "aspect" IN (SELECT 3 + 2 * 2)"#
     );
 }
@@ -479,23 +485,23 @@ fn select_33() {
 #[test]
 fn select_34a() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .column(Glyph::Aspect)
             .expr(Expr::col(Glyph::Image).max())
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
             .or_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(2)
-                    .or(Expr::col(Glyph::Aspect).lt(8))
+                    .gt(&2)
+                    .or(Expr::col(Glyph::Aspect).lt(&8))
             )
             .or_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(12)
-                    .and(Expr::col(Glyph::Aspect).lt(18))
+                    .gt(&12)
+                    .and(Expr::col(Glyph::Aspect).lt(&18))
             )
-            .or_having(Expr::col(Glyph::Aspect).gt(32))
-            .to_string(PostgresQueryBuilder),
+            .or_having(Expr::col(Glyph::Aspect).gt(&32))
+            .to_string(),
         vec![
             r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect""#,
             r#"HAVING (("aspect" > 2) OR ("aspect" < 8))"#,
@@ -510,22 +516,22 @@ fn select_34a() {
 #[should_panic]
 fn select_34b() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .column(Glyph::Aspect)
             .expr(Expr::col(Glyph::Image).max())
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
             .or_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(2)
-                    .or(Expr::col(Glyph::Aspect).lt(8))
+                    .gt(&2)
+                    .or(Expr::col(Glyph::Aspect).lt(&8))
             )
             .and_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(22)
-                    .or(Expr::col(Glyph::Aspect).lt(28))
+                    .gt(&22)
+                    .or(Expr::col(Glyph::Aspect).lt(&28))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         vec![
             r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect""#,
             r#"HAVING (("aspect" > 2) OR ("aspect" < 8))"#,
@@ -537,49 +543,53 @@ fn select_34b() {
 
 #[test]
 fn select_35() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = PgQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .and_where(Expr::col(Glyph::Aspect).is_null())
-        .build(sea_query::PostgresQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT "id" FROM "glyph" WHERE "aspect" IS NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_36() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = PgQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Expr::col(Glyph::Aspect).is_null()))
-        .build(sea_query::PostgresQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT "id" FROM "glyph" WHERE "aspect" IS NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_37() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = PgQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
-        .build(sea_query::PostgresQueryBuilder);
+        .build();
 
     assert_eq!(statement, r#"SELECT "id" FROM "glyph""#);
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_38() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = PgQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
@@ -587,18 +597,19 @@ fn select_38() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::PostgresQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT "id" FROM "glyph" WHERE "aspect" IS NULL OR "aspect" IS NOT NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_39() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = PgQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
@@ -606,28 +617,28 @@ fn select_39() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::PostgresQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT "id" FROM "glyph" WHERE "aspect" IS NULL AND "aspect" IS NOT NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_40() {
-    let statement = sea_query::Query::select()
+    let statement = PgQuery::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(any![
             Expr::col(Glyph::Aspect).is_null(),
             all![
                 Expr::col(Glyph::Aspect).is_not_null(),
-                Expr::col(Glyph::Aspect).lt(8)
+                Expr::col(Glyph::Aspect).lt(&8)
             ]
         ])
-        .to_string(sea_query::PostgresQueryBuilder);
+        .to_string();
 
     assert_eq!(
         statement,
@@ -638,28 +649,28 @@ fn select_40() {
 #[test]
 fn select_41() {
     assert_eq!(
-        Query::select()
+        PgQuery::select()
             .columns(vec![Glyph::Aspect])
             .exprs(vec![Expr::col(Glyph::Image).max()])
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect])
-            .cond_having(any![Expr::col(Glyph::Aspect).gt(2)])
-            .to_string(PostgresQueryBuilder),
+            .cond_having(any![Expr::col(Glyph::Aspect).gt(&2)])
+            .to_string(),
         r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2"#
     );
 }
 
 #[test]
 fn select_42() {
-    let statement = sea_query::Query::select()
+    let statement = PgQuery::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
             Cond::all()
-                .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
+                .add_option(Some(Expr::col(Glyph::Aspect).lt(&8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(PostgresQueryBuilder);
+        .to_string();
 
     assert_eq!(
         statement,
@@ -669,11 +680,11 @@ fn select_42() {
 
 #[test]
 fn select_43() {
-    let statement = sea_query::Query::select()
+    let statement = PgQuery::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
-        .cond_where(Cond::all().add_option::<SimpleExpr>(None))
-        .to_string(PostgresQueryBuilder);
+        .cond_where(Cond::all().add_option::<SimpleExpr<'_, _>>(None))
+        .to_string();
 
     assert_eq!(statement, r#"SELECT "id" FROM "glyph""#);
 }
@@ -682,14 +693,11 @@ fn select_43() {
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(
-        Query::insert()
+        PgQuery::insert()
             .into_table(Glyph::Table)
-            .columns(vec![Glyph::Image, Glyph::Aspect,])
-            .values_panic(vec![
-                "04108048005887010020060000204E0180400400".into(),
-                3.1415.into(),
-            ])
-            .to_string(PostgresQueryBuilder),
+            .columns(vec![Glyph::Image, Glyph::Aspect])
+            .values_panic(&[&"04108048005887010020060000204E0180400400", &3.1415])
+            .to_string(),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#
     );
 }
@@ -698,15 +706,12 @@ fn insert_2() {
 #[allow(clippy::approx_constant)]
 fn insert_3() {
     assert_eq!(
-        Query::insert()
+        PgQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![Glyph::Image, Glyph::Aspect,])
-            .values_panic(vec![
-                "04108048005887010020060000204E0180400400".into(),
-                3.1415.into(),
-            ])
-            .values_panic(vec![Value::String(None), 2.1345.into(),])
-            .to_string(PostgresQueryBuilder),
+            .values_panic(&[&"04108048005887010020060000204E0180400400", &3.1415])
+            .values_panic(&[&Value::String(None), &2.1345])
+            .to_string(),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415), (NULL, 2.1345)"#
     );
 }
@@ -715,11 +720,11 @@ fn insert_3() {
 #[cfg(feature = "with-chrono")]
 fn insert_4() {
     assert_eq!(
-        Query::insert()
+        PgQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![Glyph::Image])
-            .values_panic(vec![chrono::NaiveDateTime::from_timestamp(0, 0).into()])
-            .to_string(PostgresQueryBuilder),
+            .values_panic(&[&chrono::NaiveDateTime::from_timestamp(0, 0)])
+            .to_string(),
         "INSERT INTO \"glyph\" (\"image\") VALUES ('1970-01-01 00:00:00')"
     );
 }
@@ -728,45 +733,42 @@ fn insert_4() {
 #[cfg(feature = "with-uuid")]
 fn insert_5() {
     assert_eq!(
-        Query::insert()
+        PgQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![Glyph::Image])
-            .values_panic(vec![uuid::Uuid::nil().into()])
-            .to_string(PostgresQueryBuilder),
+            .values_panic(&[&uuid::Uuid::nil()])
+            .to_string(),
         "INSERT INTO \"glyph\" (\"image\") VALUES ('00000000-0000-0000-0000-000000000000')"
     );
 }
 
 #[test]
 fn update_1() {
+    let values: Vec<(_, &dyn QueryValue<PostgresQueryBuilder>)> = vec![
+        (Glyph::Aspect, &2.1345),
+        (Glyph::Image, &"24B0E11951B03B07F8300FD003983F03F0780060"),
+    ];
     assert_eq!(
-        Query::update()
+        PgQuery::update()
             .table(Glyph::Table)
-            .values(vec![
-                (Glyph::Aspect, 2.1345.into()),
-                (
-                    Glyph::Image,
-                    "24B0E11951B03B07F8300FD003983F03F0780060".into()
-                ),
-            ])
-            .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(PostgresQueryBuilder),
+            .values(values)
+            .and_where(Expr::col(Glyph::Id).eq(&1))
+            .to_string(),
         r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1"#
     );
 }
 
 #[test]
 fn update_3() {
+    let values: Vec<(_, &dyn QueryValue<PostgresQueryBuilder>)> =
+        vec![(Glyph::Image, &"24B0E11951B03B07F8300FD003983F03F0780060")];
     assert_eq!(
-        Query::update()
+        PgQuery::update()
             .table(Glyph::Table)
             .value_expr(Glyph::Aspect, Expr::cust("60 * 24 * 24"))
-            .values(vec![(
-                Glyph::Image,
-                "24B0E11951B03B07F8300FD003983F03F0780060".into()
-            ),])
-            .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(PostgresQueryBuilder),
+            .values(values)
+            .and_where(Expr::col(Glyph::Id).eq(&1))
+            .to_string(),
         r#"UPDATE "glyph" SET "aspect" = 60 * 24 * 24, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1"#
     );
 }
@@ -774,10 +776,10 @@ fn update_3() {
 #[test]
 fn delete_1() {
     assert_eq!(
-        Query::delete()
+        PgQuery::delete()
             .from_table(Glyph::Table)
-            .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(PostgresQueryBuilder),
+            .and_where(Expr::col(Glyph::Id).eq(&1))
+            .to_string(),
         r#"DELETE FROM "glyph" WHERE "id" = 1"#
     );
 }

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -14,7 +14,7 @@ fn create_1() {
             )
             .col(ColumnDef::new(Glyph::Aspect).double().not_null())
             .col(ColumnDef::new(Glyph::Image).text())
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -41,7 +41,7 @@ fn create_2() {
             .col(ColumnDef::new(Font::Name).string().not_null())
             .col(ColumnDef::new(Font::Variant).string_len(255).not_null())
             .col(ColumnDef::new(Font::Language).string_len(255).not_null())
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         vec![
             r#"CREATE TABLE "font" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -84,7 +84,7 @@ fn create_3() {
                     .on_delete(ForeignKeyAction::Cascade)
                     .on_update(ForeignKeyAction::Cascade)
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         vec![
             r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -108,7 +108,7 @@ fn create_4() {
         Table::create()
             .table(Glyph::Table)
             .col(ColumnDef::new(Glyph::Image).custom(Glyph::Aspect))
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         vec![r#"CREATE TABLE "glyph" ("#, r#""image" aspect"#, r#")"#,].join(" ")
     );
 }
@@ -120,7 +120,7 @@ fn create_5() {
             .table(Glyph::Table)
             .col(ColumnDef::new(Glyph::Image).json())
             .col(ColumnDef::new(Glyph::Aspect).json_binary())
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""image" json,"#,
@@ -142,7 +142,7 @@ fn create_6() {
                     .not_null()
                     .extra("ANYTHING I WANT TO SAY".to_owned())
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""id" integer NOT NULL ANYTHING I WANT TO SAY"#,
@@ -159,7 +159,7 @@ fn drop_1() {
             .table(Glyph::Table)
             .table(Char::Table)
             .cascade()
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"DROP TABLE "glyph", "character" CASCADE"#
     );
 }
@@ -169,7 +169,7 @@ fn truncate_1() {
     assert_eq!(
         Table::truncate()
             .table(Font::Table)
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"TRUNCATE TABLE "font""#
     );
 }
@@ -185,7 +185,7 @@ fn alter_1() {
                     .not_null()
                     .default(100)
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
     );
 }
@@ -200,7 +200,7 @@ fn alter_2() {
                     .big_integer()
                     .default(999)
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         vec![
             r#"ALTER TABLE "font""#,
             r#"ALTER COLUMN "new_col" TYPE bigint,"#,
@@ -216,7 +216,7 @@ fn alter_3() {
         Table::alter()
             .table(Font::Table)
             .rename_column(Alias::new("new_col"), Alias::new("new_column"))
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"ALTER TABLE "font" RENAME COLUMN "new_col" TO "new_column""#
     );
 }
@@ -227,7 +227,7 @@ fn alter_4() {
         Table::alter()
             .table(Font::Table)
             .drop_column(Alias::new("new_column"))
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"ALTER TABLE "font" DROP COLUMN "new_column""#
     );
 }
@@ -237,7 +237,7 @@ fn alter_5() {
     assert_eq!(
         Table::rename()
             .table(Font::Table, Alias::new("font_new"))
-            .to_string(PostgresQueryBuilder),
+            .to_string::<PostgresQueryBuilder>(),
         r#"ALTER TABLE "font" RENAME TO "font_new""#
     );
 }
@@ -245,5 +245,5 @@ fn alter_5() {
 #[test]
 #[should_panic(expected = "No alter option found")]
 fn alter_6() {
-    Table::alter().to_string(PostgresQueryBuilder);
+    Table::alter().to_string::<PostgresQueryBuilder>();
 }

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -1,4 +1,4 @@
-use sea_query::{extension::postgres::Type, Alias, PostgresQueryBuilder};
+use sea_query::{extension::postgres::Type, Alias};
 
 use super::*;
 
@@ -8,7 +8,7 @@ fn create_1() {
         Type::create()
             .as_enum(Font::Table)
             .values(vec![Font::Name, Font::Variant, Font::Language])
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"CREATE TYPE "font" AS ENUM ('name', 'variant', 'language')"#
     );
 }
@@ -20,7 +20,7 @@ fn drop_1() {
             .if_exists()
             .name(Font::Table)
             .restrict()
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"DROP TYPE IF EXISTS "font" RESTRICT"#
     )
 }
@@ -28,9 +28,7 @@ fn drop_1() {
 #[test]
 fn drop_2() {
     assert_eq!(
-        Type::drop()
-            .name(Font::Table)
-            .to_string(PostgresQueryBuilder),
+        Type::drop().name(Font::Table).to_string(),
         r#"DROP TYPE "font""#
     );
 }
@@ -42,7 +40,7 @@ fn drop_3() {
             .if_exists()
             .name(Font::Table)
             .cascade()
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"DROP TYPE IF EXISTS "font" CASCADE"#
     );
 }
@@ -53,7 +51,7 @@ fn alter_1() {
         Type::alter()
             .name(Font::Table)
             .add_value(Alias::new("weight"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"ALTER TYPE "font" ADD VALUE 'weight'"#
     )
 }
@@ -64,7 +62,7 @@ fn alter_2() {
             .name(Font::Table)
             .add_value(Alias::new("weight"))
             .before(Font::Variant)
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"ALTER TYPE "font" ADD VALUE 'weight' BEFORE 'variant'"#
     )
 }
@@ -76,7 +74,7 @@ fn alter_3() {
             .name(Font::Table)
             .add_value(Alias::new("weight"))
             .after(Font::Variant)
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"ALTER TYPE "font" ADD VALUE 'weight' AFTER 'variant'"#
     )
 }
@@ -87,7 +85,7 @@ fn alter_4() {
         Type::alter()
             .name(Font::Table)
             .rename_to(Alias::new("typeface"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"ALTER TYPE "font" RENAME TO 'typeface'"#
     )
 }
@@ -98,7 +96,7 @@ fn alter_5() {
         Type::alter()
             .name(Font::Table)
             .rename_value(Font::Variant, Font::Language)
-            .to_string(PostgresQueryBuilder),
+            .to_string(),
         r#"ALTER TYPE "font" RENAME VALUE 'variant' TO 'language'"#
     )
 }

--- a/tests/sqlite/index.rs
+++ b/tests/sqlite/index.rs
@@ -7,7 +7,7 @@ fn create_1() {
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
             .col(Glyph::Aspect)
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         "CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"
     );
 }
@@ -21,7 +21,7 @@ fn create_2() {
             .table(Glyph::Table)
             .col(Glyph::Aspect)
             .col(Glyph::Image)
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         "CREATE UNIQUE INDEX `idx-glyph-aspect-image` ON `glyph` (`aspect`, `image`)"
     );
 }
@@ -32,7 +32,7 @@ fn drop_1() {
         Index::drop()
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         "DROP INDEX `idx-glyph-aspect` ON `glyph`"
     );
 }

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -3,12 +3,12 @@ use super::*;
 #[test]
 fn select_1() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
             .limit(10)
             .offset(100)
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` LIMIT 10 OFFSET 100"
     );
 }
@@ -16,11 +16,11 @@ fn select_1() {
 #[test]
 fn select_2() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3"
     );
 }
@@ -28,14 +28,14 @@ fn select_2() {
 #[test]
 fn select_3() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Char::Character, Char::SizeW, Char::SizeH
             ])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .and_where(Expr::col(Char::SizeH).eq(4))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .and_where(Expr::col(Char::SizeH).eq(&4))
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 AND `size_h` = 4"
     );
 }
@@ -43,16 +43,16 @@ fn select_3() {
 #[test]
 fn select_4() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![Glyph::Image])
             .from_subquery(
-                Query::select()
+                SqliteQuery::select()
                     .columns(vec![Glyph::Image, Glyph::Aspect])
                     .from(Glyph::Table)
                     .take(),
                 Alias::new("subglyph")
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `image` FROM (SELECT `image`, `aspect` FROM `glyph`) AS `subglyph`"
     );
 }
@@ -60,11 +60,11 @@ fn select_4() {
 #[test]
 fn select_5() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .column((Glyph::Table, Glyph::Image))
             .from(Glyph::Table)
-            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![&3, &4]))
+            .to_string(),
         "SELECT `glyph`.`image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4)"
     );
 }
@@ -72,13 +72,13 @@ fn select_5() {
 #[test]
 fn select_6() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![Glyph::Aspect,])
             .exprs(vec![Expr::col(Glyph::Image).max(),])
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
-            .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(SqliteQueryBuilder),
+            .and_having(Expr::col(Glyph::Aspect).gt(&2))
+            .to_string(),
         "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` > 2"
     );
 }
@@ -86,11 +86,11 @@ fn select_6() {
 #[test]
 fn select_7() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![Glyph::Aspect,])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
+            .to_string(),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2"
     );
 }
@@ -98,13 +98,13 @@ fn select_7() {
 #[test]
 fn select_8() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Char::Character,
             ])
             .from(Char::Table)
             .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id`"
     );
 }
@@ -112,14 +112,14 @@ fn select_8() {
 #[test]
 fn select_9() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Char::Character,
             ])
             .from(Char::Table)
             .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
             .inner_join(Glyph::Table, Expr::tbl(Char::Table, Char::Character).equals(Glyph::Table, Glyph::Image))
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` INNER JOIN `glyph` ON `character`.`character` = `glyph`.`image`"
     );
 }
@@ -127,7 +127,7 @@ fn select_9() {
 #[test]
 fn select_10() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Char::Character,
             ])
@@ -136,7 +136,7 @@ fn select_10() {
                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
                 .and(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON (`character`.`font_id` = `font`.`id`) AND (`character`.`font_id` = `font`.`id`)"
     );
 }
@@ -144,15 +144,15 @@ fn select_10() {
 #[test]
 fn select_11() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
             .order_by(Glyph::Image, Order::Desc)
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"
     );
 }
@@ -160,17 +160,17 @@ fn select_11() {
 #[test]
 fn select_12() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
             .order_by_columns(vec![
                 (Glyph::Id, Order::Asc),
                 (Glyph::Aspect, Order::Desc),
             ])
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `id` ASC, `aspect` DESC"
     );
 }
@@ -178,17 +178,17 @@ fn select_12() {
 #[test]
 fn select_13() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(&0)).gt(&2))
             .order_by_columns(vec![
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
             ])
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `glyph`.`id` ASC, `glyph`.`aspect` DESC"
     );
 }
@@ -196,7 +196,7 @@ fn select_13() {
 #[test]
 fn select_14() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Glyph::Id,
                 Glyph::Aspect,
@@ -207,8 +207,8 @@ fn select_14() {
                 (Glyph::Table, Glyph::Id),
                 (Glyph::Table, Glyph::Aspect),
             ])
-            .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(SqliteQueryBuilder),
+            .and_having(Expr::col(Glyph::Aspect).gt(&2))
+            .to_string(),
         "SELECT `id`, `aspect`, MAX(`image`) FROM `glyph` GROUP BY `glyph`.`id`, `glyph`.`aspect` HAVING `aspect` > 2"
     );
 }
@@ -216,11 +216,11 @@ fn select_14() {
 #[test]
 fn select_15() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `font_id` IS NULL"
     );
 }
@@ -228,12 +228,12 @@ fn select_15() {
 #[test]
 fn select_16() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
             .and_where(Expr::col(Char::Character).is_not_null())
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `font_id` IS NULL AND `character` IS NOT NULL"
     );
 }
@@ -241,11 +241,11 @@ fn select_16() {
 #[test]
 fn select_17() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![(Glyph::Table, Glyph::Image),])
             .from(Glyph::Table)
-            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).between(3, 5))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).between(&3, &5))
+            .to_string(),
         "SELECT `glyph`.`image` FROM `glyph` WHERE `glyph`.`aspect` BETWEEN 3 AND 5"
     );
 }
@@ -253,14 +253,14 @@ fn select_17() {
 #[test]
 fn select_18() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::col(Glyph::Aspect).between(3, 5))
-            .and_where(Expr::col(Glyph::Aspect).not_between(8, 10))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::col(Glyph::Aspect).between(&3, &5))
+            .and_where(Expr::col(Glyph::Aspect).not_between(&8, &10))
+            .to_string(),
         "SELECT `aspect` FROM `glyph` WHERE (`aspect` BETWEEN 3 AND 5) AND (`aspect` NOT BETWEEN 8 AND 10)"
     );
 }
@@ -268,11 +268,11 @@ fn select_18() {
 #[test]
 fn select_19() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![Char::Character])
             .from(Char::Table)
-            .and_where(Expr::col(Char::Character).eq("A"))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::col(Char::Character).eq(&"A"))
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `character` = 'A'"
     );
 }
@@ -280,11 +280,11 @@ fn select_19() {
 #[test]
 fn select_20() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .column(Char::Character)
             .from(Char::Table)
-            .and_where(Expr::col(Char::Character).like("A"))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::col(Char::Character).like(&"A"))
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `character` LIKE 'A'"
     );
 }
@@ -292,15 +292,15 @@ fn select_20() {
 #[test]
 fn select_21() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Char::Character
             ])
             .from(Char::Table)
-            .or_where(Expr::col(Char::Character).like("A%"))
-            .or_where(Expr::col(Char::Character).like("%B"))
-            .or_where(Expr::col(Char::Character).like("%C%"))
-            .to_string(SqliteQueryBuilder),
+            .or_where(Expr::col(Char::Character).like(&"A%"))
+            .or_where(Expr::col(Char::Character).like(&"%B"))
+            .or_where(Expr::col(Char::Character).like(&"%C%"))
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `character` LIKE 'A%' OR `character` LIKE '%B' OR `character` LIKE '%C%'"
     );
 }
@@ -308,21 +308,21 @@ fn select_21() {
 #[test]
 fn select_22() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .cond_where(
                 Cond::all()
                 .add(
                     Cond::any()
-                    .add(Expr::col(Char::Character).like("C"))
-                    .add(Expr::col(Char::Character).like("D").and(Expr::col(Char::Character).like("E")))
+                    .add(Expr::col(Char::Character).like(&"C"))
+                    .add(Expr::col(Char::Character).like(&"D").and(Expr::col(Char::Character).like(&"E")))
                 )
                 .add(
-                    Expr::col(Char::Character).like("F").or(Expr::col(Char::Character).like("G"))
+                    Expr::col(Char::Character).like(&"F").or(Expr::col(Char::Character).like(&"G"))
                 )
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE (`character` LIKE 'C' OR ((`character` LIKE 'D') AND (`character` LIKE 'E'))) AND ((`character` LIKE 'F') OR (`character` LIKE 'G'))"
     );
 }
@@ -330,11 +330,11 @@ fn select_22() {
 #[test]
 fn select_23() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .and_where_option(None)
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character`"
     );
 }
@@ -342,17 +342,17 @@ fn select_23() {
 #[test]
 fn select_24() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .conditions(
                 true,
                 |x| {
-                    x.and_where(Expr::col(Char::FontId).eq(5));
+                    x.and_where(Expr::col(Char::FontId).eq(&5));
                 },
                 |_| ()
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `font_id` = 5"
     );
 }
@@ -360,15 +360,15 @@ fn select_24() {
 #[test]
 fn select_25() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .and_where(
                 Expr::col(Char::SizeW)
-                    .mul(2)
-                    .equals(Expr::col(Char::SizeH).div(2))
+                    .mul(&2)
+                    .equals(Expr::col(Char::SizeH).div(&2))
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE `size_w` * 2 = `size_h` / 2"
     );
 }
@@ -376,15 +376,15 @@ fn select_25() {
 #[test]
 fn select_26() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .column(Char::Character)
             .from(Char::Table)
             .and_where(
-                Expr::expr(Expr::col(Char::SizeW).add(1))
-                    .mul(2)
-                    .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+                Expr::expr(Expr::col(Char::SizeW).add(&1))
+                    .mul(&2)
+                    .equals(Expr::expr(Expr::col(Char::SizeH).div(&2)).sub(&1))
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` FROM `character` WHERE (`size_w` + 1) * 2 = (`size_h` / 2) - 1"
     );
 }
@@ -392,15 +392,15 @@ fn select_26() {
 #[test]
 fn select_27() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Char::Character, Char::SizeW, Char::SizeH
             ])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .and_where(Expr::col(Char::SizeH).eq(4))
-            .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .and_where(Expr::col(Char::SizeH).eq(&4))
+            .and_where(Expr::col(Char::SizeH).eq(&5))
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 AND `size_h` = 4 AND `size_h` = 5"
     );
 }
@@ -408,15 +408,15 @@ fn select_27() {
 #[test]
 fn select_28() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Char::Character, Char::SizeW, Char::SizeH
             ])
             .from(Char::Table)
-            .or_where(Expr::col(Char::SizeW).eq(3))
-            .or_where(Expr::col(Char::SizeH).eq(4))
-            .or_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(SqliteQueryBuilder),
+            .or_where(Expr::col(Char::SizeW).eq(&3))
+            .or_where(Expr::col(Char::SizeH).eq(&4))
+            .or_where(Expr::col(Char::SizeH).eq(&5))
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 OR `size_h` = 4 OR `size_h` = 5"
     );
 }
@@ -425,15 +425,15 @@ fn select_28() {
 #[should_panic]
 fn select_29() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Char::Character, Char::SizeW, Char::SizeH
             ])
             .from(Char::Table)
-            .and_where(Expr::col(Char::SizeW).eq(3))
-            .or_where(Expr::col(Char::SizeH).eq(4))
-            .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::col(Char::SizeW).eq(&3))
+            .or_where(Expr::col(Char::SizeH).eq(&4))
+            .and_where(Expr::col(Char::SizeH).eq(&5))
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 OR `size_h` = 4 AND `size_h` = 5"
     );
 }
@@ -441,17 +441,17 @@ fn select_29() {
 #[test]
 fn select_30() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![
                 Char::Character, Char::SizeW, Char::SizeH
             ])
             .from(Char::Table)
             .and_where(
-                Expr::col(Char::SizeW).mul(2)
-                    .add(Expr::col(Char::SizeH).div(3))
-                    .equals(Expr::value(4))
+                Expr::col(Char::SizeW).mul(&2)
+                    .add(Expr::col(Char::SizeH).div(&3))
+                    .equals(Expr::value(&4))
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE (`size_w` * 2) + (`size_h` / 3) = 4"
     );
 }
@@ -459,9 +459,15 @@ fn select_30() {
 #[test]
 fn select_31() {
     assert_eq!(
-        Query::select()
-            .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(Expr::value(i)) }))
-            .to_string(SqliteQueryBuilder),
+        SqliteQuery::select()
+            .expr(
+                (1..10_i32)
+                    .into_iter()
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .fold(Expr::value(&0), |expr, i| { expr.add(Expr::value(i)) })
+            )
+            .to_string(),
         "SELECT 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9"
     );
 }
@@ -469,10 +475,10 @@ fn select_31() {
 #[test]
 fn select_32() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .expr_as(Expr::col(Char::Character), Alias::new("C"))
             .from(Char::Table)
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `character` AS `C` FROM `character`"
     );
 }
@@ -480,14 +486,14 @@ fn select_32() {
 #[test]
 fn select_33() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .column(Glyph::Image)
             .from(Glyph::Table)
             .and_where(
                 Expr::col(Glyph::Aspect)
                     .in_subquery(Query::select().expr(Expr::cust("3 + 2 * 2")).take())
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "SELECT `image` FROM `glyph` WHERE `aspect` IN (SELECT 3 + 2 * 2)"
     );
 }
@@ -495,23 +501,23 @@ fn select_33() {
 #[test]
 fn select_34a() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .column(Glyph::Aspect)
             .expr(Expr::col(Glyph::Image).max())
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
             .or_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(2)
-                    .or(Expr::col(Glyph::Aspect).lt(8))
+                    .gt(&2)
+                    .or(Expr::col(Glyph::Aspect).lt(&8))
             )
             .or_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(12)
-                    .and(Expr::col(Glyph::Aspect).lt(18))
+                    .gt(&12)
+                    .and(Expr::col(Glyph::Aspect).lt(&18))
             )
-            .or_having(Expr::col(Glyph::Aspect).gt(32))
-            .to_string(SqliteQueryBuilder),
+            .or_having(Expr::col(Glyph::Aspect).gt(&32))
+            .to_string(),
         vec![
             "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect`",
             "HAVING ((`aspect` > 2) OR (`aspect` < 8))",
@@ -526,22 +532,22 @@ fn select_34a() {
 #[should_panic]
 fn select_34b() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .column(Glyph::Aspect)
             .expr(Expr::col(Glyph::Image).max())
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
             .or_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(2)
-                    .or(Expr::col(Glyph::Aspect).lt(8))
+                    .gt(&2)
+                    .or(Expr::col(Glyph::Aspect).lt(&8))
             )
             .and_having(
                 Expr::col(Glyph::Aspect)
-                    .gt(22)
-                    .or(Expr::col(Glyph::Aspect).lt(28))
+                    .gt(&22)
+                    .or(Expr::col(Glyph::Aspect).lt(&28))
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         vec![
             "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect`",
             "HAVING ((`aspect` > 2) OR (`aspect` < 8))",
@@ -553,49 +559,53 @@ fn select_34b() {
 
 #[test]
 fn select_35() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = SqliteQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .and_where(Expr::col(Glyph::Aspect).is_null())
-        .build(sea_query::SqliteQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT `id` FROM `glyph` WHERE `aspect` IS NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_36() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = SqliteQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Expr::col(Glyph::Aspect).is_null()))
-        .build(sea_query::SqliteQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT `id` FROM `glyph` WHERE `aspect` IS NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_37() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = SqliteQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
-        .build(sea_query::SqliteQueryBuilder);
+        .build();
 
     assert_eq!(statement, r#"SELECT `id` FROM `glyph`"#);
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_38() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = SqliteQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
@@ -603,18 +613,19 @@ fn select_38() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::SqliteQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT `id` FROM `glyph` WHERE `aspect` IS NULL OR `aspect` IS NOT NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_39() {
-    let (statement, values) = sea_query::Query::select()
+    let mut select = SqliteQuery::select();
+    let (statement, values) = select
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
@@ -622,28 +633,28 @@ fn select_39() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::SqliteQueryBuilder);
+        .build();
 
     assert_eq!(
         statement,
         r#"SELECT `id` FROM `glyph` WHERE `aspect` IS NULL AND `aspect` IS NOT NULL"#
     );
-    assert_eq!(values.0, vec![]);
+    assert!(values.is_empty());
 }
 
 #[test]
 fn select_40() {
-    let statement = sea_query::Query::select()
+    let statement = SqliteQuery::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(any![
             Expr::col(Glyph::Aspect).is_null(),
             all![
                 Expr::col(Glyph::Aspect).is_not_null(),
-                Expr::col(Glyph::Aspect).lt(8)
+                Expr::col(Glyph::Aspect).lt(&8)
             ]
         ])
-        .to_string(sea_query::SqliteQueryBuilder);
+        .to_string();
 
     assert_eq!(
         statement,
@@ -654,28 +665,28 @@ fn select_40() {
 #[test]
 fn select_41() {
     assert_eq!(
-        Query::select()
+        SqliteQuery::select()
             .columns(vec![Glyph::Aspect])
             .exprs(vec![Expr::col(Glyph::Image).max()])
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect])
-            .cond_having(any![Expr::col(Glyph::Aspect).gt(2)])
-            .to_string(SqliteQueryBuilder),
+            .cond_having(any![Expr::col(Glyph::Aspect).gt(&2)])
+            .to_string(),
         "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` > 2"
     );
 }
 
 #[test]
 fn select_42() {
-    let statement = sea_query::Query::select()
+    let statement = SqliteQuery::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
             Cond::all()
-                .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
+                .add_option(Some(Expr::col(Glyph::Aspect).lt(&8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(SqliteQueryBuilder);
+        .to_string();
 
     assert_eq!(
         statement,
@@ -685,11 +696,11 @@ fn select_42() {
 
 #[test]
 fn select_43() {
-    let statement = sea_query::Query::select()
+    let statement = SqliteQuery::select()
         .column(Glyph::Id)
         .from(Glyph::Table)
-        .cond_where(Cond::all().add_option::<SimpleExpr>(None))
-        .to_string(SqliteQueryBuilder);
+        .cond_where(Cond::all().add_option::<SimpleExpr<'_, _>>(None))
+        .to_string();
 
     assert_eq!(statement, r#"SELECT `id` FROM `glyph`"#);
 }
@@ -698,17 +709,17 @@ fn select_43() {
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(
-        Query::insert()
+        SqliteQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![
                 Glyph::Image,
                 Glyph::Aspect,
             ])
-            .values_panic(vec![
-                "04108048005887010020060000204E0180400400".into(),
-                3.1415.into(),
+            .values_panic(&[
+                &"04108048005887010020060000204E0180400400",
+                &3.1415,
             ])
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "INSERT INTO `glyph` (`image`, `aspect`) VALUES ('04108048005887010020060000204E0180400400', 3.1415)"
     );
 }
@@ -717,21 +728,21 @@ fn insert_2() {
 #[allow(clippy::approx_constant)]
 fn insert_3() {
     assert_eq!(
-        Query::insert()
+        SqliteQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![
                 Glyph::Image,
                 Glyph::Aspect,
             ])
-            .values_panic(vec![
-                "04108048005887010020060000204E0180400400".into(),
-                3.1415.into(),
+            .values_panic(&[
+                &"04108048005887010020060000204E0180400400",
+                &3.1415,
             ])
-            .values_panic(vec![
-                Value::Double(None),
-                2.1345.into(),
+            .values_panic(&[
+                &Value::Double(None),
+                &2.1345,
             ])
-            .to_string(SqliteQueryBuilder),
+            .to_string(),
         "INSERT INTO `glyph` (`image`, `aspect`) VALUES ('04108048005887010020060000204E0180400400', 3.1415), (NULL, 2.1345)"
     );
 }
@@ -740,11 +751,11 @@ fn insert_3() {
 #[cfg(feature = "with-chrono")]
 fn insert_4() {
     assert_eq!(
-        Query::insert()
+        SqliteQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![Glyph::Image])
-            .values_panic(vec![chrono::NaiveDateTime::from_timestamp(0, 0).into()])
-            .to_string(SqliteQueryBuilder),
+            .values_panic(&[&chrono::NaiveDateTime::from_timestamp(0, 0)])
+            .to_string(),
         "INSERT INTO `glyph` (`image`) VALUES ('1970-01-01 00:00:00')"
     );
 }
@@ -753,41 +764,42 @@ fn insert_4() {
 #[cfg(feature = "with-uuid")]
 fn insert_5() {
     assert_eq!(
-        Query::insert()
+        SqliteQuery::insert()
             .into_table(Glyph::Table)
             .columns(vec![Glyph::Image])
-            .values_panic(vec![uuid::Uuid::nil().into()])
-            .to_string(SqliteQueryBuilder),
+            .values_panic(&[&uuid::Uuid::nil()])
+            .to_string(),
         "INSERT INTO `glyph` (`image`) VALUES ('00000000-0000-0000-0000-000000000000')"
     );
 }
 
 #[test]
 fn update_1() {
+    let values: Vec<(Glyph, &dyn QueryValue<_>)> = vec![
+        (Glyph::Aspect, &2.1345),
+        (Glyph::Image, &"24B0E11951B03B07F8300FD003983F03F0780060"),
+    ];
     assert_eq!(
-        Query::update()
+        SqliteQuery::update()
             .table(Glyph::Table)
-            .values(vec![
-                (Glyph::Aspect, 2.1345.into()),
-                (Glyph::Image, "24B0E11951B03B07F8300FD003983F03F0780060".into()),
-            ])
-            .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(SqliteQueryBuilder),
+            .values(values)
+            .and_where(Expr::col(Glyph::Id).eq(&1))
+            .to_string(),
         "UPDATE `glyph` SET `aspect` = 2.1345, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1"
     );
 }
 
 #[test]
 fn update_3() {
+    let values: Vec<(Glyph, &dyn QueryValue<SqliteQueryBuilder>)> =
+        vec![(Glyph::Image, &"24B0E11951B03B07F8300FD003983F03F0780060")];
     assert_eq!(
-        Query::update()
+        SqliteQuery::update()
             .table(Glyph::Table)
             .value_expr(Glyph::Aspect, Expr::cust("60 * 24 * 24"))
-            .values(vec![
-                (Glyph::Image, "24B0E11951B03B07F8300FD003983F03F0780060".into()),
-            ])
-            .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(SqliteQueryBuilder),
+            .values(values)
+            .and_where(Expr::col(Glyph::Id).eq(&1))
+            .to_string(),
         "UPDATE `glyph` SET `aspect` = 60 * 24 * 24, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1"
     );
 }
@@ -795,10 +807,10 @@ fn update_3() {
 #[test]
 fn delete_1() {
     assert_eq!(
-        Query::delete()
+        SqliteQuery::delete()
             .from_table(Glyph::Table)
-            .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(SqliteQueryBuilder),
+            .and_where(Expr::col(Glyph::Id).eq(&1))
+            .to_string(),
         "DELETE FROM `glyph` WHERE `id` = 1"
     );
 }

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -14,7 +14,7 @@ fn create_1() {
             )
             .col(ColumnDef::new(Glyph::Aspect).double().not_null())
             .col(ColumnDef::new(Glyph::Image).text())
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         vec![
             "CREATE TABLE `glyph` (",
             "`id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,",
@@ -41,7 +41,7 @@ fn create_2() {
             .col(ColumnDef::new(Font::Name).string().not_null())
             .col(ColumnDef::new(Font::Variant).string().not_null())
             .col(ColumnDef::new(Font::Language).string().not_null())
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         vec![
             "CREATE TABLE `font` (",
             "`id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,",
@@ -83,7 +83,7 @@ fn create_3() {
                     .on_delete(ForeignKeyAction::Cascade)
                     .on_update(ForeignKeyAction::Cascade)
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         vec![
             "CREATE TABLE IF NOT EXISTS `character` (",
             "`id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,",
@@ -106,7 +106,7 @@ fn drop_1() {
             .table(Glyph::Table)
             .table(Char::Table)
             .cascade()
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         "DROP TABLE `glyph`, `character`"
     );
 }
@@ -116,7 +116,7 @@ fn truncate_1() {
     assert_eq!(
         Table::truncate()
             .table(Font::Table)
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         "TRUNCATE TABLE `font`"
     );
 }
@@ -132,7 +132,7 @@ fn alter_1() {
                     .not_null()
                     .default(99)
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         "ALTER TABLE `font` ADD COLUMN `new_col` integer NOT NULL DEFAULT 99"
     );
 }
@@ -143,7 +143,7 @@ fn alter_2() {
     Table::alter()
         .table(Font::Table)
         .modify_column(ColumnDef::new(Alias::new("new_col")).double())
-        .to_string(SqliteQueryBuilder);
+        .to_string::<SqliteQueryBuilder>();
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn alter_3() {
         Table::alter()
             .table(Font::Table)
             .rename_column(Alias::new("new_col"), Alias::new("new_column"))
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         "ALTER TABLE `font` RENAME COLUMN `new_col` TO `new_column`"
     );
 }
@@ -163,7 +163,7 @@ fn alter_4() {
     Table::alter()
         .table(Font::Table)
         .drop_column(Alias::new("new_column"))
-        .to_string(SqliteQueryBuilder);
+        .to_string::<SqliteQueryBuilder>();
 }
 
 #[test]
@@ -171,7 +171,7 @@ fn alter_5() {
     assert_eq!(
         Table::rename()
             .table(Font::Table, Alias::new("font_new"))
-            .to_string(SqliteQueryBuilder),
+            .to_string::<SqliteQueryBuilder>(),
         "ALTER TABLE `font` RENAME TO `font_new`"
     );
 }
@@ -179,5 +179,5 @@ fn alter_5() {
 #[test]
 #[should_panic(expected = "No alter option found")]
 fn alter_6() {
-    Table::alter().to_string(SqliteQueryBuilder);
+    Table::alter().to_string::<SqliteQueryBuilder>();
 }


### PR DESCRIPTION
### Summary

This PR creates a trait `QueryValue<DB>` which can be used in place of the `Value` enum for support for custom types.

### Problem

Using custom types in queries is not supported, as the `Value` enum is used as the type accepted by functions throughout sea-orm.

### Solution

A new trait `QueryValue<DB>` has been added which replaces almost all instances where `Value` is used, allowing support for custom types that implement this new trait.

### How it's implemented

Anywhere `Value` could previously be used has been replaced with the `QueryValue<DB>` trait. This means most types now have a `DB` generic attached to it.

The definition for this new trait:
```rust
/// Indicates that a SQL type is supported for use in queries.
/// Convert a value to a String for use in queries.
pub trait QueryValue<DB> {
    /// Returns the value as an escaped string safe for use in queries.
    fn query_value(&self) -> String;
}
```

Most primitive types implement QueryValue in this commit, including integers, floats, strings, bools, DateTime.

The major benefit of this change is that users can define new types for use in queries.
For example:
```rust
struct Email(String);

impl<DB> QueryValue<DB> for Email {
    fn query_value(&self) -> String {
        let mut buf = String::new();
        DB::write_string_quoted(self.0, &mut buf);
        buf
    }
}
```
```rust
enum Gender {
    Male,
    Female,
}

impl<DB> QueryValue<DB> for Gender {
    fn query_value(&self) -> String {
        let mut buf = String::new();
        match self {
            Self::Male => DB::write_string_quoted("male", &mut buf);
            Self::Female => DB::write_string_quoted("female", &mut buf);
        }
        buf
    }
}
```
The types can then be used in queries as you previously could only with `Value`:
```rust
let email = Email("example@domain.com".to_string());
let gender = Gender::Male;

let query = Query::update()
    .table(User::Table)
    .value(User::Name, &"John Doe")
    .value(User::Email, &email)
    .value(User::Gender, &gender)
    .and_where(Expr::col(User::Id).eq(&1))
    .to_owned();
```

This is a major change to the project, and the main reason behind it is for support for SeaORM custom types. Eg, enums, etc.