### PR TITLE
issues-295 Add parameter for sqlx path to proc-macro

### DIFF
--- a/sea-query-driver/src/lib.rs
+++ b/sea-query-driver/src/lib.rs
@@ -34,7 +34,7 @@ mod utils;
 /// sea_query::sea_query_driver_rusqlite!(sea_query="...")
 /// ```
 ///
-/// Specify pathes to the `sea-query` and to the `rusqlite` crates instances
+/// Specify paths to the `sea-query` and to the `rusqlite` crates instances
 /// ```
 /// sea_query::sea_query_driver_rusqlite!(rusqlite="...", sea_query="...")
 /// // or

--- a/sea-query-driver/src/lib.rs
+++ b/sea-query-driver/src/lib.rs
@@ -10,6 +10,7 @@ mod sqlx_postgres;
 #[cfg(feature = "sqlx-sqlite")]
 mod sqlx_sqlite;
 #[cfg(any(
+    feature = "rusqlite",
     feature = "sqlx-mysql",
     feature = "sqlx-postgres",
     feature = "sqlx-sqlite"

--- a/sea-query-driver/src/lib.rs
+++ b/sea-query-driver/src/lib.rs
@@ -17,7 +17,29 @@ mod sqlx_sqlite;
 ))]
 mod utils;
 
