### PR TITLE
Add SELECT EXISTS, Fix #118

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -51,6 +51,7 @@ pub struct SelectStatement {
     pub(crate) limit: Option<Value>,
     pub(crate) offset: Option<Value>,
     pub(crate) lock: Option<LockType>,
+    pub(crate) exists: Option<bool>,
 }
 
 /// List of distinct keywords that can be used in select statement
@@ -122,6 +123,7 @@ impl SelectStatement {
             limit: None,
             offset: None,
             lock: None,
+            exists: None,
         }
     }
 
@@ -140,6 +142,7 @@ impl SelectStatement {
             limit: self.limit.take(),
             offset: self.offset.take(),
             lock: self.lock.take(),
+            exists: self.exists.take(),
         }
     }
 
@@ -279,6 +282,12 @@ impl SelectStatement {
     /// Select distinct
     pub fn distinct(&mut self) -> &mut Self {
         self.distinct = Some(SelectDistinct::Distinct);
+        self
+    }
+
+    /// Select exists
+    pub fn exists(&mut self) -> &mut Self {
+        self.exists = Some(true);
         self
     }
 
@@ -1672,3 +1681,4 @@ impl ConditionalStatement for SelectStatement {
         self
     }
 }
+ 

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -791,6 +791,19 @@ fn select_48() {
 }
 
 #[test]
+fn select_49() {
+    assert_eq!(
+        Query::select()
+            .exists()
+            .columns(vec![Char::Character])
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).eq("A"))
+            .to_string(MysqlQueryBuilder),
+        "SELECT EXISTS (SELECT * FROM `character` WHERE `character` = 'A') AS `exists`"
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(
@@ -904,3 +917,4 @@ fn delete_1() {
         "DELETE FROM `glyph` WHERE `id` = 1 ORDER BY `id` ASC LIMIT 1"
     );
 }
+ 

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -775,6 +775,19 @@ fn select_48() {
 }
 
 #[test]
+fn select_49() {
+    assert_eq!(
+        Query::select()
+            .exists()
+            .columns(vec![Char::Character])
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).eq("A"))
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT EXISTS (SELECT * FROM "character" WHERE "character" = 'A') AS "exists""#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -791,6 +791,19 @@ fn select_48() {
 }
 
 #[test]
+fn select_49() {
+    assert_eq!(
+        Query::select()
+            .exists()
+            .columns(vec![Char::Character])
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).eq("A"))
+            .to_string(SqliteQueryBuilder),
+        "SELECT EXISTS (SELECT * FROM `character` WHERE `character` = 'A') AS `exists`"
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(


### PR DESCRIPTION
This would add the SELECT EXISTS statement with this api:
```rust
Query::select()
    .exists()
    .from(Char::Table)
    .and_where(Expr::col(Char::Character).eq("A"))
```

I had a doubt about the api to use, my second shot would have been this one, which would have been syntactically more equivalent to the final SQL query but more verbose (let me know if you'd preferred this one):
```rust
Query::exists(
    Query::select()
        .from(Char::Table)
        .and_where(Expr::col(Char::Character).eq("A")),
    Alias::new("exists")
)
```

I added some comments into the code to describe the process I used since it's relatively "desynchronised" with the rest of the `prepare_select_statement` due to one thing:
- The `SELECT EXISTS` statement needs to be executed "as it self", without any table to query in the main expression.

Due to this I couldn't use a function (because if no table is passed, it only results to a `SELECT ` string without any further expression). 