### PR TITLE
issue-255 Add support to CommonTableExpression columns method

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1732,10 +1732,7 @@ impl SelectStatement {
     ///             .query(
     ///                 base_query.clone().union(UnionType::All, cte_referencing).to_owned()
     ///             )
-    ///             .column(Alias::new("id"))
-    ///             .column(Alias::new("depth"))
-    ///             .column(Alias::new("next"))
-    ///             .column(Alias::new("value"))
+    ///             .columns(vec![Alias::new("id"), Alias::new("depth"), Alias::new("next"), Alias::new("value")])
     ///             .table_name(Alias::new("cte_traversal"))
     ///             .to_owned();
     ///

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -86,6 +86,17 @@ impl CommonTableExpression {
         self
     }
 
+    /// Adds a named columns to the CTE table definition.
+    pub fn columns<T, I>(&mut self, cols: I) -> &mut Self
+    where
+        T: IntoIden,
+        I: IntoIterator<Item = T>,
+    {
+        self.cols
+            .extend(cols.into_iter().map(|col| col.into_iden()));
+        self
+    }
+
     /// Some databases allow you to put "MATERIALIZED" or "NOT MATERIALIZED" in the CTE definition.
     /// This will affect how during the execution of [WithQuery] the CTE in the [WithClause] will be
     /// executed. If the database doesn't support this syntax this option specified here will be


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/255>

## Adds

Add support to CommonTableExpression method: `columns`