### PR TITLE
Basic Benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ rust_decimal = { version = "^1", optional = true }
 bigdecimal = { version = "^0.2", optional = true }
 uuid = { version = "^0", optional = true }
 
+[dev-dependencies]
+criterion = { version = "0.3", features = ["html_reports"] }
+
 [features]
 backend-mysql = []
 backend-postgres = []
@@ -92,3 +95,7 @@ required-features = ["backend-postgres"]
 name = "test-sqlite"
 path = "tests/sqlite/mod.rs"
 required-features = ["backend-sqlite"]
+
+[[bench]]
+name = "basic"
+harness = false

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -1,0 +1,39 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use sea_query::{tests_cfg::*, *};
+
+fn vanilla() -> String {
+    format!(
+        "SELECT `{}` from `{}` where `character` = {}",
+        "character",
+        "character".to_owned(),
+        123
+    )
+}
+
+fn select() -> SelectStatement {
+    Query::select()
+        .column(Char::Character)
+        .from(Char::Table)
+        .and_where(Expr::col(Char::Character).eq(123))
+        .to_owned()
+}
+
+fn select_and_build() {
+    select().build(MysqlQueryBuilder);
+}
+
+fn select_and_to_string() {
+    select().to_string(MysqlQueryBuilder);
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("vanilla", |b| b.iter(|| vanilla()));
+    c.bench_function("select", |b| b.iter(|| select()));
+    c.bench_function("select_and_build", |b| b.iter(|| select_and_build()));
+    c.bench_function("select_and_to_string", |b| {
+        b.iter(|| select_and_to_string())
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -50,7 +50,10 @@ where
 
 impl SqlWriter {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            counter: 0,
+            string: String::with_capacity(256),
+        }
     }
 
     pub fn push_param(&mut self, sign: &str, numbered: bool) {


### PR DESCRIPTION
This will hopefully initiate the investigation on how can we reduce the overhead in query building.

```
vanilla                 time:   [67.749 ns 68.807 ns 70.015 ns]                    
                        change: [-4.1822% -2.5650% -0.9084%] (p = 0.00 < 0.05)

select                  time:   [388.20 ns 389.35 ns 390.78 ns]                   
                        change: [-4.8171% -3.4688% -2.1313%] (p = 0.00 < 0.05)

select_and_build        time:   [1.3829 us 1.3897 us 1.3964 us]                              
                        change: [-6.5144% -5.4322% -4.3191%] (p = 0.00 < 0.05)

select_and_to_string    time:   [4.4667 us 4.4978 us 4.5307 us]                                  
                        change: [-0.7162% +1.5251% +4.1842%] (p = 0.24 > 0.05)

```