### PR TITLE
Support 'NULLS LAST' and 'NULLS FIRST'

### DIFF
--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -1,3 +1,15 @@
 use super::*;
 
-impl QueryBuilder for MysqlQueryBuilder {}
+impl QueryBuilder for MysqlQueryBuilder {
+    fn prepare_order_expr(
+        &self,
+        order_expr: &OrderExpr,
+        sql: &mut SqlWriter,
+        collector: &mut dyn FnMut(Value),
+    ) {
+        self.prepare_simple_expr(&order_expr.expr, sql, collector);
+        write!(sql, " ").unwrap();
+        self.prepare_order(&order_expr.order, sql, collector);
+        // MySql doesn't supports sort with nulls last
+    }
+}

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -1,15 +1,3 @@
 use super::*;
 
-impl QueryBuilder for MysqlQueryBuilder {
-    fn prepare_order_expr(
-        &self,
-        order_expr: &OrderExpr,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        self.prepare_simple_expr(&order_expr.expr, sql, collector);
-        write!(sql, " ").unwrap();
-        self.prepare_order(&order_expr.order, sql, collector);
-        // MySql doesn't supports sort with nulls last
-    }
-}
+impl QueryBuilder for MysqlQueryBuilder {}

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -17,11 +17,11 @@ impl QueryBuilder for MysqlQueryBuilder {
     ) {
         match order_expr.nulls {
             None => (),
-            Some(Nulls::Last) => {
+            Some(NullOrdering::Last) => {
                 self.prepare_simple_expr(&order_expr.expr, sql, collector);
                 write!(sql, " IS NULL ASC, ").unwrap()
             }
-            Some(Nulls::First) => {
+            Some(NullOrdering::First) => {
                 self.prepare_simple_expr(&order_expr.expr, sql, collector);
                 write!(sql, " IS NULL DESC, ").unwrap()
             }

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -1,3 +1,25 @@
 use super::*;
 
-impl QueryBuilder for MysqlQueryBuilder {}
+impl QueryBuilder for MysqlQueryBuilder {
+    fn prepare_order_expr(
+        &self,
+        order_expr: &OrderExpr,
+        sql: &mut SqlWriter,
+        collector: &mut dyn FnMut(Value),
+    ) {
+        match order_expr.nulls {
+            None => (),
+            Some(Nulls::Last) => {
+                self.prepare_simple_expr(&order_expr.expr, sql, collector);
+                write!(sql, " IS NULL ASC, ").unwrap()
+            }
+            Some(Nulls::First) => {
+                self.prepare_simple_expr(&order_expr.expr, sql, collector);
+                write!(sql, " IS NULL DESC, ").unwrap()
+            }
+        }
+        self.prepare_simple_expr(&order_expr.expr, sql, collector);
+        write!(sql, " ").unwrap();
+        self.prepare_order(&order_expr.order, sql, collector);
+    }
+}

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -105,7 +105,7 @@ impl QueryBuilder for PostgresQueryBuilder {
         match order_expr.nulls {
             None => (),
             Some(Nulls::Last) => write!(sql, " NULLS LAST").unwrap(),
-            Some(Nulls::First) => write!(sql, " NULLS FISRT").unwrap(),
+            Some(Nulls::First) => write!(sql, " NULLS FIRST").unwrap(),
         }
     }
 }

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -102,10 +102,10 @@ impl QueryBuilder for PostgresQueryBuilder {
         self.prepare_simple_expr(&order_expr.expr, sql, collector);
         write!(sql, " ").unwrap();
         self.prepare_order(&order_expr.order, sql, collector);
-        match order_expr.nulls_last {
+        match order_expr.nulls {
             None => (),
-            Some(true) => write!(sql, " NULLS LAST").unwrap(),
-            Some(false) => write!(sql, " NULLS FISRT").unwrap(),
+            Some(Nulls::Last) => write!(sql, " NULLS LAST").unwrap(),
+            Some(Nulls::First) => write!(sql, " NULLS FISRT").unwrap(),
         }
     }
 }

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -92,4 +92,20 @@ impl QueryBuilder for PostgresQueryBuilder {
             _ => QueryBuilder::prepare_simple_expr_common(self, simple_expr, sql, collector),
         }
     }
+
+    fn prepare_order_expr(
+        &self,
+        order_expr: &OrderExpr,
+        sql: &mut SqlWriter,
+        collector: &mut dyn FnMut(Value),
+    ) {
+        self.prepare_simple_expr(&order_expr.expr, sql, collector);
+        write!(sql, " ").unwrap();
+        self.prepare_order(&order_expr.order, sql, collector);
+        match order_expr.nulls_last {
+            None => (),
+            Some(true) => write!(sql, " NULLS LAST").unwrap(),
+            Some(false) => write!(sql, " NULLS FISRT").unwrap(),
+        }
+    }
 }

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -86,8 +86,8 @@ impl QueryBuilder for PostgresQueryBuilder {
         self.prepare_order(&order_expr.order, sql, collector);
         match order_expr.nulls {
             None => (),
-            Some(Nulls::Last) => write!(sql, " NULLS LAST").unwrap(),
-            Some(Nulls::First) => write!(sql, " NULLS FIRST").unwrap(),
+            Some(NullOrdering::Last) => write!(sql, " NULLS LAST").unwrap(),
+            Some(NullOrdering::First) => write!(sql, " NULLS FIRST").unwrap(),
         }
     }
 }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -637,11 +637,6 @@ pub trait QueryBuilder: QuotedBuilder {
         self.prepare_simple_expr(&order_expr.expr, sql, collector);
         write!(sql, " ").unwrap();
         self.prepare_order(&order_expr.order, sql, collector);
-        match order_expr.nulls_last {
-            Some(true) => write!(sql, " NULLS LAST").unwrap(),
-            Some(false) => write!(sql, " NULLS FISRT").unwrap(),
-            _ => (),
-        }
     }
 
     /// Translate [`JoinOn`] into SQL statement.

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -637,6 +637,11 @@ pub trait QueryBuilder: QuotedBuilder {
         self.prepare_simple_expr(&order_expr.expr, sql, collector);
         write!(sql, " ").unwrap();
         self.prepare_order(&order_expr.order, sql, collector);
+        match order_expr.nulls_last {
+            Some(true) => write!(sql, " NULLS LAST").unwrap(),
+            Some(false) => write!(sql, " NULLS FISRT").unwrap(),
+            _ => (),
+        }
     }
 
     /// Translate [`JoinOn`] into SQL statement.

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -23,10 +23,10 @@ impl QueryBuilder for SqliteQueryBuilder {
         self.prepare_simple_expr(&order_expr.expr, sql, collector);
         write!(sql, " ").unwrap();
         self.prepare_order(&order_expr.order, sql, collector);
-        match order_expr.nulls_last {
+        match order_expr.nulls {
             None => (),
-            Some(true) => write!(sql, " NULLS LAST").unwrap(),
-            Some(false) => write!(sql, " NULLS FISRT").unwrap(),
+            Some(Nulls::Last) => write!(sql, " NULLS LAST").unwrap(),
+            Some(Nulls::First) => write!(sql, " NULLS FISRT").unwrap(),
         }
     }
 }

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -25,8 +25,8 @@ impl QueryBuilder for SqliteQueryBuilder {
         self.prepare_order(&order_expr.order, sql, collector);
         match order_expr.nulls {
             None => (),
-            Some(Nulls::Last) => write!(sql, " NULLS LAST").unwrap(),
-            Some(Nulls::First) => write!(sql, " NULLS FIRST").unwrap(),
+            Some(NullOrdering::Last) => write!(sql, " NULLS LAST").unwrap(),
+            Some(NullOrdering::First) => write!(sql, " NULLS FIRST").unwrap(),
         }
     }
 }

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -26,7 +26,7 @@ impl QueryBuilder for SqliteQueryBuilder {
         match order_expr.nulls {
             None => (),
             Some(Nulls::Last) => write!(sql, " NULLS LAST").unwrap(),
-            Some(Nulls::First) => write!(sql, " NULLS FISRT").unwrap(),
+            Some(Nulls::First) => write!(sql, " NULLS FIRST").unwrap(),
         }
     }
 }

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -13,4 +13,20 @@ impl QueryBuilder for SqliteQueryBuilder {
     ) {
         // SQLite doesn't supports row locking
     }
