### PR TITLE
Support multiple tables in the select from

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -89,9 +89,15 @@ pub trait QueryBuilder: QuotedBuilder {
             false
         });
 
-        if let Some(from) = &select.from {
+        if !select.from.is_empty() {
             write!(sql, " FROM ").unwrap();
-            self.prepare_table_ref(from, sql, collector);
+            select.from.iter().fold(true, |first, table_ref| {
+                if !first {
+                    write!(sql, ", ").unwrap()
+                }
+                self.prepare_table_ref(table_ref, sql, collector);
+                false
+            });
         }
 
         if !select.join.is_empty() {

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -41,7 +41,7 @@ use crate::{
 pub struct SelectStatement {
     pub(crate) distinct: Option<SelectDistinct>,
     pub(crate) selects: Vec<SelectExpr>,
-    pub(crate) from: Option<Box<TableRef>>,
+    pub(crate) from: Vec<TableRef>,
     pub(crate) join: Vec<JoinExpr>,
     pub(crate) r#where: ConditionHolder,
     pub(crate) groups: Vec<SimpleExpr>,
@@ -113,7 +113,7 @@ impl SelectStatement {
         Self {
             distinct: None,
             selects: Vec::new(),
-            from: None,
+            from: Vec::new(),
             join: Vec::new(),
             r#where: ConditionHolder::new(),
             groups: Vec::new(),
@@ -131,7 +131,7 @@ impl SelectStatement {
         Self {
             distinct: self.distinct.take(),
             selects: std::mem::take(&mut self.selects),
-            from: self.from.take(),
+            from: std::mem::take(&mut self.from),
             join: std::mem::take(&mut self.join),
             r#where: std::mem::replace(&mut self.r#where, ConditionHolder::new()),
             groups: std::mem::take(&mut self.groups),
@@ -742,7 +742,7 @@ impl SelectStatement {
     }
 
     fn from_from(&mut self, select: TableRef) -> &mut Self {
-        self.from = Some(Box::new(select));
+        self.from.push(select);
         self
     }
 

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -107,11 +107,11 @@ impl CommonTableExpression {
 
     /// Create a CTE from a [SelectStatement] if the selections are named columns then this will
     /// return a [CommonTableExpression] that has the column names set. The [Self::table_name] is
-    /// not set.
+    /// set if the [SelectStatement] from clause contains at least one table.
     pub fn from_select(select: SelectStatement) -> Self {
         let mut cte = Self::default();
         cte.try_set_cols_from_selects(&select.selects);
-        if let Some(from) = &select.from {
+        if let Some(from) = select.from.get(0) {
             match from.deref() {
                 TableRef::Table(iden) => cte.set_table_name_from_select(iden),
                 TableRef::SchemaTable(_, iden) => cte.set_table_name_from_select(iden),

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -900,6 +900,21 @@ fn select_53() {
 }
 
 #[test]
+fn select_54() {
+    let statement = sea_query::Query::select()
+        .expr(Expr::asterisk())
+        .from(Char::Table)
+        .from(Font::Table)
+        .and_where(Expr::tbl(Font::Table, Font::Id).equals(Char::Table, Char::FontId))
+        .to_string(MysqlQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"SELECT * FROM `character`, `font` WHERE `font`.`id` = `character`.`font_id`"#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -878,6 +878,21 @@ fn select_53() {
 }
 
 #[test]
+fn select_54() {
+    let statement = sea_query::Query::select()
+        .expr(Expr::asterisk())
+        .from(Char::Table)
+        .from(Font::Table)
+        .and_where(Expr::tbl(Font::Table, Font::Id).equals(Char::Table, Char::FontId))
+        .to_string(PostgresQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"SELECT * FROM "character", "font" WHERE "font"."id" = "character"."font_id""#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -878,6 +878,21 @@ fn select_53() {
 }
 
 #[test]
+fn select_54() {
+    let statement = sea_query::Query::select()
+        .expr(Expr::asterisk())
+        .from(Char::Table)
+        .from(Font::Table)
+        .and_where(Expr::tbl(Font::Table, Font::Id).equals(Char::Table, Char::FontId))
+        .to_string(SqliteQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"SELECT * FROM "character", "font" WHERE "font"."id" = "character"."font_id""#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(


### PR DESCRIPTION
Fixes #258 

This is a breaking change since the previous behaviour would replace the `from` table when you called it multiple times.
I think this is correct, just need to be marked as such in the changelog.