### PR TITLE
Fix SQLite `chrono::NaiveTime` binding

### DIFF
--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -39,7 +39,7 @@ macro_rules! bind_params_sqlx_sqlite {
                     } else if value.is_date() {
                         query.bind(value.as_ref_date())
                     } else if value.is_time() {
-                        query.bind(value.as_ref_time())
+                        query.bind(value.as_ref_time().format("%T.f").to_string())
                     } else if value.is_date_time() {
                         query.bind(value.as_ref_date_time())
                     } else if value.is_decimal() {


### PR DESCRIPTION
Fix SQLite `chrono::NaiveTime` binding before launchbadge/sqlx#1459 being merged and released