+
+    fn prepare_order_expr(
+        &self,
+        order_expr: &OrderExpr,
+        sql: &mut SqlWriter,
+        collector: &mut dyn FnMut(Value),
+    ) {
+        self.prepare_simple_expr(&order_expr.expr, sql, collector);
+        write!(sql, " ").unwrap();
+        self.prepare_order(&order_expr.order, sql, collector);
+        match order_expr.nulls_last {
+            None => (),
+            Some(true) => write!(sql, " NULLS LAST").unwrap(),
+            Some(false) => write!(sql, " NULLS FISRT").unwrap(),
+        }
+    }
 }

--- a/src/query/ordered.rs
+++ b/src/query/ordered.rs
@@ -32,7 +32,7 @@ pub trait OrderedStatement {
         self.add_order_by(OrderExpr {
             expr: SimpleExpr::Column(col.into_column_ref()),
             order,
-            nulls_last: None,
+            nulls: None,
         })
     }
 
@@ -53,7 +53,7 @@ pub trait OrderedStatement {
         self.add_order_by(OrderExpr {
             expr,
             order,
-            nulls_last: None,
+            nulls: None,
         })
     }
 
@@ -66,7 +66,7 @@ pub trait OrderedStatement {
             self.add_order_by(OrderExpr {
                 expr: SimpleExpr::Custom(c.to_string()),
                 order,
-                nulls_last: None,
+                nulls: None,
             });
         });
         self
