### PR TITLE
Add `ColumnType::Enum`

### DIFF
--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -88,6 +88,7 @@ impl TableBuilder for MysqlQueryBuilder {
                 ColumnType::JsonBinary => "json".into(),
                 ColumnType::Uuid => "binary(16)".into(),
                 ColumnType::Custom(iden) => iden.to_string(),
+                ColumnType::Enum(_, variants) => format!("ENUM('{}')", variants.join("', '")),
             }
         )
         .unwrap()

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -96,6 +96,7 @@ impl TableBuilder for PostgresQueryBuilder {
                 ColumnType::JsonBinary => "jsonb".into(),
                 ColumnType::Uuid => "uuid".into(),
                 ColumnType::Custom(iden) => iden.to_string(),
+                ColumnType::Enum(name, _) => name.into(),
             }
         )
         .unwrap()

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -108,6 +108,7 @@ impl TableBuilder for SqliteQueryBuilder {
                 ColumnType::JsonBinary => "text".into(),
                 ColumnType::Uuid => "text(36)".into(),
                 ColumnType::Custom(iden) => iden.to_string(),
+                ColumnType::Enum(_, _) => "text".into(),
             }
         )
         .unwrap()

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -36,6 +36,7 @@ pub enum ColumnType {
     JsonBinary,
     Uuid,
     Custom(DynIden),
+    Enum(String, Vec<String>),
 }
 
 /// All column specification keywords

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -403,6 +403,20 @@ impl ColumnDef {
         self
     }
 
+    /// Set column type as enum.
+    pub fn enumeration<N, S, V>(&mut self, name: N, variants: V) -> &mut Self
+    where
+        N: ToString,
+        S: ToString,
+        V: IntoIterator<Item = S>,
+    {
+        self.types = Some(ColumnType::Enum(
+            name.to_string(),
+            variants.into_iter().map(|v| v.to_string()).collect(),
+        ));
+        self
+    }
+
     /// Some extra options in custom string
     pub fn extra(&mut self, string: String) -> &mut Self {
         self.spec.push(ColumnSpec::Extra(string));


### PR DESCRIPTION
## Info
- Required by SeaQL/sea-orm#324