### PR TITLE
issues-213 Add support for multiple ALTER table

### DIFF
--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -119,47 +119,53 @@ impl TableBuilder for PostgresQueryBuilder {
     }
 
     fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut SqlWriter) {
-        let alter_option = match &alter.alter_option {
-            Some(alter_option) => alter_option,
-            None => panic!("No alter option found"),
+        if alter.options.is_empty() {
+            panic!("No alter option found")
         };
         write!(sql, "ALTER TABLE ").unwrap();
         if let Some(table) = &alter.table {
             table.prepare(sql, self.quote());
             write!(sql, " ").unwrap();
         }
-        match alter_option {
-            TableAlterOption::AddColumn(column_def) => {
-                write!(sql, "ADD COLUMN ").unwrap();
-                self.prepare_column_def(column_def, sql);
-            }
-            TableAlterOption::ModifyColumn(column_def) => {
-                write!(sql, "ALTER COLUMN ").unwrap();
-                column_def.name.prepare(sql, self.quote());
-                write!(sql, " TYPE").unwrap();
-                self.prepare_column_type_check_auto_increment(column_def, sql);
-                for column_spec in column_def.spec.iter() {
-                    if let ColumnSpec::AutoIncrement = column_spec {
-                        continue;
-                    }
-                    write!(sql, ", ").unwrap();
+
+        alter.options.iter().fold(true, |first, option| {
+            if !first {
+                write!(sql, ", ").unwrap();
+            };
+            match option {
+                TableAlterOption::AddColumn(column_def) => {
+                    write!(sql, "ADD COLUMN ").unwrap();
+                    self.prepare_column_def(column_def, sql);
+                }
+                TableAlterOption::ModifyColumn(column_def) => {
                     write!(sql, "ALTER COLUMN ").unwrap();
                     column_def.name.prepare(sql, self.quote());
-                    write!(sql, " SET ").unwrap();
-                    self.prepare_column_spec(column_spec, sql);
+                    write!(sql, " TYPE").unwrap();
+                    self.prepare_column_type_check_auto_increment(column_def, sql);
+                    for column_spec in column_def.spec.iter() {
+                        if let ColumnSpec::AutoIncrement = column_spec {
+                            continue;
+                        }
+                        write!(sql, ", ").unwrap();
+                        write!(sql, "ALTER COLUMN ").unwrap();
+                        column_def.name.prepare(sql, self.quote());
+                        write!(sql, " SET ").unwrap();
+                        self.prepare_column_spec(column_spec, sql);
+                    }
+                }
+                TableAlterOption::RenameColumn(from_name, to_name) => {
+                    write!(sql, "RENAME COLUMN ").unwrap();
+                    from_name.prepare(sql, self.quote());
+                    write!(sql, " TO ").unwrap();
+                    to_name.prepare(sql, self.quote());
+                }
+                TableAlterOption::DropColumn(column_name) => {
+                    write!(sql, "DROP COLUMN ").unwrap();
+                    column_name.prepare(sql, self.quote());
                 }
             }
-            TableAlterOption::RenameColumn(from_name, to_name) => {
-                write!(sql, "RENAME COLUMN ").unwrap();
-                from_name.prepare(sql, self.quote());
-                write!(sql, " TO ").unwrap();
-                to_name.prepare(sql, self.quote());
-            }
-            TableAlterOption::DropColumn(column_name) => {
-                write!(sql, "DROP COLUMN ").unwrap();
-                column_name.prepare(sql, self.quote());
-            }
-        }
+            false
+        });
     }
 
     fn prepare_table_rename_statement(&self, rename: &TableRenameStatement, sql: &mut SqlWriter) {

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -135,16 +135,18 @@ impl TableBuilder for SqliteQueryBuilder {
     }
 
     fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut SqlWriter) {
-        let alter_option = match &alter.alter_option {
-            Some(alter_option) => alter_option,
-            None => panic!("No alter option found"),
+        if alter.options.is_empty() {
+            panic!("No alter option found")
         };
+        if alter.options.len() > 1 {
+            panic!("Does not support multiple ALTER")
+        }
         write!(sql, "ALTER TABLE ").unwrap();
         if let Some(table) = &alter.table {
             table.prepare(sql, self.quote());
             write!(sql, " ").unwrap();
         }
-        match alter_option {
+        match &alter.options[0] {
             TableAlterOption::AddColumn(column_def) => {
                 write!(sql, "ADD COLUMN ").unwrap();
                 self.prepare_column_def(column_def, sql);

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -240,3 +240,15 @@ fn alter_5() {
 fn alter_6() {
     Table::alter().to_string(MysqlQueryBuilder);
 }
+
+#[test]
+fn alter_7() {
+    assert_eq!(
+        Table::alter()
+            .table(Font::Table)
+            .drop_column(Alias::new("new_column"))
+            .rename_column(Font::Name, Alias::new("name_new"))
+            .to_string(MysqlQueryBuilder),
+        "ALTER TABLE `font` DROP COLUMN `new_column`, RENAME COLUMN `name` TO `name_new`"
+    );
+}

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -327,3 +327,15 @@ fn alter_5() {
 fn alter_6() {
     Table::alter().to_string(PostgresQueryBuilder);
 }
+
+#[test]
+fn alter_7() {
+    assert_eq!(
+        Table::alter()
+            .table(Font::Table)
+            .add_column(ColumnDef::new(Alias::new("new_col")).integer())
+            .rename_column(Font::Name, Alias::new("name_new"))
+            .to_string(PostgresQueryBuilder),
+        r#"ALTER TABLE "font" ADD COLUMN "new_col" integer, RENAME COLUMN "name" TO "name_new""#
+    );
+}

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -273,3 +273,13 @@ fn alter_5() {
 fn alter_6() {
     Table::alter().to_string(SqliteQueryBuilder);
 }
+
+#[test]
+#[should_panic(expected = "Does not support multiple ALTER")]
+fn alter_7() {
+    let _ = Table::alter()
+        .table(Font::Table)
+        .add_column(ColumnDef::new(Alias::new("new_col")).integer())
+        .rename_column(Font::Name, Alias::new("name_new"))
+        .to_string(SqliteQueryBuilder);
+}


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/213>

## Adds

Add support:

```
let table = Table::alter()
    .table(Alias::new("table"))
    .add_column(ColumnDef::new(Alias::new("new_col")).integer())
    .add_column(ColumnDef::new(Alias::new("new_col2")).integer())
    .to_owned();
```

For MySQL and PostgreSQL generate:
```
ALTER TABLE tblName
    ADD COLUMN new_col INTEGER,
    ADD COLUMN new_col2 INTEGER
```

For SQLLite should panic.