@@ -81,7 +81,7 @@ pub trait OrderedStatement {
             self.add_order_by(OrderExpr {
                 expr: SimpleExpr::Column(c.into_column_ref()),
                 order,
-                nulls_last: None,
+                nulls: None,
             });
         });
         self
@@ -113,8 +113,8 @@ pub trait OrderedStatement {
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .order_by_nulls_last(Glyph::Image, Order::Desc, true)
-    ///     .order_by_nulls_last((Glyph::Table, Glyph::Aspect), Order::Asc, false)
+    ///     .order_by_nulls_last(Glyph::Image, Order::Desc, Nulls::Last)
+    ///     .order_by_nulls_last((Glyph::Table, Glyph::Aspect), Order::Asc, Nulls::First)
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -122,14 +122,14 @@ pub trait OrderedStatement {
     ///     r#"SELECT "aspect" FROM "glyph" ORDER BY "image" DESC NULLS LAST, "glyph"."aspect" ASC NULLS FISRT"#
     /// );
     /// ```
-    fn order_by_nulls_last<T>(&mut self, col: T, order: Order, nulls_last: bool) -> &mut Self
+    fn order_by_nulls_last<T>(&mut self, col: T, order: Order, nulls: Nulls) -> &mut Self
     where
         T: IntoColumnRef,
     {
         self.add_order_by(OrderExpr {
             expr: SimpleExpr::Column(col.into_column_ref()),
             order,
-            nulls_last: Some(nulls_last),
+            nulls: Some(nulls),
         })
     }
 
@@ -138,21 +138,17 @@ pub trait OrderedStatement {
         &mut self,
         expr: SimpleExpr,
         order: Order,
-        nulls_last: bool,
+        nulls: Nulls,
     ) -> &mut Self {
         self.add_order_by(OrderExpr {
             expr,
             order,
-            nulls_last: Some(nulls_last),
+            nulls: Some(nulls),
         })
     }
 
     /// Order by custom string with nulls order option.
-    fn order_by_customs_nulls_last<T>(
-        &mut self,
-        cols: Vec<(T, Order)>,
-        nulls_last: bool,
-    ) -> &mut Self
+    fn order_by_customs_nulls_last<T>(&mut self, cols: Vec<(T, Order)>, nulls: Nulls) -> &mut Self
     where
         T: ToString,
     {
@@ -160,18 +156,14 @@ pub trait OrderedStatement {
             self.add_order_by(OrderExpr {
                 expr: SimpleExpr::Custom(c.to_string()),
                 order,
-                nulls_last: Some(nulls_last),
+                nulls: Some(nulls),
             });
         });
         self
     }
 
     /// Order by vector of columns with nulls order option.
-    fn order_by_columns_nulls_last<T>(
-        &mut self,
-        cols: Vec<(T, Order)>,
-        nulls_last: bool,
-    ) -> &mut Self
+    fn order_by_columns_nulls_last<T>(&mut self, cols: Vec<(T, Order)>, nulls: Nulls) -> &mut Self
     where
         T: IntoColumnRef,
     {
@@ -179,7 +171,7 @@ pub trait OrderedStatement {
             self.add_order_by(OrderExpr {
                 expr: SimpleExpr::Column(c.into_column_ref()),
                 order,
-                nulls_last: Some(nulls_last),
+                nulls: Some(nulls),
             });
         });
         self

--- a/src/query/ordered.rs
+++ b/src/query/ordered.rs
@@ -121,6 +121,10 @@ pub trait OrderedStatement {
     ///     query.to_string(PostgresQueryBuilder),
     ///     r#"SELECT "aspect" FROM "glyph" ORDER BY "image" DESC NULLS LAST, "glyph"."aspect" ASC NULLS FISRT"#
     /// );
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `aspect` FROM `glyph` ORDER BY `image` IS NULL ASC, `image` DESC, `glyph`.`aspect` IS NULL DESC, `glyph`.`aspect` ASC"#
+    /// );
     /// ```
     fn order_by_with_nulls<T>(&mut self, col: T, order: Order, nulls: Nulls) -> &mut Self
     where

--- a/src/query/ordered.rs
+++ b/src/query/ordered.rs
@@ -113,8 +113,8 @@ pub trait OrderedStatement {
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .order_by_nulls_last(Glyph::Image, Order::Desc, Nulls::Last)
-    ///     .order_by_nulls_last((Glyph::Table, Glyph::Aspect), Order::Asc, Nulls::First)
+    ///     .order_by_with_nulls(Glyph::Image, Order::Desc, Nulls::Last)
+    ///     .order_by_with_nulls((Glyph::Table, Glyph::Aspect), Order::Asc, Nulls::First)
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -122,7 +122,7 @@ pub trait OrderedStatement {
     ///     r#"SELECT "aspect" FROM "glyph" ORDER BY "image" DESC NULLS LAST, "glyph"."aspect" ASC NULLS FISRT"#
     /// );
     /// ```
-    fn order_by_nulls_last<T>(&mut self, col: T, order: Order, nulls: Nulls) -> &mut Self
+    fn order_by_with_nulls<T>(&mut self, col: T, order: Order, nulls: Nulls) -> &mut Self
     where
         T: IntoColumnRef,
     {
@@ -134,7 +134,7 @@ pub trait OrderedStatement {
     }
 
     /// Order by [`SimpleExpr`] with nulls order option.
-    fn order_by_expr_nulls_last(
+    fn order_by_expr_with_nulls(
         &mut self,
         expr: SimpleExpr,
         order: Order,
@@ -148,7 +148,7 @@ pub trait OrderedStatement {
     }
 
     /// Order by custom string with nulls order option.
-    fn order_by_customs_nulls_last<T>(&mut self, cols: Vec<(T, Order)>, nulls: Nulls) -> &mut Self
+    fn order_by_customs_with_nulls<T>(&mut self, cols: Vec<(T, Order)>, nulls: Nulls) -> &mut Self
     where
         T: ToString,
     {
@@ -163,7 +163,7 @@ pub trait OrderedStatement {
     }
 
     /// Order by vector of columns with nulls order option.
-    fn order_by_columns_nulls_last<T>(&mut self, cols: Vec<(T, Order)>, nulls: Nulls) -> &mut Self
+    fn order_by_columns_with_nulls<T>(&mut self, cols: Vec<(T, Order)>, nulls: Nulls) -> &mut Self
     where
         T: IntoColumnRef,
     {

--- a/src/query/ordered.rs
+++ b/src/query/ordered.rs
@@ -119,7 +119,7 @@ pub trait OrderedStatement {
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "aspect" FROM "glyph" ORDER BY "image" DESC NULLS LAST, "glyph"."aspect" ASC NULLS FISRT"#
+    ///     r#"SELECT "aspect" FROM "glyph" ORDER BY "image" DESC NULLS LAST, "glyph"."aspect" ASC NULLS FIRST"#
     /// );
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),

--- a/src/query/ordered.rs
+++ b/src/query/ordered.rs
@@ -113,8 +113,8 @@ pub trait OrderedStatement {
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .order_by_with_nulls(Glyph::Image, Order::Desc, Nulls::Last)
-    ///     .order_by_with_nulls((Glyph::Table, Glyph::Aspect), Order::Asc, Nulls::First)
+    ///     .order_by_with_nulls(Glyph::Image, Order::Desc, NullOrdering::Last)
+    ///     .order_by_with_nulls((Glyph::Table, Glyph::Aspect), Order::Asc, NullOrdering::First)
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -126,7 +126,7 @@ pub trait OrderedStatement {
     ///     r#"SELECT `aspect` FROM `glyph` ORDER BY `image` IS NULL ASC, `image` DESC, `glyph`.`aspect` IS NULL DESC, `glyph`.`aspect` ASC"#
     /// );
     /// ```
-    fn order_by_with_nulls<T>(&mut self, col: T, order: Order, nulls: Nulls) -> &mut Self
+    fn order_by_with_nulls<T>(&mut self, col: T, order: Order, nulls: NullOrdering) -> &mut Self
     where
         T: IntoColumnRef,
     {
@@ -142,7 +142,7 @@ pub trait OrderedStatement {
         &mut self,
         expr: SimpleExpr,
         order: Order,
-        nulls: Nulls,
+        nulls: NullOrdering,
     ) -> &mut Self {
         self.add_order_by(OrderExpr {
             expr,
@@ -152,7 +152,7 @@ pub trait OrderedStatement {
     }
 
     /// Order by custom string with nulls order option.
-    fn order_by_customs_with_nulls<T>(&mut self, cols: Vec<(T, Order, Nulls)>) -> &mut Self
+    fn order_by_customs_with_nulls<T>(&mut self, cols: Vec<(T, Order, NullOrdering)>) -> &mut Self
     where
         T: ToString,
     {
@@ -167,7 +167,7 @@ pub trait OrderedStatement {
     }
 
     /// Order by vector of columns with nulls order option.
-    fn order_by_columns_with_nulls<T>(&mut self, cols: Vec<(T, Order, Nulls)>) -> &mut Self
+    fn order_by_columns_with_nulls<T>(&mut self, cols: Vec<(T, Order, NullOrdering)>) -> &mut Self
     where
         T: IntoColumnRef,
     {

--- a/src/query/ordered.rs
+++ b/src/query/ordered.rs
@@ -148,11 +148,11 @@ pub trait OrderedStatement {
     }
 
     /// Order by custom string with nulls order option.
-    fn order_by_customs_with_nulls<T>(&mut self, cols: Vec<(T, Order)>, nulls: Nulls) -> &mut Self
+    fn order_by_customs_with_nulls<T>(&mut self, cols: Vec<(T, Order, Nulls)>) -> &mut Self
     where
         T: ToString,
     {
-        cols.into_iter().for_each(|(c, order)| {
+        cols.into_iter().for_each(|(c, order, nulls)| {
             self.add_order_by(OrderExpr {
                 expr: SimpleExpr::Custom(c.to_string()),
                 order,
@@ -163,11 +163,11 @@ pub trait OrderedStatement {
     }
 
     /// Order by vector of columns with nulls order option.
-    fn order_by_columns_with_nulls<T>(&mut self, cols: Vec<(T, Order)>, nulls: Nulls) -> &mut Self
+    fn order_by_columns_with_nulls<T>(&mut self, cols: Vec<(T, Order, Nulls)>) -> &mut Self
     where
         T: IntoColumnRef,
     {
-        cols.into_iter().for_each(|(c, order)| {
+        cols.into_iter().for_each(|(c, order, nulls)| {
             self.add_order_by(OrderExpr {
                 expr: SimpleExpr::Column(c.into_column_ref()),
                 order,

--- a/src/types.rs
+++ b/src/types.rs
@@ -148,12 +148,19 @@ pub enum JoinType {
     RightJoin,
 }
 
+/// Nulls order
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Nulls {
+    First,
+    Last,
+}
+
 /// Order expression
 #[derive(Debug, Clone)]
 pub struct OrderExpr {
     pub(crate) expr: SimpleExpr,
     pub(crate) order: Order,
-    pub(crate) nulls_last: Option<bool>,
+    pub(crate) nulls: Option<Nulls>,
 }
 
 /// Join on types

--- a/src/types.rs
+++ b/src/types.rs
@@ -153,6 +153,7 @@ pub enum JoinType {
 pub struct OrderExpr {
     pub(crate) expr: SimpleExpr,
     pub(crate) order: Order,
+    pub(crate) nulls_last: Option<bool>,
 }
 
 /// Join on types

--- a/src/types.rs
+++ b/src/types.rs
@@ -153,7 +153,7 @@ pub enum JoinType {
 
 /// Nulls order
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Nulls {
+pub enum NullOrdering {
     First,
     Last,
 }
@@ -163,7 +163,7 @@ pub enum Nulls {
 pub struct OrderExpr {
     pub(crate) expr: SimpleExpr,
     pub(crate) order: Order,
-    pub(crate) nulls: Option<Nulls>,
+    pub(crate) nulls: Option<NullOrdering>,
 }
 
 /// Join on types

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -791,6 +791,79 @@ fn select_48() {
 }
 
 #[test]
+fn select_49() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by_with_nulls(Glyph::Image, Order::Desc, Nulls::First)
+            .order_by_with_nulls((Glyph::Table, Glyph::Aspect), Order::Asc, Nulls::Last)
+            .to_string(MysqlQueryBuilder),
+        [
+            r#"SELECT `aspect`"#,
+            r#"FROM `glyph`"#,
+            r#"WHERE IFNULL(`aspect`, 0) > 2"#,
+            r#"ORDER BY `image` IS NULL DESC,"#,
+            r#"`image` DESC,"#,
+            r#"`glyph`.`aspect` IS NULL ASC,"#,
+            r#"`glyph`.`aspect` ASC"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+fn select_50() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by_columns_with_nulls(vec![
+                (Glyph::Id, Order::Asc, Nulls::First),
+                (Glyph::Aspect, Order::Desc, Nulls::Last),
+            ])
+            .to_string(MysqlQueryBuilder),
+        [
+            r#"SELECT `aspect`"#,
+            r#"FROM `glyph`"#,
+            r#"WHERE IFNULL(`aspect`, 0) > 2"#,
+            r#"ORDER BY `id` IS NULL DESC,"#,
+            r#"`id` ASC,"#,
+            r#"`aspect` IS NULL ASC,"#,
+            r#"`aspect` DESC"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+fn select_51() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by_columns_with_nulls(vec![
+                ((Glyph::Table, Glyph::Id), Order::Asc, Nulls::First),
+                ((Glyph::Table, Glyph::Aspect), Order::Desc, Nulls::Last),
+            ])
+            .to_string(MysqlQueryBuilder),
+        [
+            r#"SELECT `aspect`"#,
+            r#"FROM `glyph`"#,
+            r#"WHERE IFNULL(`aspect`, 0) > 2"#,
+            r#"ORDER BY `glyph`.`id` IS NULL DESC,"#,
+            r#"`glyph`.`id` ASC,"#,
+            r#"`glyph`.`aspect` IS NULL ASC,"#,
+            r#"`glyph`.`aspect` DESC"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -825,8 +825,12 @@ fn select_51() {
             .columns(vec![Glyph::Aspect,])
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .order_by_with_nulls(Glyph::Image, Order::Desc, Nulls::First)
-            .order_by_with_nulls((Glyph::Table, Glyph::Aspect), Order::Asc, Nulls::Last)
+            .order_by_with_nulls(Glyph::Image, Order::Desc, NullOrdering::First)
+            .order_by_with_nulls(
+                (Glyph::Table, Glyph::Aspect),
+                Order::Asc,
+                NullOrdering::Last
+            )
             .to_string(MysqlQueryBuilder),
         [
             r#"SELECT `aspect`"#,
@@ -849,8 +853,8 @@ fn select_52() {
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by_columns_with_nulls(vec![
-                (Glyph::Id, Order::Asc, Nulls::First),
-                (Glyph::Aspect, Order::Desc, Nulls::Last),
+                (Glyph::Id, Order::Asc, NullOrdering::First),
+                (Glyph::Aspect, Order::Desc, NullOrdering::Last),
             ])
             .to_string(MysqlQueryBuilder),
         [
@@ -874,8 +878,12 @@ fn select_53() {
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by_columns_with_nulls(vec![
-                ((Glyph::Table, Glyph::Id), Order::Asc, Nulls::First),
-                ((Glyph::Table, Glyph::Aspect), Order::Desc, Nulls::Last),
+                ((Glyph::Table, Glyph::Id), Order::Asc, NullOrdering::First),
+                (
+                    (Glyph::Table, Glyph::Aspect),
+                    Order::Desc,
+                    NullOrdering::Last
+                ),
             ])
             .to_string(MysqlQueryBuilder),
         [

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -809,8 +809,12 @@ fn select_51() {
             .columns(vec![Glyph::Aspect,])
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .order_by_with_nulls(Glyph::Image, Order::Desc, Nulls::First)
-            .order_by_with_nulls((Glyph::Table, Glyph::Aspect), Order::Asc, Nulls::Last)
+            .order_by_with_nulls(Glyph::Image, Order::Desc, NullOrdering::First)
+            .order_by_with_nulls(
+                (Glyph::Table, Glyph::Aspect),
+                Order::Asc,
+                NullOrdering::Last
+            )
             .to_string(PostgresQueryBuilder),
         [
             r#"SELECT "aspect""#,
@@ -831,8 +835,8 @@ fn select_52() {
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by_columns_with_nulls(vec![
-                (Glyph::Id, Order::Asc, Nulls::First),
-                (Glyph::Aspect, Order::Desc, Nulls::Last),
+                (Glyph::Id, Order::Asc, NullOrdering::First),
+                (Glyph::Aspect, Order::Desc, NullOrdering::Last),
             ])
             .to_string(PostgresQueryBuilder),
         [
@@ -854,8 +858,12 @@ fn select_53() {
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by_columns_with_nulls(vec![
-                ((Glyph::Table, Glyph::Id), Order::Asc, Nulls::First),
-                ((Glyph::Table, Glyph::Aspect), Order::Desc, Nulls::Last),
+                ((Glyph::Table, Glyph::Id), Order::Asc, NullOrdering::First),
+                (
+                    (Glyph::Table, Glyph::Aspect),
+                    Order::Desc,
+                    NullOrdering::Last
+                ),
             ])
             .to_string(PostgresQueryBuilder),
         [

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -775,6 +775,73 @@ fn select_48() {
 }
 
 #[test]
+fn select_49() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by_with_nulls(Glyph::Image, Order::Desc, Nulls::First)
+            .order_by_with_nulls((Glyph::Table, Glyph::Aspect), Order::Asc, Nulls::Last)
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"SELECT "aspect""#,
+            r#"FROM "glyph""#,
+            r#"WHERE COALESCE("aspect", 0) > 2"#,
+            r#"ORDER BY "image" DESC NULLS FIRST,"#,
+            r#""glyph"."aspect" ASC NULLS LAST"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+fn select_50() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by_columns_with_nulls(vec![
+                (Glyph::Id, Order::Asc, Nulls::First),
+                (Glyph::Aspect, Order::Desc, Nulls::Last),
+            ])
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"SELECT "aspect""#,
+            r#"FROM "glyph""#,
+            r#"WHERE COALESCE("aspect", 0) > 2"#,
+            r#"ORDER BY "id" ASC NULLS FIRST,"#,
+            r#""aspect" DESC NULLS LAST"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+fn select_51() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by_columns_with_nulls(vec![
+                ((Glyph::Table, Glyph::Id), Order::Asc, Nulls::First),
+                ((Glyph::Table, Glyph::Aspect), Order::Desc, Nulls::Last),
+            ])
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"SELECT "aspect""#,
+            r#"FROM "glyph""#,
+            r#"WHERE COALESCE("aspect", 0) > 2"#,
+            r#"ORDER BY "glyph"."id" ASC NULLS FIRST,"#,
+            r#""glyph"."aspect" DESC NULLS LAST"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -791,6 +791,73 @@ fn select_48() {
 }
 
 #[test]
+fn select_49() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by_with_nulls(Glyph::Image, Order::Desc, Nulls::First)
+            .order_by_with_nulls((Glyph::Table, Glyph::Aspect), Order::Asc, Nulls::Last)
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"SELECT `aspect`"#,
+            r#"FROM `glyph`"#,
+            r#"WHERE IFNULL(`aspect`, 0) > 2"#,
+            r#"ORDER BY `image` DESC NULLS FIRST,"#,
+            r#"`glyph`.`aspect` ASC NULLS LAST"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+fn select_50() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by_columns_with_nulls(vec![
+                (Glyph::Id, Order::Asc, Nulls::First),
+                (Glyph::Aspect, Order::Desc, Nulls::Last),
+            ])
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"SELECT `aspect`"#,
+            r#"FROM `glyph`"#,
+            r#"WHERE IFNULL(`aspect`, 0) > 2"#,
+            r#"ORDER BY `id` ASC NULLS FIRST,"#,
+            r#"`aspect` DESC NULLS LAST"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+fn select_51() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by_columns_with_nulls(vec![
+                ((Glyph::Table, Glyph::Id), Order::Asc, Nulls::First),
+                ((Glyph::Table, Glyph::Aspect), Order::Desc, Nulls::Last),
+            ])
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"SELECT `aspect`"#,
+            r#"FROM `glyph`"#,
+            r#"WHERE IFNULL(`aspect`, 0) > 2"#,
+            r#"ORDER BY `glyph`.`id` ASC NULLS FIRST,"#,
+            r#"`glyph`.`aspect` DESC NULLS LAST"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -825,8 +825,12 @@ fn select_51() {
             .columns(vec![Glyph::Aspect,])
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .order_by_with_nulls(Glyph::Image, Order::Desc, Nulls::First)
-            .order_by_with_nulls((Glyph::Table, Glyph::Aspect), Order::Asc, Nulls::Last)
+            .order_by_with_nulls(Glyph::Image, Order::Desc, NullOrdering::First)
+            .order_by_with_nulls(
+                (Glyph::Table, Glyph::Aspect),
+                Order::Asc,
+                NullOrdering::Last
+            )
             .to_string(SqliteQueryBuilder),
         [
             r#"SELECT `aspect`"#,
@@ -847,8 +851,8 @@ fn select_52() {
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by_columns_with_nulls(vec![
-                (Glyph::Id, Order::Asc, Nulls::First),
-                (Glyph::Aspect, Order::Desc, Nulls::Last),
+                (Glyph::Id, Order::Asc, NullOrdering::First),
+                (Glyph::Aspect, Order::Desc, NullOrdering::Last),
             ])
             .to_string(SqliteQueryBuilder),
         [
@@ -870,8 +874,12 @@ fn select_53() {
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by_columns_with_nulls(vec![
-                ((Glyph::Table, Glyph::Id), Order::Asc, Nulls::First),
-                ((Glyph::Table, Glyph::Aspect), Order::Desc, Nulls::Last),
+                ((Glyph::Table, Glyph::Id), Order::Asc, NullOrdering::First),
+                (
+                    (Glyph::Table, Glyph::Aspect),
+                    Order::Desc,
+                    NullOrdering::Last
+                ),
             ])
             .to_string(SqliteQueryBuilder),
         [


### PR DESCRIPTION
Hi,
In PostgreSQL, by default, null values sort as if larger than any non-null value
ref: https://www.postgresql.org/docs/current/queries-order.html
SQLite considers NULL values to be smaller than any other values for sorting purposes
ref: https://sqlite.org/lang_select.html
Mysql seems doesn't support the syntax to sort nulls last in.

#209 