-/// Macro for generate rusqlite driver.
+/// Macro for generate `rusqlite` driver.
+///
+/// Examples:
+/// ```
+/// sea_query::sea_query_driver_rusqlite!()
+/// ```
+///
+/// Specify a path to the `rusqlite` crate instance
+/// ```
+/// sea_query::sea_query_driver_rusqlite!(driver="...")
+/// ```
+///
+/// Specify a path to the `sea-query` crate instance
+/// ```
+/// sea_query::sea_query_driver_rusqlite!(sea_query="...")
+/// ```
+///
+/// Specify pathes to the `sea-query` and to the `rusqlite` crates instances
+/// ```
+/// sea_query::sea_query_driver_rusqlite!(driver="...", sea_query="...")
+/// // or
+/// sea_query::sea_query_driver_rusqlite!(sea_query="...", driver="...")
+/// ```
 #[cfg(feature = "rusqlite")]
 #[proc_macro]
 pub fn sea_query_driver_rusqlite(input: TokenStream) -> TokenStream {
@@ -25,6 +47,28 @@ pub fn sea_query_driver_rusqlite(input: TokenStream) -> TokenStream {
 }
 
 /// Macro for generate new mod for sqlx-mysql.
+///
+/// Examples:
+/// ```
+/// sea_query::sea_query_driver_mysql!()
+/// ```
+///
+/// Specify a path to the `sqlx` crate instance
+/// ```
+/// sea_query::sea_query_driver_mysql!(driver="...")
+/// ```
+///
+/// Specify a path to the `sea-query` crate instance
+/// ```
+/// sea_query::sea_query_driver_mysql!(sea_query="...")
+/// ```
+///
+/// Specify pathes to the `sea-query` and to the `sqlx` crates instances
+/// ```
+/// sea_query::sea_query_driver_mysql!(driver="...", sea_query="...")
+/// // or
+/// sea_query::sea_query_driver_mysql!(sea_query="...", driver="...")
+/// ```
 #[cfg(feature = "sqlx-mysql")]
 #[proc_macro]
 pub fn sea_query_driver_mysql(input: TokenStream) -> TokenStream {
@@ -39,6 +83,28 @@ pub fn bind_params_sqlx_mysql(input: TokenStream) -> TokenStream {
 }
 
 /// Macro to generate sqlx-postgres driver.
+///
+/// Examples:
+/// ```
+/// sea_query::sea_query_driver_postgres!()
+/// ```
+///
+/// Specify a path to the `sqlx` crate instance
+/// ```
+/// sea_query::sea_query_driver_postgres!(driver="...")
+/// ```
+///
+/// Specify a path to the `sea-query` crate instance
+/// ```
+/// sea_query::sea_query_driver_postgres!(sea_query="...")
+/// ```
+///
+/// Specify pathes to the `sea-query` and to the `sqlx` crates instances
+/// ```
+/// sea_query::sea_query_driver_postgres!(driver="...", sea_query="...")
+/// // or
+/// sea_query::sea_query_driver_postgres!(sea_query="...", driver="...")
+/// ```
 #[cfg(feature = "sqlx-postgres")]
 #[proc_macro]
 pub fn sea_query_driver_postgres(input: TokenStream) -> TokenStream {
@@ -53,6 +119,28 @@ pub fn bind_params_sqlx_postgres(input: TokenStream) -> TokenStream {
 }
 
 /// Macro to generate sqlx-sqlite driver.
+///
+/// Examples:
+/// ```
+/// sea_query::sea_query_driver_sqlite!()
+/// ```
+///
+/// Specify a path to the `sqlx` crate instance
+/// ```
+/// sea_query::sea_query_driver_sqlite!(driver="...")
+/// ```
+///
+/// Specify a path to the `sea-query` crate instance
+/// ```
+/// sea_query::sea_query_driver_sqlite!(sea_query="...")
+/// ```
+///
+/// Specify pathes to the `sea-query` and to the `sqlx` crates instances
+/// ```
+/// sea_query::sea_query_driver_sqlite!(driver="...", sea_query="...")
+/// // or
+/// sea_query::sea_query_driver_sqlite!(sea_query="...", driver="...")
+/// ```
 #[cfg(feature = "sqlx-sqlite")]
 #[proc_macro]
 pub fn sea_query_driver_sqlite(input: TokenStream) -> TokenStream {

--- a/sea-query-driver/src/lib.rs
+++ b/sea-query-driver/src/lib.rs
@@ -16,42 +16,49 @@ mod sqlx_sqlite;
 ))]
 mod utils;
 
+/// Macro for generate rusqlite driver.
 #[cfg(feature = "rusqlite")]
 #[proc_macro]
-pub fn sea_query_driver_rusqlite(_: TokenStream) -> TokenStream {
-    rusqlite::sea_query_driver_rusqlite_impl()
+pub fn sea_query_driver_rusqlite(input: TokenStream) -> TokenStream {
+    rusqlite::sea_query_driver_rusqlite_impl(input)
 }
 
+/// Macro for generate new mod for sqlx-mysql.
 #[cfg(feature = "sqlx-mysql")]
 #[proc_macro]
-pub fn sea_query_driver_mysql(_: TokenStream) -> TokenStream {
-    sqlx_mysql::sea_query_driver_mysql_impl()
+pub fn sea_query_driver_mysql(input: TokenStream) -> TokenStream {
+    sqlx_mysql::sea_query_driver_mysql_impl(input)
 }
 
+/// Macro to easily bind [`Values`] to [`sqlx::query::Query`] or to [`sqlx::query::QueryAs`] for sqlx-mysql.
 #[cfg(feature = "sqlx-mysql")]
 #[proc_macro]
 pub fn bind_params_sqlx_mysql(input: TokenStream) -> TokenStream {
     sqlx_mysql::bind_params_sqlx_mysql_impl(input)
 }
 
+/// Macro to generate sqlx-postgres driver.
 #[cfg(feature = "sqlx-postgres")]
 #[proc_macro]
-pub fn sea_query_driver_postgres(_: TokenStream) -> TokenStream {
-    sqlx_postgres::sea_query_driver_postgres_impl()
+pub fn sea_query_driver_postgres(input: TokenStream) -> TokenStream {
+    sqlx_postgres::sea_query_driver_postgres_impl(input)
 }
 
+/// Macro to easily bind [`Values`] to [`sqlx::query::Query`] or to [`sqlx::query::QueryAs`] for sqlx-postgres.
 #[cfg(feature = "sqlx-postgres")]
 #[proc_macro]
 pub fn bind_params_sqlx_postgres(input: TokenStream) -> TokenStream {
     sqlx_postgres::bind_params_sqlx_postgres_impl(input)
 }
 
+/// Macro to generate sqlx-sqlite driver.
 #[cfg(feature = "sqlx-sqlite")]
 #[proc_macro]
-pub fn sea_query_driver_sqlite(_: TokenStream) -> TokenStream {
-    sqlx_sqlite::sea_query_driver_sqlite_impl()
+pub fn sea_query_driver_sqlite(input: TokenStream) -> TokenStream {
+    sqlx_sqlite::sea_query_driver_sqlite_impl(input)
 }
 
+/// Macro to easily bind [`Values`] to [`sqlx::query::Query`] or to [`sqlx::query::QueryAs`] for sqlx-sqlite.
 #[cfg(feature = "sqlx-sqlite")]
 #[proc_macro]
 pub fn bind_params_sqlx_sqlite(input: TokenStream) -> TokenStream {

--- a/sea-query-driver/src/lib.rs
+++ b/sea-query-driver/src/lib.rs
@@ -26,7 +26,7 @@ mod utils;
 ///
 /// Specify a path to the `rusqlite` crate instance
 /// ```
-/// sea_query::sea_query_driver_rusqlite!(driver="...")
+/// sea_query::sea_query_driver_rusqlite!(rusqlite="...")
 /// ```
 ///
 /// Specify a path to the `sea-query` crate instance
@@ -36,9 +36,9 @@ mod utils;
 ///
 /// Specify pathes to the `sea-query` and to the `rusqlite` crates instances
 /// ```
-/// sea_query::sea_query_driver_rusqlite!(driver="...", sea_query="...")
+/// sea_query::sea_query_driver_rusqlite!(rusqlite="...", sea_query="...")
 /// // or
-/// sea_query::sea_query_driver_rusqlite!(sea_query="...", driver="...")
+/// sea_query::sea_query_driver_rusqlite!(sea_query="...", rusqlite="...")
 /// ```
 #[cfg(feature = "rusqlite")]
 #[proc_macro]
@@ -55,7 +55,7 @@ pub fn sea_query_driver_rusqlite(input: TokenStream) -> TokenStream {
 ///
 /// Specify a path to the `sqlx` crate instance
 /// ```
-/// sea_query::sea_query_driver_mysql!(driver="...")
+/// sea_query::sea_query_driver_mysql!(sqlx="...")
 /// ```
 ///
 /// Specify a path to the `sea-query` crate instance
@@ -65,9 +65,9 @@ pub fn sea_query_driver_rusqlite(input: TokenStream) -> TokenStream {
 ///
 /// Specify pathes to the `sea-query` and to the `sqlx` crates instances
 /// ```
-/// sea_query::sea_query_driver_mysql!(driver="...", sea_query="...")
+/// sea_query::sea_query_driver_mysql!(sqlx="...", sea_query="...")
 /// // or
-/// sea_query::sea_query_driver_mysql!(sea_query="...", driver="...")
+/// sea_query::sea_query_driver_mysql!(sea_query="...", sqlx="...")
 /// ```
 #[cfg(feature = "sqlx-mysql")]
 #[proc_macro]
@@ -91,7 +91,7 @@ pub fn bind_params_sqlx_mysql(input: TokenStream) -> TokenStream {
 ///
 /// Specify a path to the `sqlx` crate instance
 /// ```
-/// sea_query::sea_query_driver_postgres!(driver="...")
+/// sea_query::sea_query_driver_postgres!(sqlx="...")
 /// ```
 ///
 /// Specify a path to the `sea-query` crate instance
@@ -101,9 +101,9 @@ pub fn bind_params_sqlx_mysql(input: TokenStream) -> TokenStream {
 ///
 /// Specify pathes to the `sea-query` and to the `sqlx` crates instances
 /// ```
-/// sea_query::sea_query_driver_postgres!(driver="...", sea_query="...")
+/// sea_query::sea_query_driver_postgres!(sqlx="...", sea_query="...")
 /// // or
-/// sea_query::sea_query_driver_postgres!(sea_query="...", driver="...")
+/// sea_query::sea_query_driver_postgres!(sea_query="...", sqlx="...")
 /// ```
 #[cfg(feature = "sqlx-postgres")]
 #[proc_macro]
@@ -127,7 +127,7 @@ pub fn bind_params_sqlx_postgres(input: TokenStream) -> TokenStream {
 ///
 /// Specify a path to the `sqlx` crate instance
 /// ```
-/// sea_query::sea_query_driver_sqlite!(driver="...")
+/// sea_query::sea_query_driver_sqlite!(sqlx="...")
 /// ```
 ///
 /// Specify a path to the `sea-query` crate instance
@@ -137,9 +137,9 @@ pub fn bind_params_sqlx_postgres(input: TokenStream) -> TokenStream {
 ///
 /// Specify pathes to the `sea-query` and to the `sqlx` crates instances
 /// ```
-/// sea_query::sea_query_driver_sqlite!(driver="...", sea_query="...")
+/// sea_query::sea_query_driver_sqlite!(sqlx="...", sea_query="...")
 /// // or
-/// sea_query::sea_query_driver_sqlite!(sea_query="...", driver="...")
+/// sea_query::sea_query_driver_sqlite!(sea_query="...", sqlx="...")
 /// ```
 #[cfg(feature = "sqlx-sqlite")]
 #[proc_macro]

--- a/sea-query-driver/src/rusqlite.rs
+++ b/sea-query-driver/src/rusqlite.rs
@@ -1,10 +1,10 @@
-use crate::utils::DriverArgs;
+use crate::utils::RusqliteDriverArgs;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
 
 pub fn sea_query_driver_rusqlite_impl(input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(input as DriverArgs);
+    let args = parse_macro_input!(input as RusqliteDriverArgs);
     let rusqlite_path = args.driver;
     let sea_query_path = args.sea_query;
 

--- a/sea-query-driver/src/rusqlite.rs
+++ b/sea-query-driver/src/rusqlite.rs
@@ -1,7 +1,11 @@
+use crate::utils::DriverArgs;
 use proc_macro::TokenStream;
 use quote::quote;
+use syn::parse_macro_input;
 
-pub fn sea_query_driver_rusqlite_impl() -> TokenStream {
+pub fn sea_query_driver_rusqlite_impl(input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(input as DriverArgs);
+
     let with_json = if cfg!(feature = "with-json") {
         quote! { Value::Json(v) => box_to_sql!(v), }
     } else {
@@ -42,8 +46,8 @@ pub fn sea_query_driver_rusqlite_impl() -> TokenStream {
 
     let output = quote! {
         mod sea_query_driver_rusqlite {
-            use rusqlite::{types::{Null, ToSqlOutput}, Result, ToSql};
-            use sea_query::{Value, Values};
+            use #args::rusqlite::{types::{Null, ToSqlOutput}, Result, ToSql};
+            use ::sea_query::{Value, Values};
 
             pub struct RusqliteValue(pub Value);
 

--- a/sea-query-driver/src/rusqlite.rs
+++ b/sea-query-driver/src/rusqlite.rs
@@ -5,6 +5,8 @@ use syn::parse_macro_input;
 
 pub fn sea_query_driver_rusqlite_impl(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as DriverArgs);
+    let sqlx_path = args.sqlx;
+    let sea_query_path = args.sea_query;
 
     let with_json = if cfg!(feature = "with-json") {
         quote! { Value::Json(v) => box_to_sql!(v), }
@@ -46,8 +48,8 @@ pub fn sea_query_driver_rusqlite_impl(input: TokenStream) -> TokenStream {
 
     let output = quote! {
         mod sea_query_driver_rusqlite {
-            use #args::rusqlite::{types::{Null, ToSqlOutput}, Result, ToSql};
-            use ::sea_query::{Value, Values};
+            use #sqlx_path::rusqlite::{types::{Null, ToSqlOutput}, Result, ToSql};
+            use #sea_query_path::sea_query::{Value, Values};
 
             pub struct RusqliteValue(pub Value);
 

--- a/sea-query-driver/src/rusqlite.rs
+++ b/sea-query-driver/src/rusqlite.rs
@@ -5,7 +5,7 @@ use syn::parse_macro_input;
 
 pub fn sea_query_driver_rusqlite_impl(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as DriverArgs);
-    let sqlx_path = args.sqlx;
+    let rusqlite_path = args.driver;
     let sea_query_path = args.sea_query;
 
     let with_json = if cfg!(feature = "with-json") {
@@ -48,7 +48,7 @@ pub fn sea_query_driver_rusqlite_impl(input: TokenStream) -> TokenStream {
 
     let output = quote! {
         mod sea_query_driver_rusqlite {
-            use #sqlx_path::rusqlite::{types::{Null, ToSqlOutput}, Result, ToSql};
+            use #rusqlite_path::rusqlite::{types::{Null, ToSqlOutput}, Result, ToSql};
             use #sea_query_path::sea_query::{Value, Values};
 
             pub struct RusqliteValue(pub Value);

--- a/sea-query-driver/src/sqlx_mysql.rs
+++ b/sea-query-driver/src/sqlx_mysql.rs
@@ -108,7 +108,7 @@ pub fn bind_params_sqlx_mysql_impl(input: TokenStream) -> TokenStream {
 
 pub fn sea_query_driver_mysql_impl(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as DriverArgs);
-    let sqlx_path = args.sqlx;
+    let sqlx_path = args.driver;
     let sea_query_path = args.sea_query;
 
     let output = quote! {

--- a/sea-query-driver/src/sqlx_mysql.rs
+++ b/sea-query-driver/src/sqlx_mysql.rs
@@ -107,25 +107,27 @@ pub fn bind_params_sqlx_mysql_impl(input: TokenStream) -> TokenStream {
 }
 
 pub fn sea_query_driver_mysql_impl(input: TokenStream) -> TokenStream {
-    let sqlx_path = parse_macro_input!(input as DriverArgs);
+    let args = parse_macro_input!(input as DriverArgs);
+    let sqlx_path = args.sqlx;
+    let sea_query_path = args.sea_query;
 
     let output = quote! {
         mod sea_query_driver_mysql {
             use #sqlx_path::sqlx::{mysql::MySqlArguments, MySql};
-            use ::sea_query::{Value, Values};
+            use #sea_query_path::sea_query::{Value, Values};
 
             type SqlxQuery<'a> = #sqlx_path::sqlx::query::Query<'a, MySql, MySqlArguments>;
             type SqlxQueryAs<'a, T> = #sqlx_path::sqlx::query::QueryAs<'a, MySql, T, MySqlArguments>;
 
             pub fn bind_query<'a>(query: SqlxQuery<'a>, params: &'a Values) -> SqlxQuery<'a> {
-                ::sea_query::bind_params_sqlx_mysql!(query, params.0)
+                #sea_query_path::sea_query::bind_params_sqlx_mysql!(query, params.0)
             }
 
             pub fn bind_query_as<'a, T>(
                 query: SqlxQueryAs<'a, T>,
                 params: &'a Values,
             ) -> SqlxQueryAs<'a, T> {
-                ::sea_query::bind_params_sqlx_mysql!(query, params.0)
+                #sea_query_path::sea_query::bind_params_sqlx_mysql!(query, params.0)
             }
         }
     };

--- a/sea-query-driver/src/sqlx_mysql.rs
+++ b/sea-query-driver/src/sqlx_mysql.rs
@@ -1,10 +1,10 @@
-use crate::utils::Args;
+use crate::utils::{BindParamArgs, DriverArgs};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
 
 pub fn bind_params_sqlx_mysql_impl(input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(input as Args);
+    let args = parse_macro_input!(input as BindParamArgs);
     let query = args.query;
     let params = args.params;
 
@@ -106,24 +106,26 @@ pub fn bind_params_sqlx_mysql_impl(input: TokenStream) -> TokenStream {
     output.into()
 }
 
-pub fn sea_query_driver_mysql_impl() -> TokenStream {
+pub fn sea_query_driver_mysql_impl(input: TokenStream) -> TokenStream {
+    let sqlx_path = parse_macro_input!(input as DriverArgs);
+
     let output = quote! {
         mod sea_query_driver_mysql {
-            use sqlx::{mysql::MySqlArguments, MySql};
-            use sea_query::{Value, Values};
+            use #sqlx_path::sqlx::{mysql::MySqlArguments, MySql};
+            use ::sea_query::{Value, Values};
 
-            type SqlxQuery<'a> = sqlx::query::Query<'a, MySql, MySqlArguments>;
-            type SqlxQueryAs<'a, T> = sqlx::query::QueryAs<'a, MySql, T, MySqlArguments>;
+            type SqlxQuery<'a> = #sqlx_path::sqlx::query::Query<'a, MySql, MySqlArguments>;
+            type SqlxQueryAs<'a, T> = #sqlx_path::sqlx::query::QueryAs<'a, MySql, T, MySqlArguments>;
 
             pub fn bind_query<'a>(query: SqlxQuery<'a>, params: &'a Values) -> SqlxQuery<'a> {
-                sea_query::bind_params_sqlx_mysql!(query, params.0)
+                ::sea_query::bind_params_sqlx_mysql!(query, params.0)
             }
 
             pub fn bind_query_as<'a, T>(
                 query: SqlxQueryAs<'a, T>,
                 params: &'a Values,
             ) -> SqlxQueryAs<'a, T> {
-                sea_query::bind_params_sqlx_mysql!(query, params.0)
+                ::sea_query::bind_params_sqlx_mysql!(query, params.0)
             }
         }
     };

--- a/sea-query-driver/src/sqlx_mysql.rs
+++ b/sea-query-driver/src/sqlx_mysql.rs
@@ -1,4 +1,4 @@
-use crate::utils::{BindParamArgs, DriverArgs};
+use crate::utils::{BindParamArgs, SqlxDriverArgs};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
@@ -107,7 +107,7 @@ pub fn bind_params_sqlx_mysql_impl(input: TokenStream) -> TokenStream {
 }
 
 pub fn sea_query_driver_mysql_impl(input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(input as DriverArgs);
+    let args = parse_macro_input!(input as SqlxDriverArgs);
     let sqlx_path = args.driver;
     let sea_query_path = args.sea_query;
 

--- a/sea-query-driver/src/sqlx_postgres.rs
+++ b/sea-query-driver/src/sqlx_postgres.rs
@@ -115,7 +115,7 @@ pub fn bind_params_sqlx_postgres_impl(input: TokenStream) -> TokenStream {
 
 pub fn sea_query_driver_postgres_impl(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as DriverArgs);
-    let sqlx_path = args.sqlx;
+    let sqlx_path = args.driver;
     let sea_query_path = args.sea_query;
 
     let output = quote! {

--- a/sea-query-driver/src/sqlx_postgres.rs
+++ b/sea-query-driver/src/sqlx_postgres.rs
@@ -1,4 +1,4 @@
-use crate::utils::{BindParamArgs, DriverArgs};
+use crate::utils::{BindParamArgs, SqlxDriverArgs};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
@@ -114,7 +114,7 @@ pub fn bind_params_sqlx_postgres_impl(input: TokenStream) -> TokenStream {
 }
 
 pub fn sea_query_driver_postgres_impl(input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(input as DriverArgs);
+    let args = parse_macro_input!(input as SqlxDriverArgs);
     let sqlx_path = args.driver;
     let sea_query_path = args.sea_query;
 

--- a/sea-query-driver/src/sqlx_postgres.rs
+++ b/sea-query-driver/src/sqlx_postgres.rs
@@ -1,10 +1,10 @@
-use crate::utils::Args;
+use crate::utils::{BindParamArgs, DriverArgs};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
 
 pub fn bind_params_sqlx_postgres_impl(input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(input as Args);
+    let args = parse_macro_input!(input as BindParamArgs);
     let query = args.query;
     let params = args.params;
 
@@ -113,24 +113,26 @@ pub fn bind_params_sqlx_postgres_impl(input: TokenStream) -> TokenStream {
     output.into()
 }
 
-pub fn sea_query_driver_postgres_impl() -> TokenStream {
+pub fn sea_query_driver_postgres_impl(input: TokenStream) -> TokenStream {
+    let sqlx_path = parse_macro_input!(input as DriverArgs);
+
     let output = quote! {
         mod sea_query_driver_postgres {
-            use sqlx::{postgres::PgArguments, Postgres};
-            use sea_query::{Value, Values};
+            use #sqlx_path::sqlx::{postgres::PgArguments, Postgres};
+            use ::sea_query::{Value, Values};
 
-            type SqlxQuery<'a> = sqlx::query::Query<'a, Postgres, PgArguments>;
-            type SqlxQueryAs<'a, T> = sqlx::query::QueryAs<'a, Postgres, T, PgArguments>;
+            type SqlxQuery<'a> = #sqlx_path::sqlx::query::Query<'a, Postgres, PgArguments>;
+            type SqlxQueryAs<'a, T> = #sqlx_path::sqlx::query::QueryAs<'a, Postgres, T, PgArguments>;
 
             pub fn bind_query<'a>(query: SqlxQuery<'a>, params: &'a Values) -> SqlxQuery<'a> {
-                sea_query::bind_params_sqlx_postgres!(query, params.0)
+                ::sea_query::bind_params_sqlx_postgres!(query, params.0)
             }
 
             pub fn bind_query_as<'a, T>(
                 query: SqlxQueryAs<'a, T>,
                 params: &'a Values,
             ) -> SqlxQueryAs<'a, T> {
-                sea_query::bind_params_sqlx_postgres!(query, params.0)
+                ::sea_query::bind_params_sqlx_postgres!(query, params.0)
             }
         }
     };

--- a/sea-query-driver/src/sqlx_postgres.rs
+++ b/sea-query-driver/src/sqlx_postgres.rs
@@ -114,25 +114,27 @@ pub fn bind_params_sqlx_postgres_impl(input: TokenStream) -> TokenStream {
 }
 
 pub fn sea_query_driver_postgres_impl(input: TokenStream) -> TokenStream {
-    let sqlx_path = parse_macro_input!(input as DriverArgs);
+    let args = parse_macro_input!(input as DriverArgs);
+    let sqlx_path = args.sqlx;
+    let sea_query_path = args.sea_query;
 
     let output = quote! {
         mod sea_query_driver_postgres {
             use #sqlx_path::sqlx::{postgres::PgArguments, Postgres};
-            use ::sea_query::{Value, Values};
+            use #sea_query_path::sea_query::{Value, Values};
 
             type SqlxQuery<'a> = #sqlx_path::sqlx::query::Query<'a, Postgres, PgArguments>;
             type SqlxQueryAs<'a, T> = #sqlx_path::sqlx::query::QueryAs<'a, Postgres, T, PgArguments>;
 
             pub fn bind_query<'a>(query: SqlxQuery<'a>, params: &'a Values) -> SqlxQuery<'a> {
-                ::sea_query::bind_params_sqlx_postgres!(query, params.0)
+                #sea_query_path::sea_query::bind_params_sqlx_postgres!(query, params.0)
             }
 
             pub fn bind_query_as<'a, T>(
                 query: SqlxQueryAs<'a, T>,
                 params: &'a Values,
             ) -> SqlxQueryAs<'a, T> {
-                ::sea_query::bind_params_sqlx_postgres!(query, params.0)
+                #sea_query_path::sea_query::bind_params_sqlx_postgres!(query, params.0)
             }
         }
     };

--- a/sea-query-driver/src/sqlx_sqlite.rs
+++ b/sea-query-driver/src/sqlx_sqlite.rs
@@ -1,10 +1,10 @@
-use crate::utils::Args;
+use crate::utils::{BindParamArgs, DriverArgs};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
 
 pub fn bind_params_sqlx_sqlite(input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(input as Args);
+    let args = parse_macro_input!(input as BindParamArgs);
     let query = args.query;
     let params = args.params;
 
@@ -106,24 +106,26 @@ pub fn bind_params_sqlx_sqlite(input: TokenStream) -> TokenStream {
     output.into()
 }
 
-pub fn sea_query_driver_sqlite_impl() -> TokenStream {
+pub fn sea_query_driver_sqlite_impl(input: TokenStream) -> TokenStream {
+    let sqlx_path = parse_macro_input!(input as DriverArgs);
+
     let output = quote! {
         mod sea_query_driver_sqlite {
-            use sqlx::{sqlite::SqliteArguments, Sqlite};
-            use sea_query::{Value, Values};
+            use #sqlx_path::sqlx::{sqlite::SqliteArguments, Sqlite};
+            use ::sea_query::{Value, Values};
 
-            type SqlxQuery<'a> = sqlx::query::Query<'a, Sqlite, SqliteArguments<'a>>;
-            type SqlxQueryAs<'a, T> = sqlx::query::QueryAs<'a, Sqlite, T, SqliteArguments<'a>>;
+            type SqlxQuery<'a> = #sqlx_path::sqlx::query::Query<'a, Sqlite, SqliteArguments<'a>>;
+            type SqlxQueryAs<'a, T> = #sqlx_path::sqlx::query::QueryAs<'a, Sqlite, T, SqliteArguments<'a>>;
 
             pub fn bind_query<'a>(query: SqlxQuery<'a>, params: &'a Values) -> SqlxQuery<'a> {
-                sea_query::bind_params_sqlx_sqlite!(query, params.0)
+                ::sea_query::bind_params_sqlx_sqlite!(query, params.0)
             }
 
             pub fn bind_query_as<'a, T>(
                 query: SqlxQueryAs<'a, T>,
                 params: &'a Values,
             ) -> SqlxQueryAs<'a, T> {
-                sea_query::bind_params_sqlx_sqlite!(query, params.0)
+                ::sea_query::bind_params_sqlx_sqlite!(query, params.0)
             }
         }
     };

--- a/sea-query-driver/src/sqlx_sqlite.rs
+++ b/sea-query-driver/src/sqlx_sqlite.rs
@@ -108,7 +108,7 @@ pub fn bind_params_sqlx_sqlite(input: TokenStream) -> TokenStream {
 
 pub fn sea_query_driver_sqlite_impl(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as DriverArgs);
-    let sqlx_path = args.sqlx;
+    let sqlx_path = args.driver;
     let sea_query_path = args.sea_query;
 
     let output = quote! {

--- a/sea-query-driver/src/sqlx_sqlite.rs
+++ b/sea-query-driver/src/sqlx_sqlite.rs
@@ -107,25 +107,27 @@ pub fn bind_params_sqlx_sqlite(input: TokenStream) -> TokenStream {
 }
 
 pub fn sea_query_driver_sqlite_impl(input: TokenStream) -> TokenStream {
-    let sqlx_path = parse_macro_input!(input as DriverArgs);
+    let args = parse_macro_input!(input as DriverArgs);
+    let sqlx_path = args.sqlx;
+    let sea_query_path = args.sea_query;
 
     let output = quote! {
         mod sea_query_driver_sqlite {
             use #sqlx_path::sqlx::{sqlite::SqliteArguments, Sqlite};
-            use ::sea_query::{Value, Values};
+            use #sea_query_path::sea_query::{Value, Values};
 
             type SqlxQuery<'a> = #sqlx_path::sqlx::query::Query<'a, Sqlite, SqliteArguments<'a>>;
             type SqlxQueryAs<'a, T> = #sqlx_path::sqlx::query::QueryAs<'a, Sqlite, T, SqliteArguments<'a>>;
 
             pub fn bind_query<'a>(query: SqlxQuery<'a>, params: &'a Values) -> SqlxQuery<'a> {
-                ::sea_query::bind_params_sqlx_sqlite!(query, params.0)
+                #sea_query_path::sea_query::bind_params_sqlx_sqlite!(query, params.0)
             }
 
             pub fn bind_query_as<'a, T>(
                 query: SqlxQueryAs<'a, T>,
                 params: &'a Values,
             ) -> SqlxQueryAs<'a, T> {
-                ::sea_query::bind_params_sqlx_sqlite!(query, params.0)
+                #sea_query_path::sea_query::bind_params_sqlx_sqlite!(query, params.0)
             }
         }
     };

--- a/sea-query-driver/src/sqlx_sqlite.rs
+++ b/sea-query-driver/src/sqlx_sqlite.rs
@@ -1,4 +1,4 @@
-use crate::utils::{BindParamArgs, DriverArgs};
+use crate::utils::{BindParamArgs, SqlxDriverArgs};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
@@ -107,7 +107,7 @@ pub fn bind_params_sqlx_sqlite(input: TokenStream) -> TokenStream {
 }
 
 pub fn sea_query_driver_sqlite_impl(input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(input as DriverArgs);
+    let args = parse_macro_input!(input as SqlxDriverArgs);
     let sqlx_path = args.driver;
     let sea_query_path = args.sea_query;
 

--- a/sea-query-driver/src/utils.rs
+++ b/sea-query-driver/src/utils.rs
@@ -55,7 +55,7 @@ macro_rules! args_parse_impl {
                     let arg: DriverArg = input.parse()?;
                     args.sea_query = Some(arg.0)
                 } else {
-                    return Err(lookahead.error());
+                    return Ok(args);
                 };
                 let comma: Option<token::Comma> = input.parse()?;
                 if comma.is_none() {
@@ -67,8 +67,6 @@ macro_rules! args_parse_impl {
                 } else if lookahead.peek(kw::sea_query) {
                     let arg: DriverArg = input.parse()?;
                     args.sea_query = Some(arg.0)
-                } else {
-                    return Err(lookahead.error());
                 };
                 Ok(args)
             }

--- a/sea-query-driver/src/utils.rs
+++ b/sea-query-driver/src/utils.rs
@@ -39,7 +39,7 @@ impl parse::Parse for DriverArgs {
                 sea_query: None,
             });
         }
-        let comma: Option<token::Comma> = input.parse()?;
+        let _: Option<token::Comma> = input.parse()?;
         let sea_query = parse_option_path(&input)?;
 
         Ok(DriverArgs { driver, sea_query })

--- a/sea-query-driver/src/utils.rs
+++ b/sea-query-driver/src/utils.rs
@@ -1,16 +1,40 @@
+use proc_macro2::TokenStream;
 use syn::{parse, token};
 
-pub struct Args {
+pub struct BindParamArgs {
     pub(crate) query: syn::Expr,
     pub(crate) params: syn::Expr,
 }
 
-impl parse::Parse for Args {
+impl parse::Parse for BindParamArgs {
     fn parse(input: parse::ParseStream) -> parse::Result<Self> {
         let query: syn::Expr = input.parse()?;
         let _: token::Comma = input.parse()?;
         let params: syn::Expr = input.parse()?;
 
-        Ok(Args { query, params })
+        Ok(BindParamArgs { query, params })
+    }
+}
+
+pub struct DriverArgs {
+    pub(crate) path: Option<syn::TypePath>,
+}
+
+impl parse::Parse for DriverArgs {
+    fn parse(input: parse::ParseStream) -> parse::Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(syn::Ident) {
+            input.parse().map(|path| Self { path: Some(path) })
+        } else {
+            Ok(Self { path: None })
+        }
+    }
+}
+
+impl quote::ToTokens for DriverArgs {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if let Some(path) = &self.path {
+            path.to_tokens(tokens)
+        }
     }
 }

--- a/sea-query-driver/src/utils.rs
+++ b/sea-query-driver/src/utils.rs
@@ -16,11 +16,11 @@ impl parse::Parse for BindParamArgs {
     }
 }
 
-pub struct DriverArgs {
+pub struct OptionTypePath {
     pub(crate) path: Option<syn::TypePath>,
 }
 
-impl parse::Parse for DriverArgs {
+impl parse::Parse for OptionTypePath {
     fn parse(input: parse::ParseStream) -> parse::Result<Self> {
         let lookahead = input.lookahead1();
         if lookahead.peek(syn::Ident) {
@@ -31,10 +31,25 @@ impl parse::Parse for DriverArgs {
     }
 }
 
-impl quote::ToTokens for DriverArgs {
+impl quote::ToTokens for OptionTypePath {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         if let Some(path) = &self.path {
             path.to_tokens(tokens)
         }
+    }
+}
+
+pub struct DriverArgs {
+    pub(crate) sqlx: OptionTypePath,
+    pub(crate) sea_query: OptionTypePath,
+}
+
+impl parse::Parse for DriverArgs {
+    fn parse(input: parse::ParseStream) -> parse::Result<Self> {
+        let sqlx: OptionTypePath = input.parse()?;
+        let _: token::Comma = input.parse()?;
+        let sea_query: OptionTypePath = input.parse()?;
+
+        Ok(DriverArgs { sqlx, sea_query })
     }
 }

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -1,6 +1,6 @@
 use crate::{DynIden, Expr, IntoIden, SimpleExpr, Value};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct OnConflict {
     pub(crate) target: Option<OnConflictTarget>,
     pub(crate) action: Option<OnConflictAction>,
@@ -224,14 +224,5 @@ impl OnConflict {
                 .collect(),
         ));
         self
-    }
-}
-
-impl Default for OnConflict {
-    fn default() -> Self {
-        Self {
-            target: None,
-            action: None,
-        }
     }
 }


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/295>

## Adds

After this PR can do: `sea_query::sea_query_driver_postgres!(common);`, where **common** is prefix for `::sqlx`

## Changes

- prefix for `sqlx` in drivers
- prefix for `sea-query` in drivers
