### PR TITLE
Add support for ORDER BY FIELD/CASE

### DIFF
--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -28,7 +28,27 @@ impl QueryBuilder for MysqlQueryBuilder {
         }
         self.prepare_simple_expr(&order_expr.expr, sql, collector);
         write!(sql, " ").unwrap();
-        self.prepare_order(&order_expr.order, sql, collector);
+        self.prepare_order(order_expr, sql, collector);
+    }
+
+    fn prepare_field_order(
+        &self,
+        order_expr: &OrderExpr,
+        values: &Values,
+        sql: &mut SqlWriter,
+        collector: &mut dyn FnMut(Value),
+    ) {
+        write!(sql, " FIELD (").unwrap();
+        self.prepare_simple_expr(&order_expr.expr, sql, collector);
+        write!(sql, ", [").unwrap();
+        let len = values.0.len();
+        for i in 0..len {
+            self.prepare_value(&values.0[i], sql, collector);
+            if i != len - 1 {
+                write!(sql, ", ").unwrap();
+            }
+        }
+        write!(sql, "])").unwrap();
     }
 
     fn prepare_query_statement(

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -81,8 +81,10 @@ impl QueryBuilder for PostgresQueryBuilder {
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     ) {
-        self.prepare_simple_expr(&order_expr.expr, sql, collector);
-        write!(sql, " ").unwrap();
+        if !matches!(order_expr.order, Order::Field(_)) {
+            self.prepare_simple_expr(&order_expr.expr, sql, collector);
+            write!(sql, " ").unwrap();
+        }
         self.prepare_order(order_expr, sql, collector);
         match order_expr.nulls {
             None => (),

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -83,7 +83,7 @@ impl QueryBuilder for PostgresQueryBuilder {
     ) {
         self.prepare_simple_expr(&order_expr.expr, sql, collector);
         write!(sql, " ").unwrap();
-        self.prepare_order(&order_expr.order, sql, collector);
+        self.prepare_order(order_expr, sql, collector);
         match order_expr.nulls {
             None => (),
             Some(NullOrdering::Last) => write!(sql, " NULLS LAST").unwrap(),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -840,7 +840,7 @@ pub trait QueryBuilder: QuotedBuilder {
     ) {
         self.prepare_simple_expr(&order_expr.expr, sql, collector);
         write!(sql, " ").unwrap();
-        self.prepare_order(&order_expr.order, sql, collector);
+        self.prepare_order(order_expr, sql, collector);
     }
 
     /// Translate [`JoinOn`] into SQL statement.
@@ -857,11 +857,37 @@ pub trait QueryBuilder: QuotedBuilder {
     }
 
     /// Translate [`Order`] into SQL statement.
-    fn prepare_order(&self, order: &Order, sql: &mut SqlWriter, _collector: &mut dyn FnMut(Value)) {
-        match order {
+    fn prepare_order(
+        &self,
+        order_expr: &OrderExpr,
+        sql: &mut SqlWriter,
+        collector: &mut dyn FnMut(Value),
+    ) {
+        match &order_expr.order {
             Order::Asc => write!(sql, "ASC").unwrap(),
             Order::Desc => write!(sql, "DESC").unwrap(),
+            Order::Field(values) => self.prepare_field_order(order_expr, values, sql, collector),
         }
+    }
+
+    /// Translate [`Order::Field`] into SQL statement
+    fn prepare_field_order(
+        &self,
+        order_expr: &OrderExpr,
+        values: &Values,
+        sql: &mut SqlWriter,
+        collector: &mut dyn FnMut(Value),
+    ) {
+        write!(sql, " CASE ").unwrap();
+        let mut i = 0;
+        for value in &values.0 {
+            self.prepare_simple_expr(&order_expr.expr, sql, collector);
+            write!(sql, "=").unwrap();
+            self.prepare_value(value, sql, collector);
+            write!(sql, " THEN {} ", i).unwrap();
+            i += 1;
+        }
+        write!(sql, "ELSE {}", i).unwrap();
     }
 
     /// Translate [`Value`] into SQL statement.

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -20,8 +20,10 @@ impl QueryBuilder for SqliteQueryBuilder {
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     ) {
-        self.prepare_simple_expr(&order_expr.expr, sql, collector);
-        write!(sql, " ").unwrap();
+        if !matches!(order_expr.order, Order::Field(_)) {
+            self.prepare_simple_expr(&order_expr.expr, sql, collector);
+            write!(sql, " ").unwrap();
+        }
         self.prepare_order(order_expr, sql, collector);
         match order_expr.nulls {
             None => (),

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -22,7 +22,7 @@ impl QueryBuilder for SqliteQueryBuilder {
     ) {
         self.prepare_simple_expr(&order_expr.expr, sql, collector);
         write!(sql, " ").unwrap();
-        self.prepare_order(&order_expr.order, sql, collector);
+        self.prepare_order(order_expr, sql, collector);
         match order_expr.nulls {
             None => (),
             Some(NullOrdering::Last) => write!(sql, " NULLS LAST").unwrap(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Base types used throughout sea-query.
 
-use crate::{expr::*, query::*};
+use crate::{expr::*, query::*, Values};
 use std::fmt;
 
 #[cfg(not(feature = "thread-safe"))]
@@ -174,10 +174,11 @@ pub enum JoinOn {
 }
 
 /// Ordering options
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Order {
     Asc,
     Desc,
+    Field(Values),
 }
 
 /// Helper for create name alias

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -900,6 +900,54 @@ fn select_53() {
 }
 
 #[test]
+fn select_54() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by(
+                Glyph::Id,
+                Order::Field(Values(vec![4.into(), 5.into(), 1.into(), 3.into(),]))
+            )
+            .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
+            .to_string(MysqlQueryBuilder),
+        [
+            r#"SELECT `aspect`"#,
+            r#"FROM `glyph`"#,
+            r#"WHERE IFNULL(`aspect`, 0) > 2"#,
+            r#"ORDER BY FIELD(`id`, 4, 5, 1, 3),"#,
+            r#"`glyph`.`aspect` ASC"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+fn select_55() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
+            .order_by(
+                Glyph::Id,
+                Order::Field(Values(vec![4.into(), 5.into(), 1.into(), 3.into(),]))
+            )
+            .to_string(MysqlQueryBuilder),
+        [
+            r#"SELECT `aspect`"#,
+            r#"FROM `glyph`"#,
+            r#"WHERE IFNULL(`aspect`, 0) > 2"#,
+            r#"ORDER BY `glyph`.`aspect` ASC,"#,
+            r#"FIELD(`id`, 4, 5, 1, 3)"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -878,6 +878,73 @@ fn select_53() {
 }
 
 #[test]
+fn select_54() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by(
+                Glyph::Id,
+                Order::Field(Values(vec![
+                    Value::Int(Some(4)),
+                    Value::Int(Some(5)),
+                    Value::Int(Some(1)),
+                    Value::Int(Some(3))
+                ]))
+            )
+            .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"SELECT "aspect""#,
+            r#"FROM "glyph""#,
+            r#"WHERE COALESCE("aspect", 0) > 2"#,
+            r#"ORDER BY CASE"#,
+            r#"WHEN "id"=4 THEN 0"#,
+            r#"WHEN "id"=5 THEN 1"#,
+            r#"WHEN "id"=1 THEN 2"#,
+            r#"WHEN "id"=3 THEN 3"#,
+            r#"ELSE 4 END,"#,
+            r#""glyph"."aspect" ASC"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+fn select_55() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
+            .order_by(
+                Glyph::Id,
+                Order::Field(Values(vec![
+                    Value::Int(Some(4)),
+                    Value::Int(Some(5)),
+                    Value::Int(Some(1)),
+                    Value::Int(Some(3))
+                ]))
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"SELECT "aspect""#,
+            r#"FROM "glyph""#,
+            r#"WHERE COALESCE("aspect", 0) > 2"#,
+            r#"ORDER BY "glyph"."aspect" ASC,"#,
+            r#"CASE WHEN "id"=4 THEN 0"#,
+            r#"WHEN "id"=5 THEN 1"#,
+            r#"WHEN "id"=1 THEN 2"#,
+            r#"WHEN "id"=3 THEN 3"#,
+            r#"ELSE 4 END"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -878,6 +878,73 @@ fn select_53() {
 }
 
 #[test]
+fn select_54() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by(
+                Glyph::Id,
+                Order::Field(Values(vec![
+                    Value::Int(Some(4)),
+                    Value::Int(Some(5)),
+                    Value::Int(Some(1)),
+                    Value::Int(Some(3))
+                ]))
+            )
+            .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"SELECT "aspect""#,
+            r#"FROM "glyph""#,
+            r#"WHERE IFNULL("aspect", 0) > 2"#,
+            r#"ORDER BY CASE"#,
+            r#"WHEN "id"=4 THEN 0"#,
+            r#"WHEN "id"=5 THEN 1"#,
+            r#"WHEN "id"=1 THEN 2"#,
+            r#"WHEN "id"=3 THEN 3"#,
+            r#"ELSE 4 END,"#,
+            r#""glyph"."aspect" ASC"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+fn select_55() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Glyph::Aspect,])
+            .from(Glyph::Table)
+            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
+            .order_by(
+                Glyph::Id,
+                Order::Field(Values(vec![
+                    Value::Int(Some(4)),
+                    Value::Int(Some(5)),
+                    Value::Int(Some(1)),
+                    Value::Int(Some(3))
+                ]))
+            )
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"SELECT "aspect""#,
+            r#"FROM "glyph""#,
+            r#"WHERE IFNULL("aspect", 0) > 2"#,
+            r#"ORDER BY "glyph"."aspect" ASC,"#,
+            r#"CASE WHEN "id"=4 THEN 0"#,
+            r#"WHEN "id"=5 THEN 1"#,
+            r#"WHEN "id"=1 THEN 2"#,
+            r#"WHEN "id"=3 THEN 3"#,
+            r#"ELSE 4 END"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(


### PR DESCRIPTION
Implemented #246 and tested.

The correct syntax differs a little from the one in #246:

PostgreSQL and SQLite:
```sql
ORDER BY
  CASE
    WHEN code='USD' THEN 1
    WHEN code='CAD' THEN 2
    WHEN code='AUD' THEN 3
    WHEN code='BBD' THEN 4
    WHEN code='EUR' THEN 5
    WHEN code='GBP' THEN 6
    ELSE 7
    END
```

MySQL:
```sql
SELECT * FROM my_table
ORDER BY FIELD(my_col, 'USD', 'CAD', 'AUD', 'BBD', 'EUR', 'GBP')
```

"Major" changes:
* `prepare_order` takes the `OrderExpr` instead of only `Order` as it needs access to the column name if the order is `Order::Field`
* `Order` does not derive `Eq, Copy` anymore as `Values` does not implement those traits.

Implementation notes:
* Added a new function called `prepare_field_order` in `QueryBuilder` trait.
* Default implementation inside the trait of `prepare_field_order` produces the `CASE-WHEN-THEN-ELSE-END` syntax.
* Reimplementation inside `MySQLQueryBuilder` produces the `FIELD` syntax.
*  Inside `prepare_order_expr` if `matches!(order_expr.order, Order::Field(_))` the column name is not written after the `ORDER BY`.