### PR TITLE
issues-142 full support lock in select

### DIFF
--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -7,7 +7,7 @@ impl QueryBuilder for SqliteQueryBuilder {
 
     fn prepare_select_lock(
         &self,
-        _select_lock: &LockType,
+        _select_lock: &Lock,
         _sql: &mut SqlWriter,
         _collector: &mut dyn FnMut(Value),
     ) {


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/142>

## Adds

Add full support for `LOCK` in `SELECT` statement.

References:

* https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE
* https://dev.mysql.com/doc/refman/8.0/en/select.html