### PR TITLE
Support the use of chrono::DateTime<Utc> using the type alias DateTim…

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -748,6 +748,8 @@ pub trait QueryBuilder: QuotedBuilder {
             Value::DateTime(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::DateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::DateTimeUtc(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-bigdecimal")]
@@ -787,6 +789,10 @@ pub trait QueryBuilder: QuotedBuilder {
             #[cfg(feature = "with-chrono")]
             Value::DateTimeWithTimeZone(Some(v)) => {
                 write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S %:z").to_string()).unwrap()
+            }
+            #[cfg(feature = "with-chrono")]
+            Value::DateTimeUtc(Some(v)) => {
+                write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S %z").to_string()).unwrap()
             }
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(Some(v)) => write!(s, "{}", v).unwrap(),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -792,7 +792,7 @@ pub trait QueryBuilder: QuotedBuilder {
             }
             #[cfg(feature = "with-chrono")]
             Value::DateTimeUtc(Some(v)) => {
-                write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S %z").to_string()).unwrap()
+                write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S %:z").to_string()).unwrap()
             }
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(Some(v)) => write!(s, "{}", v).unwrap(),

--- a/src/driver/postgres.rs
+++ b/src/driver/postgres.rs
@@ -53,6 +53,8 @@ impl ToSql for Value {
             Value::DateTime(v) => box_to_sql!(v, chrono::NaiveDateTime),
             #[cfg(feature = "postgres-chrono")]
             Value::DateTimeWithTimeZone(v) => box_to_sql!(v, chrono::DateTime<chrono::FixedOffset>),
+            #[cfg(feature = "postgres-chrono")]
+            Value::DateTimeUtc(v) => box_to_sql!(v, chrono::DateTime<chrono::Utc>),
             #[cfg(feature = "postgres-rust_decimal")]
             Value::Decimal(v) => box_to_sql!(v, rust_decimal::Decimal),
             #[cfg(feature = "postgres-bigdecimal")]

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -42,6 +42,8 @@ macro_rules! bind_params_sqlx_mysql {
                         query.bind(value.as_ref_time())
                     } else if value.is_date_time() {
                         query.bind(value.as_ref_date_time())
+                    } else if value.is_date_time_utc() {
+                        query.bind(value.as_ref_date_time_utc())
                     } else if value.is_date_time_with_time_zone() {
                         query.bind(value.as_ref_date_time_with_time_zone_in_naive_utc())
                     } else if value.is_decimal() {

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -42,6 +42,8 @@ macro_rules! bind_params_sqlx_postgres {
                         query.bind(value.as_ref_time())
                     } else if value.is_date_time() {
                         query.bind(value.as_ref_date_time())
+                    } else if value.is_date_time_utc() {
+                        query.bind(value.as_ref_date_time_utc())
                     } else if value.is_date_time_with_time_zone() {
                         query.bind(value.as_ref_date_time_with_time_zone())
                     } else if value.is_decimal() {

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -42,6 +42,8 @@ macro_rules! bind_params_sqlx_sqlite {
                         query.bind(value.as_ref_time())
                     } else if value.is_date_time() {
                         query.bind(value.as_ref_date_time())
+                    } else if value.is_date_time_utc() {
+                        query.bind(value.as_ref_date_time_utc())
                     } else if value.is_date_time_with_time_zone() {
                         query.bind(value.as_ref_date_time_with_time_zone_in_naive_utc())
                     } else if value.is_decimal() {

--- a/src/value.rs
+++ b/src/value.rs
@@ -605,6 +605,17 @@ impl Value {
     pub fn as_ref_date_time_utc(&self) -> Option<&bool> {
         panic!("not Value::DateTimeUtc")
     }
+    #[cfg(feature = "with-chrono")]
+    pub fn as_ref_date_time_naive_utc(&self) -> Option<String> {
+        match self {
+            Self::DateTimeWithTimeZone(v) => v.as_ref().map(|v| format! {"{:?}", v.as_ref()}),
+            _ => panic!("not Value::DateTimeWithTimeZone"),
+        }
+    }
+    #[cfg(not(feature = "with-chrono"))]
+    pub fn as_ref_date_time_naive_utc(&self) -> Option<&bool> {
+        panic!("not Value::DateTimeWithTimeZone")
+    }
 }
 
 impl Value {

--- a/src/value.rs
+++ b/src/value.rs
@@ -595,9 +595,9 @@ impl Value {
     }
 
     #[cfg(feature = "with-chrono")]
-    pub fn as_ref_date_time_utc(&self) -> Option<String> {
+    pub fn as_ref_date_time_utc(&self) -> Option<&DateTime<Utc>> {
         match self {
-            Self::DateTimeUtc(v) => v.as_ref().map(|v| v.naive_utc().to_string()),
+            Self::DateTimeUtc(v) => v.as_ref().map(|v| v.as_ref()),
             _ => panic!("not Value::DateTimeUtc"),
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -61,7 +61,29 @@ pub enum Value {
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     DateTimeWithTimeZone(Option<Box<DateTime<FixedOffset>>>),
 
-    /// Add support for `chrono::DateTime<Utc>`
+    /// Support for `chrono::DateTime<Utc>`
+    ///
+    /// #### Example
+    /// ```
+    /// use sea_orm::entity::prelude::*;
+    ///
+    /// #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    /// #[sea_orm(table_name = "satellites")]
+    /// pub struct Model {
+    ///     #[sea_orm(primary_key)]
+    ///     pub id: i32,
+    ///     pub satellite_name: String,
+    ///     // For older mysql databases like 5.7
+    ///     // use `Option<DateTimeUtc` to ensure the value is nullable
+    ///     pub launch_date: Option<DateTimeUtc>,
+    ///     pub deployment_date: DateTimeUtc,
+    /// }
+    ///
+    /// #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    /// pub enum Relation {}
+    ///
+    /// impl ActiveModelBehavior for ActiveModel {}
+    /// ```
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     DateTimeUtc(Option<Box<DateTime<Utc>>>),


### PR DESCRIPTION
Support DateTime<Utc> natively.

After researching and diving into the code, I found that the best way is to convert the `DateTime<Utc>` into a `DateTime<FixedOffset>` with the `FixedOffset` being based on `chrono::Utc` . This is helpful especially in databases like MySQL which store the `TIMESTAMP` in UTC despite a timezone being specified.