### PR TITLE
`driver/postgres` handle non-exhaustive `Value`

### DIFF
--- a/src/driver/postgres.rs
+++ b/src/driver/postgres.rs
@@ -59,6 +59,7 @@ impl ToSql for Value {
             Value::BigDecimal(_) => unimplemented!("Not supported"),
             #[cfg(feature = "postgres-uuid")]
             Value::Uuid(v) => box_to_sql!(v, uuid::Uuid),
+            _ => unimplemented!(),
         }
     }
 

--- a/src/driver/postgres.rs
+++ b/src/driver/postgres.rs
@@ -59,6 +59,7 @@ impl ToSql for Value {
             Value::BigDecimal(_) => unimplemented!("Not supported"),
             #[cfg(feature = "postgres-uuid")]
             Value::Uuid(v) => box_to_sql!(v, uuid::Uuid),
+            #[allow(unreachable_patterns)]
             _ => unimplemented!(),
         }
     }


### PR DESCRIPTION
```
error[E0004]: non-exhaustive patterns: `&Date(_)`, `&Time(_)`, `&DateTime(_)` and 3 more not covered
  --> /Users/ari/.cargo/registry/src/github.com-1ecc6299db9ec823/sea-query-0.19.0/src/driver/postgres.rs:32:15
   |
32 |           match self {
   |                 ^^^^ patterns `&Date(_)`, `&Time(_)`, `&DateTime(_)` and 3 more not covered
   |
  ::: /Users/ari/.cargo/registry/src/github.com-1ecc6299db9ec823/sea-query-0.19.0/src/value.rs:27:1
   |
27 | / pub enum Value {
28 | |     Bool(Option<bool>),
29 | |     TinyInt(Option<i8>),
30 | |     SmallInt(Option<i16>),
...  |
74 | |     BigDecimal(Option<Box<BigDecimal>>),
75 | | }
   | |_- `value::Value` defined here
   |
   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
   = note: the matched value is of type `&value::Value`

For more information about this error, try `rustc --explain E0004`.
error: could not compile `sea-query` due to previous error
```

*Originally posted by @Acidic9 on Discord*