### PR TITLE
Add support for replace insert

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -14,7 +14,7 @@ pub trait QueryBuilder: QuotedBuilder {
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     ) {
-        write!(sql, "INSERT").unwrap();
+        self.prepare_insert(insert.replace, sql);
 
         if let Some(table) = &insert.table {
             write!(sql, " INTO ").unwrap();
@@ -803,6 +803,14 @@ pub trait QueryBuilder: QuotedBuilder {
 
         if with_clause.recursive {
             write!(sql, "RECURSIVE ").unwrap();
+        }
+    }
+
+    fn prepare_insert(&self, replace: bool, sql: &mut SqlWriter) {
+        if replace {
+            write!(sql, "REPLACE").unwrap();
+        } else {
+            write!(sql, "INSERT").unwrap();
         }
     }
 


### PR DESCRIPTION
Adds support for the `REPLACE` directive. Eventually a better implementation (at least for Sqlite) would add all the `OR REPLACE | ABORT | FAIL | IGNORE | ROLLBACK` or we could direct people to use the `ON CONFLICT` syntax (when #167 is merged)