### PR TITLE
Allow for trailing commas in any and all macros

### DIFF
--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -272,7 +272,7 @@ impl std::convert::From<SimpleExpr> for ConditionExpression {
 /// ```
 #[macro_export]
 macro_rules! any {
-    ( $( $x:expr ),* ) => {
+    ( $( $x:expr ),* $(,)?) => {
         {
             let mut tmp = sea_query::Condition::any();
             $(
@@ -307,7 +307,7 @@ macro_rules! any {
 /// );
 #[macro_export]
 macro_rules! all {
-    ( $( $x:expr ),* ) => {
+    ( $( $x:expr ),* $(,)?) => {
         {
             let mut tmp = sea_query::Condition::all();
             $(


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes #268

I didn't look around for other cases where this might be nice. These are just the two I happened to run into.

## Adds

Support for trailing commas for the `any` and `all` macros.

## Breaking Changes

Backwards compatible.

## Changes

Tiny couple-character change to the macro definitions in `src/query/condition.rs`.
