### PR TITLE
Add Expr::asterisk() and Expr::tbl_asterisk(table: DynIden) methods - Fix #217

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -251,10 +251,10 @@ pub trait QueryBuilder: QuotedBuilder {
                         write!(sql, ".").unwrap();
                         column.prepare(sql, self.quote());
                     }
-                    ColumnRef::Wildcard => {
+                    ColumnRef::Asterisk => {
                         write!(sql, "*").unwrap();
                     }
-                    ColumnRef::TableWildcard(table) => {
+                    ColumnRef::TableAsterisk(table) => {
                         table.prepare(sql, self.quote());
                         write!(sql, ".*").unwrap();
                     }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -251,6 +251,13 @@ pub trait QueryBuilder: QuotedBuilder {
                         write!(sql, ".").unwrap();
                         column.prepare(sql, self.quote());
                     }
+                    ColumnRef::Wildcard => {
+                        write!(sql, "*").unwrap();
+                    }
+                    ColumnRef::TableWildcard(table) => {
+                        table.prepare(sql, self.quote());
+                        write!(sql, ".*").unwrap();
+                    }
                 };
             }
             SimpleExpr::Tuple(exprs) => {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -67,7 +67,7 @@ impl Expr {
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT * FROM `character`#
+    ///     r#"SELECT * FROM `character`"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
@@ -212,7 +212,7 @@ impl Expr {
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT * FROM `character`#
+    ///     r#"SELECT * FROM `character`"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
@@ -228,7 +228,7 @@ impl Expr {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .tbl_wildcard(Char::Character)
+    ///     .expr(Expr::tbl_wildcard(Char::Table))
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
     ///     .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -53,7 +53,7 @@ impl Expr {
         }
     }
 
-    /// Express the wildcard without table prefix.
+    /// Express the asterisk without table prefix.
     ///
     /// # Examples
     ///
@@ -61,7 +61,7 @@ impl Expr {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Expr::wildcard())
+    ///     .expr(Expr::asterisk())
     ///     .from(Char::Table)
     ///     .to_owned();
     ///
@@ -101,8 +101,8 @@ impl Expr {
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` = 1"#
     /// );
     /// ```
-    pub fn wildcard() -> Self {
-        Self::col(ColumnRef::Wildcard)
+    pub fn asterisk() -> Self {
+        Self::col(ColumnRef::Asterisk)
     }
 
     /// Express the target column without table prefix.
@@ -198,7 +198,7 @@ impl Expr {
         ))
     }
 
-    /// Express the wildcard with table prefix.
+    /// Express the asterisk with table prefix.
     ///
     /// # Examples
     ///
@@ -206,7 +206,7 @@ impl Expr {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Expr::wildcard())
+    ///     .expr(Expr::asterisk())
     ///     .from(Char::Table)
     ///     .to_owned();
     ///
@@ -228,7 +228,7 @@ impl Expr {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Expr::tbl_wildcard(Char::Table))
+    ///     .expr(Expr::tbl_asterisk(Char::Table))
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
     ///     .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
@@ -247,11 +247,11 @@ impl Expr {
     ///     r#"SELECT `character`.*, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// ```
-    pub fn tbl_wildcard<T>(t: T) -> Self
+    pub fn tbl_asterisk<T>(t: T) -> Self
     where
         T: IntoIden
     {
-        Self::col(ColumnRef::TableWildcard(t.into_iden()))
+        Self::col(ColumnRef::TableAsterisk(t.into_iden()))
     }
 
     /// Express the target column with table prefix.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -53,6 +53,58 @@ impl Expr {
         }
     }
 
+    /// Express the wildcard without table prefix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Expr::wildcard())
+    ///     .from(Char::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT * FROM `character`#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT * FROM "character""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT * FROM `character`"#
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::col((Char::Table, Char::SizeW)).eq(1))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` = 1"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" = 1"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` = 1"#
+    /// );
+    /// ```
+    pub fn wildcard() -> Self {
+        Self::col(ColumnRef::Wildcard)
+    }
+
     /// Express the target column without table prefix.
     ///
     /// # Examples
