### PR TITLE
issues-229 add column if not exists

### DIFF
--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -134,8 +134,11 @@ impl TableBuilder for MysqlQueryBuilder {
                 write!(sql, ", ").unwrap();
             };
             match option {
-                TableAlterOption::AddColumn(column_def) => {
+                TableAlterOption::AddColumn(column_def, if_not_exists) => {
                     write!(sql, "ADD COLUMN ").unwrap();
+                    if *if_not_exists {
+                        write!(sql, "IF NOT EXISTS ").unwrap();
+                    }
                     self.prepare_column_def(column_def, sql);
                 }
                 TableAlterOption::ModifyColumn(column_def) => {

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -134,12 +134,12 @@ impl TableBuilder for MysqlQueryBuilder {
                 write!(sql, ", ").unwrap();
             };
             match option {
-                TableAlterOption::AddColumn(column_def, if_not_exists) => {
+                TableAlterOption::AddColumn(AddColumnOption {
+                    column,
+                    if_not_exists: _,
+                }) => {
                     write!(sql, "ADD COLUMN ").unwrap();
-                    if *if_not_exists {
-                        write!(sql, "IF NOT EXISTS ").unwrap();
-                    }
-                    self.prepare_column_def(column_def, sql);
+                    self.prepare_column_def(column, sql);
                 }
                 TableAlterOption::ModifyColumn(column_def) => {
                     write!(sql, "MODIFY COLUMN ").unwrap();

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -133,12 +133,15 @@ impl TableBuilder for PostgresQueryBuilder {
                 write!(sql, ", ").unwrap();
             };
             match option {
-                TableAlterOption::AddColumn(column_def, if_not_exists) => {
+                TableAlterOption::AddColumn(AddColumnOption {
+                    column,
+                    if_not_exists,
+                }) => {
                     write!(sql, "ADD COLUMN ").unwrap();
                     if *if_not_exists {
                         write!(sql, "IF NOT EXISTS ").unwrap();
                     }
-                    self.prepare_column_def(column_def, sql);
+                    self.prepare_column_def(column, sql);
                 }
                 TableAlterOption::ModifyColumn(column_def) => {
                     write!(sql, "ALTER COLUMN ").unwrap();

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -133,8 +133,11 @@ impl TableBuilder for PostgresQueryBuilder {
                 write!(sql, ", ").unwrap();
             };
             match option {
-                TableAlterOption::AddColumn(column_def) => {
+                TableAlterOption::AddColumn(column_def, if_not_exists) => {
                     write!(sql, "ADD COLUMN ").unwrap();
+                    if *if_not_exists {
+                        write!(sql, "IF NOT EXISTS ").unwrap();
+                    }
                     self.prepare_column_def(column_def, sql);
                 }
                 TableAlterOption::ModifyColumn(column_def) => {

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -147,9 +147,12 @@ impl TableBuilder for SqliteQueryBuilder {
             write!(sql, " ").unwrap();
         }
         match &alter.options[0] {
-            TableAlterOption::AddColumn(column_def, _) => {
+            TableAlterOption::AddColumn(AddColumnOption {
+                column,
+                if_not_exists: _,
+            }) => {
                 write!(sql, "ADD COLUMN ").unwrap();
-                self.prepare_column_def(column_def, sql);
+                self.prepare_column_def(column, sql);
             }
             TableAlterOption::ModifyColumn(_) => {
                 panic!("Sqlite not support modifying table column")

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -147,7 +147,7 @@ impl TableBuilder for SqliteQueryBuilder {
             write!(sql, " ").unwrap();
         }
         match &alter.options[0] {
-            TableAlterOption::AddColumn(column_def) => {
+            TableAlterOption::AddColumn(column_def, _) => {
                 write!(sql, "ADD COLUMN ").unwrap();
                 self.prepare_column_def(column_def, sql);
             }

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -36,10 +36,17 @@ pub struct TableAlterStatement {
     pub(crate) options: Vec<TableAlterOption>,
 }
 
+/// table alter add column options
+#[derive(Debug, Clone)]
+pub struct AddColumnOption {
+    pub(crate) column: ColumnDef,
+    pub(crate) if_not_exists: bool,
+}
+
 /// All available table alter options
 #[derive(Debug, Clone)]
 pub enum TableAlterOption {
-    AddColumn(ColumnDef, bool),
+    AddColumn(AddColumnOption),
     ModifyColumn(ColumnDef),
     RenameColumn(DynIden, DynIden),
     DropColumn(DynIden),
@@ -101,7 +108,10 @@ impl TableAlterStatement {
     /// ```
     pub fn add_column(&mut self, column_def: &mut ColumnDef) -> &mut Self {
         self.options
-            .push(TableAlterOption::AddColumn(column_def.take(), false));
+            .push(TableAlterOption::AddColumn(AddColumnOption {
+                column: column_def.take(),
+                if_not_exists: false,
+            }));
         self
     }
 
@@ -137,7 +147,10 @@ impl TableAlterStatement {
     /// ```
     pub fn add_column_if_not_exists(&mut self, column_def: &mut ColumnDef) -> &mut Self {
         self.options
-            .push(TableAlterOption::AddColumn(column_def.take(), true));
+            .push(TableAlterOption::AddColumn(AddColumnOption {
+                column: column_def.take(),
+                if_not_exists: true,
+            }));
         self
     }
 

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -39,7 +39,7 @@ pub struct TableAlterStatement {
 /// All available table alter options
 #[derive(Debug, Clone)]
 pub enum TableAlterOption {
-    AddColumn(ColumnDef),
+    AddColumn(ColumnDef, bool),
     ModifyColumn(ColumnDef),
     RenameColumn(DynIden, DynIden),
     DropColumn(DynIden),
@@ -101,7 +101,43 @@ impl TableAlterStatement {
     /// ```
     pub fn add_column(&mut self, column_def: &mut ColumnDef) -> &mut Self {
         self.options
-            .push(TableAlterOption::AddColumn(column_def.take()));
+            .push(TableAlterOption::AddColumn(column_def.take(), false));
+        self
+    }
+
+    /// Try add a column to an existing table if it does not exists
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let table = Table::alter()
+    ///     .table(Font::Table)
+    ///     .add_column_if_not_exists(
+    ///         ColumnDef::new(Alias::new("new_col"))
+    ///             .integer()
+    ///             .not_null()
+    ///             .default(100),
+    ///     )
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     table.to_string(MysqlQueryBuilder),
+    ///     r#"ALTER TABLE `font` ADD COLUMN IF NOT EXISTS `new_col` int NOT NULL DEFAULT 100"#
+    /// );
+    /// assert_eq!(
+    ///     table.to_string(PostgresQueryBuilder),
+    ///     r#"ALTER TABLE "font" ADD COLUMN IF NOT EXISTS "new_col" integer NOT NULL DEFAULT 100"#
+    /// );
+    /// assert_eq!(
+    ///     table.to_string(SqliteQueryBuilder),
+    ///     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#,
+    /// );
+    /// ```
+    pub fn add_column_if_not_exists(&mut self, column_def: &mut ColumnDef) -> &mut Self {
+        self.options
+            .push(TableAlterOption::AddColumn(column_def.take(), true));
         self
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/229>

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - https://github.com/SeaQL/sea-query/pull/277

## Adds

Add support for query like: 
```
ALTER TABLE name
    ADD COLUMN IF NOT EXISTS column_name data_type
```

for PostgreSQL and for MySQL. For SQLLite this is ignored