### PR TITLE
issues-285 Fix timestamp_with_time_zone_len

### DIFF
--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -68,7 +68,7 @@ impl TableBuilder for PostgresQueryBuilder {
                     None => "timestamp".into(),
                 },
                 ColumnType::TimestampWithTimeZone(precision) => match precision {
-                    Some(precision) => format!("timestamp with time zone({})", precision),
+                    Some(precision) => format!("timestamp({}) with time zone", precision),
                     None => "timestamp with time zone".into(),
                 },
                 ColumnType::Time(precision) => match precision {

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -21,6 +21,7 @@ pub enum Character {
     SizeW,
     SizeH,
     FontId,
+    CreatedAt,
 }
 
 /// A shorthand for [`Character`]
@@ -39,6 +40,7 @@ impl Iden for Character {
                 Self::SizeW => "size_w",
                 Self::SizeH => "size_h",
                 Self::FontId => "font_id",
+                Self::CreatedAt => "created_at",
             }
         )
         .unwrap();

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -233,6 +233,26 @@ fn create_10() {
 }
 
 #[test]
+fn create_11() {
+    assert_eq!(
+        Table::create()
+            .table(Char::Table)
+            .col(
+                ColumnDef::new(Char::CreatedAt)
+                    .timestamp_with_time_zone_len(0)
+                    .not_null()
+            )
+            .to_string(PostgresQueryBuilder),
+        vec![
+            r#"CREATE TABLE "character" ("#,
+            r#""created_at" timestamp(0) with time zone NOT NULL"#,
+            r#")"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Table::drop()


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/285>

## Fixes

### Befor fix

```sql
CREATE TABLE "foo" (
  [...]
  "created_at" timestamp with time zone(0),
)
```
Execution Error: error returned from database: syntax error at or near "("

### After fix

```sql
CREATE TABLE "foo" (
  [...]
  "created_at" timestamp(0) with time zone,
)
```