@@ -144,6 +196,62 @@ impl Expr {
         Expr::expr(SimpleExpr::Tuple(
             n.into_iter().collect::<Vec<SimpleExpr>>(),
         ))
+    }
+
+    /// Express the wildcard with table prefix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Expr::wildcard())
+    ///     .from(Char::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT * FROM `character`#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT * FROM "character""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT * FROM `character`"#
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .tbl_wildcard(Char::Character)
+    ///     .column((Font::Table, Font::Name))
+    ///     .from(Char::Table)
+    ///     .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character`.*, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character".*, "font"."name" FROM "character" INNER JOIN "font" ON "character"."font_id" = "font"."id""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT `character`.*, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
+    /// );
+    /// ```
+    pub fn tbl_wildcard<T>(t: T) -> Self
+    where
+        T: IntoIden
+    {
+        Self::col(ColumnRef::TableWildcard(t.into_iden()))
     }
 
     /// Express the target column with table prefix.

--- a/src/types.rs
+++ b/src/types.rs
@@ -63,6 +63,8 @@ pub enum ColumnRef {
     Column(DynIden),
     TableColumn(DynIden, DynIden),
     SchemaTableColumn(DynIden, DynIden, DynIden),
+    Wildcard,
+    TableWildcard(DynIden)
 }
 
 pub trait IntoColumnRef {

--- a/src/types.rs
+++ b/src/types.rs
@@ -63,8 +63,8 @@ pub enum ColumnRef {
     Column(DynIden),
     TableColumn(DynIden, DynIden),
     SchemaTableColumn(DynIden, DynIden, DynIden),
-    Wildcard,
-    TableWildcard(DynIden)
+    Asterisk,
+    TableAsterisk(DynIden)
 }
 
 pub trait IntoColumnRef {

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -793,7 +793,7 @@ fn select_48() {
 #[test]
 fn select_49() {
     let statement = sea_query::Query::select()
-        .epxr(Expr::wildcard())
+        .expr(Expr::wildcard())
         .from(Char::Table)
         .to_string(MysqlQueryBuilder);
 
@@ -806,7 +806,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = sea_query::Query::select()
-        .epxr(Expr::tbl_wildcard(Char::Table))
+        .expr(Expr::tbl_wildcard(Char::Table))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
@@ -814,7 +814,7 @@ fn select_50() {
 
     assert_eq!(
         statement,
-        r#"SELECT `character`.*, `font`.`name` FROM `character` INNJER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
+        r#"SELECT `character`.*, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     );
 }
 

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -793,7 +793,7 @@ fn select_48() {
 #[test]
 fn select_49() {
     let statement = sea_query::Query::select()
-        .expr(Expr::wildcard())
+        .expr(Expr::asterisk())
         .from(Char::Table)
         .to_string(MysqlQueryBuilder);
 
@@ -806,7 +806,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = sea_query::Query::select()
-        .expr(Expr::tbl_wildcard(Char::Table))
+        .expr(Expr::tbl_asterisk(Char::Table))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -791,6 +791,34 @@ fn select_48() {
 }
 
 #[test]
+fn select_49() {
+    let statement = sea_query::Query::select()
+        .epxr(Expr::wildcard())
+        .from(Char::Table)
+        .to_string(MysqlQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"SELECT * FROM `character`"#
+    );
+}
+
+#[test]
+fn select_50() {
+    let statement = sea_query::Query::select()
+        .epxr(Expr::wildcard(Char::Table))
+        .column((Font::Table, Font::Name))
+        .from(Char::Table)
+        .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+        .to_string(MysqlQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"SELECT `character`.*, `font`.`name` FROM `character` INNJER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -806,7 +806,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = sea_query::Query::select()
-        .epxr(Expr::wildcard(Char::Table))
+        .epxr(Expr::tbl_wildcard(Char::Table))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -777,7 +777,7 @@ fn select_48() {
 #[test]
 fn select_49() {
     let statement = sea_query::Query::select()
-        .epxr(Expr::wildcard())
+        .expr(Expr::wildcard())
         .from(Char::Table)
         .to_string(PostgresQueryBuilder);
 
@@ -790,7 +790,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = sea_query::Query::select()
-        .epxr(Expr::tbl_wildcard(Char::Table))
+        .expr(Expr::tbl_wildcard(Char::Table))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
@@ -798,7 +798,7 @@ fn select_50() {
 
     assert_eq!(
         statement,
-        r#"SELECT "character".*, "font"."name" FROM "character" INNJER JOIN "font" ON "character"."font_id" = "font"."id""#
+        r#"SELECT "character".*, "font"."name" FROM "character" INNER JOIN "font" ON "character"."font_id" = "font"."id""#
     );
 }
 

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -790,7 +790,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = sea_query::Query::select()
-        .epxr(Expr::wildcard(Char::Table))
+        .epxr(Expr::tbl_wildcard(Char::Table))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -777,7 +777,7 @@ fn select_48() {
 #[test]
 fn select_49() {
     let statement = sea_query::Query::select()
-        .expr(Expr::wildcard())
+        .expr(Expr::asterisk())
         .from(Char::Table)
         .to_string(PostgresQueryBuilder);
 
@@ -790,7 +790,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = sea_query::Query::select()
-        .expr(Expr::tbl_wildcard(Char::Table))
+        .expr(Expr::tbl_asterisk(Char::Table))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -775,6 +775,34 @@ fn select_48() {
 }
 
 #[test]
+fn select_49() {
+    let statement = sea_query::Query::select()
+        .epxr(Expr::wildcard())
+        .from(Char::Table)
+        .to_string(PostgresQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"SELECT * FROM "character""#
+    );
+}
+
+#[test]
+fn select_50() {
+    let statement = sea_query::Query::select()
+        .epxr(Expr::wildcard(Char::Table))
+        .column((Font::Table, Font::Name))
+        .from(Char::Table)
+        .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+        .to_string(PostgresQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"SELECT "character".*, "font"."name" FROM "character" INNJER JOIN "font" ON "character"."font_id" = "font"."id""#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -793,7 +793,7 @@ fn select_48() {
 #[test]
 fn select_49() {
     let statement = sea_query::Query::select()
-        .epxr(Expr::wildcard())
+        .expr(Expr::wildcard())
         .from(Char::Table)
         .to_string(SqliteQueryBuilder);
 
@@ -806,7 +806,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = sea_query::Query::select()
-        .epxr(Expr::tbl_wildcard(Char::Table))
+        .expr(Expr::tbl_wildcard(Char::Table))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
@@ -814,7 +814,7 @@ fn select_50() {
 
     assert_eq!(
         statement,
-        r#"SELECT `character`.*, `font`.`name` FROM `character` INNJER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
+        r#"SELECT `character`.*, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     );
 }
 

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -793,7 +793,7 @@ fn select_48() {
 #[test]
 fn select_49() {
     let statement = sea_query::Query::select()
-        .expr(Expr::wildcard())
+        .expr(Expr::asterisk())
         .from(Char::Table)
         .to_string(SqliteQueryBuilder);
 
@@ -806,7 +806,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = sea_query::Query::select()
-        .expr(Expr::tbl_wildcard(Char::Table))
+        .expr(Expr::tbl_asterisk(Char::Table))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -791,6 +791,34 @@ fn select_48() {
 }
 
 #[test]
+fn select_49() {
+    let statement = sea_query::Query::select()
+        .epxr(Expr::wildcard())
+        .from(Char::Table)
+        .to_string(SqliteQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"SELECT * FROM `character`"#
+    );
+}
+
+#[test]
+fn select_50() {
+    let statement = sea_query::Query::select()
+        .epxr(Expr::wildcard(Char::Table))
+        .column((Font::Table, Font::Name))
+        .from(Char::Table)
+        .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+        .to_string(SqliteQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"SELECT `character`.*, `font`.`name` FROM `character` INNJER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -806,7 +806,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = sea_query::Query::select()
-        .epxr(Expr::wildcard(Char::Table))
+        .epxr(Expr::tbl_wildcard(Char::Table))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))


### PR DESCRIPTION
This fix #217, adding two new methods:
- `Expr::wildcard()`
```rust
Query::select()
    .expr(Expr::wildcard())
    .from(Char::Table)
    .to_string(MysqlQueryBuilder);
```
```sql
SELECT *
FROM `character`
```
- `Expr::tbl_wildcard(table: DynIden)`
```rust
Query::select()
    .expr(Expr::tbl_wildcard(Char::Table))
    .column((Font::Table, Font::Name))
    .from(Char::Table)
    .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
    .to_string(MysqlQueryBuilder);
```
```sql
SELECT `character`.*, `font`.`name`
FROM `character`
INNER JOIN `font` ON `character`.`font_id` = `font`.`id`
```