### PR TITLE
Making pagination efficient with `first` function.

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1709,6 +1709,36 @@ impl SelectStatement {
         self
     }
 
+    /// First rows to return.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .column(Glyph::Aspect)
+    ///     .from(Glyph::Table)
+    ///     .first(10)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `aspect` FROM `glyph` LIMIT 10"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "aspect" FROM "glyph" LIMIT 10"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "aspect" FROM "glyph" LIMIT 10"#
+    /// );
+    /// ```
+    pub fn first(&mut self, first: u64) -> &mut Self {
+        Self::reset_offset(self).limit(first)
+    }
+
     /// Row locking (if supported).
     ///
     /// # Examples

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -15,6 +15,18 @@ fn select_1() {
 }
 
 #[test]
+fn select_1a() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
+            .from(Char::Table)
+            .first(10)
+            .to_string(MysqlQueryBuilder),
+        "SELECT `character`, `size_w`, `size_h` FROM `character` LIMIT 10"
+    );
+}
+
+#[test]
 fn select_2() {
     assert_eq!(
         Query::select()

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -15,6 +15,18 @@ fn select_1() {
 }
 
 #[test]
+fn select_1a() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
+            .from(Char::Table)
+            .first(10)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "character", "size_w", "size_h" FROM "character" LIMIT 10"#
+    );
+}
+
+#[test]
 fn select_2() {
     assert_eq!(
         Query::select()

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -15,6 +15,18 @@ fn select_1() {
 }
 
 #[test]
+fn select_1a() {
+    assert_eq!(
+        Query::select()
+            .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
+            .from(Char::Table)
+            .first(10)
+            .to_string(SqliteQueryBuilder),
+        r#"SELECT "character", "size_w", "size_h" FROM "character" LIMIT 10"#
+    );
+}
+
+#[test]
 fn select_2() {
     assert_eq!(
         Query::select()


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes  https://github.com/SeaQL/sea-orm/issues/300
<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - This PR will help optimise the `fetch_page` in https://github.com/SeaQL/sea-orm

## Adds
- `first` function to the `SelectStatement` struct.
- Corresponding tests for `mysql`, `postgres` and `sqlite`

## Improves
This will improve the pagination.
