### PR TITLE
Fix item link in docs

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -918,7 +918,7 @@ pub trait QueryBuilder: QuotedBuilder {
         collector(value.clone());
     }
 
-    /// Translate [`Tuple`] into SQL statement.
+    /// Translate [`SimpleExpr::Tuple`] into SQL statement.
     fn prepare_tuple(
         &self,
         exprs: &[SimpleExpr],


### PR DESCRIPTION
## Fixes

- Use the right path to refer to SimpleExpr::Tuple