### PR TITLE
Add `Value::DateTimeLocal`

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -939,6 +939,8 @@ pub trait QueryBuilder: QuotedBuilder {
             #[cfg(feature = "with-chrono")]
             Value::DateTimeUtc(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
+            Value::DateTimeLocal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
             Value::DateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(None) => write!(s, "NULL").unwrap(),
@@ -978,6 +980,10 @@ pub trait QueryBuilder: QuotedBuilder {
             }
             #[cfg(feature = "with-chrono")]
             Value::DateTimeUtc(Some(v)) => {
+                write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S %:z").to_string()).unwrap()
+            }
+            #[cfg(feature = "with-chrono")]
+            Value::DateTimeLocal(Some(v)) => {
                 write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S %:z").to_string()).unwrap()
             }
             #[cfg(feature = "with-chrono")]

--- a/src/driver/postgres.rs
+++ b/src/driver/postgres.rs
@@ -54,6 +54,8 @@ impl ToSql for Value {
             #[cfg(feature = "postgres-chrono")]
             Value::DateTimeUtc(v) => box_to_sql!(v, chrono::DateTime<chrono::Utc>),
             #[cfg(feature = "postgres-chrono")]
+            Value::DateTimeLocal(v) => box_to_sql!(v, chrono::DateTime<chrono::Local>),
+            #[cfg(feature = "postgres-chrono")]
             Value::DateTimeWithTimeZone(v) => box_to_sql!(v, chrono::DateTime<chrono::FixedOffset>),
             #[cfg(feature = "postgres-rust_decimal")]
             Value::Decimal(v) => box_to_sql!(v, rust_decimal::Decimal),

--- a/src/driver/rusqlite.rs
+++ b/src/driver/rusqlite.rs
@@ -76,6 +76,10 @@ macro_rules! sea_query_driver_rusqlite {
                                 ty_to_sql!(self.0.as_ref_time())
                             } else if self.0.is_date_time() {
                                 ty_to_sql!(self.0.as_ref_date_time())
+                            } else if self.0.is_date_time_utc() {
+                                ty_to_sql!(self.0.as_ref_date_time_utc())
+                            } else if self.0.is_date_time_local() {
+                                ty_to_sql!(self.0.as_ref_date_time_local())
                             } else if self.0.is_date_time_with_time_zone() {
                                 ty_to_sql!(self.0.as_ref_date_time_with_time_zone())
                             } else if self.0.is_uuid() {

--- a/src/driver/sqlx_mysql.rs
+++ b/src/driver/sqlx_mysql.rs
@@ -44,6 +44,8 @@ macro_rules! bind_params_sqlx_mysql {
                         query.bind(value.as_ref_date_time())
                     } else if value.is_date_time_utc() {
                         query.bind(value.as_ref_date_time_utc())
+                    } else if value.is_date_time_local() {
+                        query.bind(value.as_ref_date_time_local())
                     } else if value.is_date_time_with_time_zone() {
                         query.bind(value.as_naive_utc_in_string())
                     } else if value.is_decimal() {

--- a/src/driver/sqlx_postgres.rs
+++ b/src/driver/sqlx_postgres.rs
@@ -44,6 +44,8 @@ macro_rules! bind_params_sqlx_postgres {
                         query.bind(value.as_ref_date_time())
                     } else if value.is_date_time_utc() {
                         query.bind(value.as_ref_date_time_utc())
+                    } else if value.is_date_time_local() {
+                        query.bind(value.as_ref_date_time_local())
                     } else if value.is_date_time_with_time_zone() {
                         query.bind(value.as_ref_date_time_with_time_zone())
                     } else if value.is_decimal() {

--- a/src/driver/sqlx_sqlite.rs
+++ b/src/driver/sqlx_sqlite.rs
@@ -44,6 +44,8 @@ macro_rules! bind_params_sqlx_sqlite {
                         query.bind(value.as_ref_date_time())
                     } else if value.is_date_time_utc() {
                         query.bind(value.as_naive_utc_in_string())
+                    } else if value.is_date_time_local() {
+                        query.bind(value.as_naive_utc_in_string())
                     } else if value.is_date_time_with_time_zone() {
                         query.bind(value.as_naive_utc_in_string())
                     } else if value.is_decimal() {

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,7 +7,7 @@ use serde_json::Value as Json;
 use std::str::from_utf8;
 
 #[cfg(feature = "with-chrono")]
-use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use chrono::{DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 
 #[cfg(feature = "with-rust_decimal")]
 use rust_decimal::Decimal;
@@ -60,6 +60,10 @@ pub enum Value {
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     DateTimeUtc(Option<Box<DateTime<Utc>>>),
+
+    #[cfg(feature = "with-chrono")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
+    DateTimeLocal(Option<Box<DateTime<Local>>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
@@ -290,7 +294,7 @@ mod with_json {
 #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
 mod with_chrono {
     use super::*;
-    use chrono::{Offset, Utc};
+    use chrono::{Local, Offset, Utc};
 
     type_to_box_value!(NaiveDate, Date, Date);
     type_to_box_value!(NaiveTime, Time, Time(None));
@@ -299,6 +303,12 @@ mod with_chrono {
     impl From<DateTime<Utc>> for Value {
         fn from(v: DateTime<Utc>) -> Value {
             Value::DateTimeUtc(Some(Box::new(v)))
+        }
+    }
+
+    impl From<DateTime<Local>> for Value {
+        fn from(v: DateTime<Local>) -> Value {
+            Value::DateTimeLocal(Some(Box::new(v)))
         }
     }
 
@@ -325,6 +335,29 @@ mod with_chrono {
 
         fn type_name() -> String {
             stringify!(DateTime<Utc>).to_owned()
+        }
+
+        fn column_type() -> ColumnType {
+            ColumnType::TimestampWithTimeZone(None)
+        }
+    }
+
+    impl Nullable for DateTime<Local> {
+        fn null() -> Value {
+            Value::DateTimeLocal(None)
+        }
+    }
+
+    impl ValueType for DateTime<Local> {
+        fn try_from(v: Value) -> Result<Self, ValueTypeErr> {
+            match v {
+                Value::DateTimeLocal(Some(x)) => Ok(*x),
+                _ => Err(ValueTypeErr),
+            }
+        }
+
+        fn type_name() -> String {
+            stringify!(DateTime<Local>).to_owned()
         }
 
         fn column_type() -> ColumnType {
@@ -563,6 +596,13 @@ impl Value {
         #[cfg(not(feature = "with-chrono"))]
         return false;
     }
+
+    pub fn is_date_time_local(&self) -> bool {
+        #[cfg(feature = "with-chrono")]
+        return matches!(self, Self::DateTimeLocal(_));
+        #[cfg(not(feature = "with-chrono"))]
+        return false;
+    }
     pub fn is_date_time_with_time_zone(&self) -> bool {
         #[cfg(feature = "with-chrono")]
         return matches!(self, Self::DateTimeWithTimeZone(_));
@@ -583,6 +623,18 @@ impl Value {
     }
 
     #[cfg(feature = "with-chrono")]
+    pub fn as_ref_date_time_local(&self) -> Option<&DateTime<Local>> {
+        match self {
+            Self::DateTimeLocal(v) => box_to_opt_ref!(v),
+            _ => panic!("not Value::DateTimeLocal"),
+        }
+    }
+    #[cfg(not(feature = "with-chrono"))]
+    pub fn as_ref_date_time_local(&self) -> Option<&bool> {
+        panic!("not Value::DateTimeLocal")
+    }
+
+    #[cfg(feature = "with-chrono")]
     pub fn as_ref_date_time_with_time_zone(&self) -> Option<&DateTime<FixedOffset>> {
         match self {
             Self::DateTimeWithTimeZone(v) => box_to_opt_ref!(v),
@@ -599,6 +651,7 @@ impl Value {
         match self {
             Self::DateTime(v) => v.as_ref().map(|v| v.to_string()),
             Self::DateTimeUtc(v) => v.as_ref().map(|v| v.naive_utc().to_string()),
+            Self::DateTimeLocal(v) => v.as_ref().map(|v| v.naive_utc().to_string()),
             Self::DateTimeWithTimeZone(v) => v.as_ref().map(|v| v.naive_utc().to_string()),
             _ => panic!("not Value::DateTime"),
         }
@@ -1024,6 +1077,8 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::DateTimeWithTimeZone(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::DateTimeUtc(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(feature = "with-chrono")]
+        Value::DateTimeLocal(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-rust_decimal")]
         Value::Decimal(Some(v)) => {
             use rust_decimal::prelude::ToPrimitive;
@@ -1328,6 +1383,17 @@ mod tests {
         let value: Value = timestamp.into();
         let out: DateTime<Utc> = value.unwrap();
         assert_eq!(out, timestamp);
+    }
+
+    #[test]
+    #[cfg(feature = "with-chrono")]
+    fn test_chrono_local_value() {
+        let timestamp_utc =
+            DateTime::<Utc>::from_utc(NaiveDate::from_ymd(2022, 1, 2).and_hms(3, 4, 5), Utc);
+        let timestamp_local: DateTime<Local> = timestamp_utc.into();
+        let value: Value = timestamp_local.into();
+        let out: DateTime<Local> = value.unwrap();
+        assert_eq!(out, timestamp_local);
     }
 
     #[test]


### PR DESCRIPTION
## PR Info
- Required by SeaQL/sea-orm#489

### Added
- introduce `Value::DateTimeLocal`
- following database drivers now bind `Value::DateTimeLocal`
  - postgres
  - rusqlite
  - sqlx_mysql
  - sqlx_postgres
  - sqlx_sqlite
- following database driver now bind `Value::DateTimeUtc`
  - rusqlite