### PR TITLE
issues-269 add support for ANY, SOME, ALL

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -53,6 +53,9 @@ impl QueryBuilder for PostgresQueryBuilder {
                     PgFunction::WebsearchToTsquery => "WEBSEARCH_TO_TSQUERY",
                     PgFunction::TsRank => "TS_RANK",
                     PgFunction::TsRankCd => "TS_RANK_CD",
+                    PgFunction::Any => "ANY",
+                    PgFunction::Some => "SOME",
+                    PgFunction::All => "ALL",
                 }
             )
             .unwrap(),

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -53,8 +53,11 @@ impl QueryBuilder for PostgresQueryBuilder {
                     PgFunction::WebsearchToTsquery => "WEBSEARCH_TO_TSQUERY",
                     PgFunction::TsRank => "TS_RANK",
                     PgFunction::TsRankCd => "TS_RANK_CD",
+                    #[cfg(feature = "postgres-array")]
                     PgFunction::Any => "ANY",
+                    #[cfg(feature = "postgres-array")]
                     PgFunction::Some => "SOME",
+                    #[cfg(feature = "postgres-array")]
                     PgFunction::All => "ALL",
                 }
             )

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -12,8 +12,11 @@ pub enum PgFunction {
     WebsearchToTsquery,
     TsRank,
     TsRankCd,
+    #[cfg(feature = "postgres-array")]
     Any,
+    #[cfg(feature = "postgres-array")]
     Some,
+    #[cfg(feature = "postgres-array")]
     All,
 }
 
@@ -249,6 +252,7 @@ impl PgFunc {
     ///     r#"SELECT ANY('{0,1}')"#
     /// );
     /// ```
+    #[cfg(feature = "postgres-array")]
     pub fn any<T>(expr: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,
@@ -272,6 +276,7 @@ impl PgFunc {
     ///     r#"SELECT SOME('{0,1}')"#
     /// );
     /// ```
+    #[cfg(feature = "postgres-array")]
     pub fn some<T>(expr: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,
@@ -295,6 +300,7 @@ impl PgFunc {
     ///     r#"SELECT ALL('{0,1}')"#
     /// );
     /// ```
+    #[cfg(feature = "postgres-array")]
     pub fn all<T>(expr: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -12,6 +12,9 @@ pub enum PgFunction {
     WebsearchToTsquery,
     TsRank,
     TsRankCd,
+    Any,
+    Some,
+    All,
 }
 
 /// Function call helper.
@@ -228,5 +231,74 @@ impl PgFunc {
         T: Into<SimpleExpr>,
     {
         Expr::func(Function::PgFunction(PgFunction::TsRankCd)).args(vec![vector, query])
+    }
+
+    /// Call `ANY` function. Postgres only.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(PgFunc::any(Expr::val(vec![0, 1])))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT ANY('{0,1}')"#
+    /// );
+    /// ```
+    pub fn any<T>(expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        Expr::func(Function::PgFunction(PgFunction::Any)).arg(expr)
+    }
+
+    /// Call `SOME` function. Postgres only.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(PgFunc::some(Expr::val(vec![0, 1])))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT SOME('{0,1}')"#
+    /// );
+    /// ```
+    pub fn some<T>(expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        Expr::func(Function::PgFunction(PgFunction::Some)).arg(expr)
+    }
+
+    /// Call `ALL` function. Postgres only.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(PgFunc::all(Expr::val(vec![0, 1])))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT ALL('{0,1}')"#
+    /// );
+    /// ```
+    pub fn all<T>(expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        Expr::func(Function::PgFunction(PgFunction::All)).arg(expr)
     }
 }


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/269>

## Adds

Add support for `ALL`, `SOME`, `ANY` functions for postgres backend
