### PR TITLE
Add ability to alter foreign keys

### DIFF
--- a/src/backend/foreign_key_builder.rs
+++ b/src/backend/foreign_key_builder.rs
@@ -1,5 +1,12 @@
 use crate::*;
 
+#[derive(Debug, PartialEq)]
+pub enum Mode {
+    Creation,
+    Alter,
+    TableAlter,
+}
+
 pub trait ForeignKeyBuilder: QuotedBuilder {
     /// Translate [`ForeignKeyCreateStatement`] into SQL statement.
     fn prepare_foreign_key_create_statement(
@@ -7,7 +14,7 @@ pub trait ForeignKeyBuilder: QuotedBuilder {
         create: &ForeignKeyCreateStatement,
         sql: &mut SqlWriter,
     ) {
-        self.prepare_foreign_key_create_statement_internal(create, sql, false, true)
+        self.prepare_foreign_key_create_statement_internal(create, sql, Mode::Alter)
     }
 
     /// Translate [`ForeignKeyDropStatement`] into SQL statement.
@@ -16,7 +23,7 @@ pub trait ForeignKeyBuilder: QuotedBuilder {
         drop: &ForeignKeyDropStatement,
         sql: &mut SqlWriter,
     ) {
-        self.prepare_foreign_key_drop_statement_internal(drop, sql, true)
+        self.prepare_foreign_key_drop_statement_internal(drop, sql, Mode::Alter)
     }
 
     /// Translate [`ForeignKeyAction`] into SQL statement.
@@ -45,9 +52,8 @@ pub trait ForeignKeyBuilder: QuotedBuilder {
         &self,
         drop: &ForeignKeyDropStatement,
         sql: &mut SqlWriter,
-        inside_table_single_alter: bool,
+        mode: Mode,
     );
-
 
     #[doc(hidden)]
     /// Internal function to factor foreign key creation in table and outside.
@@ -55,7 +61,6 @@ pub trait ForeignKeyBuilder: QuotedBuilder {
         &self,
         create: &ForeignKeyCreateStatement,
         sql: &mut SqlWriter,
-        inside_table_creation: bool,
-        inside_table_single_alter: bool,
+        mode: Mode,
     );
 }

--- a/src/backend/foreign_key_builder.rs
+++ b/src/backend/foreign_key_builder.rs
@@ -7,7 +7,16 @@ pub trait ForeignKeyBuilder: QuotedBuilder {
         create: &ForeignKeyCreateStatement,
         sql: &mut SqlWriter,
     ) {
-        self.prepare_foreign_key_create_statement_internal(create, sql, false)
+        self.prepare_foreign_key_create_statement_internal(create, sql, false, true)
+    }
+
+    /// Translate [`ForeignKeyDropStatement`] into SQL statement.
+    fn prepare_foreign_key_drop_statement(
+        &self,
+        drop: &ForeignKeyDropStatement,
+        sql: &mut SqlWriter,
+    ) {
+        self.prepare_foreign_key_drop_statement_internal(drop, sql, true)
     }
 
     /// Translate [`ForeignKeyAction`] into SQL statement.
@@ -30,12 +39,15 @@ pub trait ForeignKeyBuilder: QuotedBuilder {
         .unwrap()
     }
 
-    /// Translate [`ForeignKeyDropStatement`] into SQL statement.
-    fn prepare_foreign_key_drop_statement(
+    #[doc(hidden)]
+    /// Internal function to factor foreign key drop in table and outside.
+    fn prepare_foreign_key_drop_statement_internal(
         &self,
         drop: &ForeignKeyDropStatement,
         sql: &mut SqlWriter,
+        inside_table_single_alter: bool,
     );
+
 
     #[doc(hidden)]
     /// Internal function to factor foreign key creation in table and outside.
@@ -44,5 +56,6 @@ pub trait ForeignKeyBuilder: QuotedBuilder {
         create: &ForeignKeyCreateStatement,
         sql: &mut SqlWriter,
         inside_table_creation: bool,
+        inside_table_single_alter: bool,
     );
 }

--- a/src/backend/mysql/foreign_key.rs
+++ b/src/backend/mysql/foreign_key.rs
@@ -5,9 +5,9 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
         &self,
         drop: &ForeignKeyDropStatement,
         sql: &mut SqlWriter,
-        inside_table_single_alter: bool,
+        mode: Mode,
     ) {
-        if inside_table_single_alter {
+        if mode == Mode::Alter {
             write!(sql, "ALTER TABLE ").unwrap();
             if let Some(table) = &drop.table {
                 table.prepare(sql, self.quote());
@@ -25,10 +25,9 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
         &self,
         create: &ForeignKeyCreateStatement,
         sql: &mut SqlWriter,
-        inside_table_creation: bool,
-        inside_table_single_alter: bool,
+        mode: Mode,
     ) {
-        if !inside_table_creation && inside_table_single_alter {
+        if mode == Mode::Alter {
             write!(sql, "ALTER TABLE ").unwrap();
             if let Some(table) = &create.foreign_key.table {
                 table.prepare(sql, self.quote());
@@ -36,7 +35,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
             write!(sql, " ").unwrap();
         }
 
-        if !inside_table_creation {
+        if mode != Mode::Creation {
             write!(sql, "ADD ").unwrap();
         }
 

--- a/src/backend/mysql/foreign_key.rs
+++ b/src/backend/mysql/foreign_key.rs
@@ -1,17 +1,21 @@
 use super::*;
 
 impl ForeignKeyBuilder for MysqlQueryBuilder {
-    fn prepare_foreign_key_drop_statement(
+    fn prepare_foreign_key_drop_statement_internal(
         &self,
         drop: &ForeignKeyDropStatement,
         sql: &mut SqlWriter,
+        inside_table_single_alter: bool,
     ) {
-        write!(sql, "ALTER TABLE ").unwrap();
-        if let Some(table) = &drop.table {
-            table.prepare(sql, self.quote());
+        if inside_table_single_alter {
+            write!(sql, "ALTER TABLE ").unwrap();
+            if let Some(table) = &drop.table {
+                table.prepare(sql, self.quote());
+            }
+            write!(sql, " ").unwrap();
         }
 
-        write!(sql, " DROP FOREIGN KEY ").unwrap();
+        write!(sql, "DROP FOREIGN KEY ").unwrap();
         if let Some(name) = &drop.foreign_key.name {
             write!(sql, "`{}`", name).unwrap();
         }
@@ -22,13 +26,18 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
         create: &ForeignKeyCreateStatement,
         sql: &mut SqlWriter,
         inside_table_creation: bool,
+        inside_table_single_alter: bool,
     ) {
-        if !inside_table_creation {
+        if !inside_table_creation && inside_table_single_alter {
             write!(sql, "ALTER TABLE ").unwrap();
             if let Some(table) = &create.foreign_key.table {
                 table.prepare(sql, self.quote());
             }
-            write!(sql, " ADD ").unwrap();
+            write!(sql, " ").unwrap();
+        }
+
+        if !inside_table_creation {
+            write!(sql, "ADD ").unwrap();
         }
 
         write!(sql, "CONSTRAINT ").unwrap();

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -159,11 +159,10 @@ impl TableBuilder for MysqlQueryBuilder {
                     column_name.prepare(sql, self.quote());
                 }
                 TableAlterOption::DropForeignKey(drop) => {
-                    self.prepare_foreign_key_drop_statement_internal(drop, sql, false);
+                    self.prepare_foreign_key_drop_statement_internal(drop, sql, Mode::TableAlter);
                 }
-                TableAlterOption::AddForeignKey(create) => {
-                    self.prepare_foreign_key_create_statement_internal(create, sql, false, false)
-                }
+                TableAlterOption::AddForeignKey(create) => self
+                    .prepare_foreign_key_create_statement_internal(create, sql, Mode::TableAlter),
             };
             false
         });

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -158,11 +158,21 @@ impl TableBuilder for MysqlQueryBuilder {
                     write!(sql, "DROP COLUMN ").unwrap();
                     column_name.prepare(sql, self.quote());
                 }
-                TableAlterOption::DropForeignKey(drop) => {
-                    self.prepare_foreign_key_drop_statement_internal(drop, sql, Mode::TableAlter);
+                TableAlterOption::DropForeignKey(name) => {
+                    let mut foreign_key = TableForeignKey::new();
+                    foreign_key.name(name);
+                    let drop = ForeignKeyDropStatement {
+                        foreign_key: foreign_key,
+                        table: None
+                    };
+                    self.prepare_foreign_key_drop_statement_internal(&drop, sql, Mode::TableAlter);
                 }
-                TableAlterOption::AddForeignKey(create) => self
-                    .prepare_foreign_key_create_statement_internal(create, sql, Mode::TableAlter),
+                TableAlterOption::AddForeignKey(foreign_key) => {
+                    let create = ForeignKeyCreateStatement {
+                        foreign_key: foreign_key.to_owned()
+                    };
+                    self.prepare_foreign_key_create_statement_internal(&create, sql, Mode::TableAlter);
+                },
             };
             false
         });

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -158,6 +158,12 @@ impl TableBuilder for MysqlQueryBuilder {
                     write!(sql, "DROP COLUMN ").unwrap();
                     column_name.prepare(sql, self.quote());
                 }
+                TableAlterOption::DropForeignKey(drop) => {
+                    self.prepare_foreign_key_drop_statement_internal(drop, sql, false);
+                }
+                TableAlterOption::AddForeignKey(create) => {
+                    self.prepare_foreign_key_create_statement_internal(create, sql, false, false)
+                }
             };
             false
         });

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -160,7 +160,7 @@ impl TableBuilder for MysqlQueryBuilder {
                 }
                 TableAlterOption::DropForeignKey(name) => {
                     let mut foreign_key = TableForeignKey::new();
-                    foreign_key.name(name);
+                    foreign_key.name(&name.to_string());
                     let drop = ForeignKeyDropStatement {
                         foreign_key: foreign_key,
                         table: None

--- a/src/backend/postgres/foreign_key.rs
+++ b/src/backend/postgres/foreign_key.rs
@@ -5,9 +5,9 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
         &self,
         drop: &ForeignKeyDropStatement,
         sql: &mut SqlWriter,
-        inside_table_single_alter: bool,
+        mode: Mode,
     ) {
-        if inside_table_single_alter {
+        if mode == Mode::Alter {
             write!(sql, "ALTER TABLE ").unwrap();
             if let Some(table) = &drop.table {
                 table.prepare(sql, self.quote());
@@ -25,17 +25,17 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
         &self,
         create: &ForeignKeyCreateStatement,
         sql: &mut SqlWriter,
-        inside_table_creation: bool,
-        inside_table_single_alter: bool,
+        mode: Mode,
     ) {
-        if !inside_table_creation && inside_table_single_alter{
+        if mode == Mode::Alter {
             write!(sql, "ALTER TABLE ").unwrap();
             if let Some(table) = &create.foreign_key.table {
                 table.prepare(sql, self.quote());
             }
             write!(sql, " ").unwrap();
         }
-        if !inside_table_creation {
+
+        if mode != Mode::Creation {
             write!(sql, "ADD ").unwrap();
         }
 

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -170,11 +170,10 @@ impl TableBuilder for PostgresQueryBuilder {
                     column_name.prepare(sql, self.quote());
                 }
                 TableAlterOption::DropForeignKey(drop) => {
-                    self.prepare_foreign_key_drop_statement_internal(drop, sql, false)
+                    self.prepare_foreign_key_drop_statement_internal(drop, sql, Mode::TableAlter)
                 }
-                TableAlterOption::AddForeignKey(create) => {
-                    self.prepare_foreign_key_create_statement_internal(create, sql, false, false)
-                }
+                TableAlterOption::AddForeignKey(create) => self
+                    .prepare_foreign_key_create_statement_internal(create, sql, Mode::TableAlter),
             }
             false
         });

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -169,11 +169,21 @@ impl TableBuilder for PostgresQueryBuilder {
                     write!(sql, "DROP COLUMN ").unwrap();
                     column_name.prepare(sql, self.quote());
                 }
-                TableAlterOption::DropForeignKey(drop) => {
-                    self.prepare_foreign_key_drop_statement_internal(drop, sql, Mode::TableAlter)
+                TableAlterOption::DropForeignKey(name) => {
+                    let mut foreign_key = TableForeignKey::new();
+                    foreign_key.name(name);
+                    let drop = ForeignKeyDropStatement {
+                        foreign_key: foreign_key,
+                        table: None
+                    };
+                    self.prepare_foreign_key_drop_statement_internal(&drop, sql, Mode::TableAlter);
                 }
-                TableAlterOption::AddForeignKey(create) => self
-                    .prepare_foreign_key_create_statement_internal(create, sql, Mode::TableAlter),
+                TableAlterOption::AddForeignKey(foreign_key) => {
+                    let create = ForeignKeyCreateStatement {
+                        foreign_key: foreign_key.to_owned()
+                    };
+                    self.prepare_foreign_key_create_statement_internal(&create, sql, Mode::TableAlter);
+                },
             }
             false
         });

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -169,6 +169,12 @@ impl TableBuilder for PostgresQueryBuilder {
                     write!(sql, "DROP COLUMN ").unwrap();
                     column_name.prepare(sql, self.quote());
                 }
+                TableAlterOption::DropForeignKey(drop) => {
+                    self.prepare_foreign_key_drop_statement_internal(drop, sql, false)
+                }
+                TableAlterOption::AddForeignKey(create) => {
+                    self.prepare_foreign_key_create_statement_internal(create, sql, false, false)
+                }
             }
             false
         });

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -171,7 +171,7 @@ impl TableBuilder for PostgresQueryBuilder {
                 }
                 TableAlterOption::DropForeignKey(name) => {
                     let mut foreign_key = TableForeignKey::new();
-                    foreign_key.name(name);
+                    foreign_key.name(&name.to_string());
                     let drop = ForeignKeyDropStatement {
                         foreign_key: foreign_key,
                         table: None

--- a/src/backend/sqlite/foreign_key.rs
+++ b/src/backend/sqlite/foreign_key.rs
@@ -5,9 +5,9 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
         &self,
         drop: &ForeignKeyDropStatement,
         sql: &mut SqlWriter,
-        inside_table_single_alter: bool,
+        mode: Mode,
     ) {
-        if inside_table_single_alter {
+        if mode != Mode::Creation {
             panic!("Sqlite does not support modification of foreign key constraints to existing tables");
         }
 
@@ -21,10 +21,9 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
         &self,
         create: &ForeignKeyCreateStatement,
         sql: &mut SqlWriter,
-        inside_table_creation: bool,
-        inside_table_single_alter: bool,
+        mode: Mode,
     ) {
-        if !inside_table_creation || inside_table_single_alter {
+        if mode != Mode::Creation {
             panic!("Sqlite does not support modification of foreign key constraints to existing tables");
         }
 

--- a/src/backend/sqlite/foreign_key.rs
+++ b/src/backend/sqlite/foreign_key.rs
@@ -1,17 +1,17 @@
 use super::*;
 
 impl ForeignKeyBuilder for SqliteQueryBuilder {
-    fn prepare_foreign_key_drop_statement(
+    fn prepare_foreign_key_drop_statement_internal(
         &self,
         drop: &ForeignKeyDropStatement,
         sql: &mut SqlWriter,
+        inside_table_single_alter: bool,
     ) {
-        write!(sql, "ALTER TABLE ").unwrap();
-        if let Some(table) = &drop.table {
-            table.prepare(sql, self.quote());
+        if inside_table_single_alter {
+            panic!("Sqlite does not support modification of foreign key constraints to existing tables");
         }
 
-        write!(sql, " DROP FOREIGN KEY ").unwrap();
+        write!(sql, "DROP FOREIGN KEY ").unwrap();
         if let Some(name) = &drop.foreign_key.name {
             write!(sql, "`{}`", name).unwrap();
         }
@@ -22,8 +22,9 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
         create: &ForeignKeyCreateStatement,
         sql: &mut SqlWriter,
         inside_table_creation: bool,
+        inside_table_single_alter: bool,
     ) {
-        if !inside_table_creation {
+        if !inside_table_creation || inside_table_single_alter {
             panic!("Sqlite does not support modification of foreign key constraints to existing tables");
         }
 

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -163,6 +163,12 @@ impl TableBuilder for SqliteQueryBuilder {
             TableAlterOption::DropColumn(_) => {
                 panic!("Sqlite not support dropping table column")
             }
+            TableAlterOption::DropForeignKey(_) => {
+                panic!("Sqlite does not support modification of foreign key constraints to existing tables");
+            }
+            TableAlterOption::AddForeignKey(_) => {
+                panic!("Sqlite does not support modification of foreign key constraints to existing tables");
+            }
         }
     }
 

--- a/src/backend/table_builder.rs
+++ b/src/backend/table_builder.rs
@@ -36,7 +36,7 @@ pub trait TableBuilder: IndexBuilder + ForeignKeyBuilder + QuotedBuilder {
             if count > 0 {
                 write!(sql, ", ").unwrap();
             }
-            self.prepare_foreign_key_create_statement_internal(foreign_key, sql, true, false);
+            self.prepare_foreign_key_create_statement_internal(foreign_key, sql, Mode::Creation);
             count += 1;
         }
 

--- a/src/backend/table_builder.rs
+++ b/src/backend/table_builder.rs
@@ -36,7 +36,7 @@ pub trait TableBuilder: IndexBuilder + ForeignKeyBuilder + QuotedBuilder {
             if count > 0 {
                 write!(sql, ", ").unwrap();
             }
-            self.prepare_foreign_key_create_statement_internal(foreign_key, sql, true);
+            self.prepare_foreign_key_create_statement_internal(foreign_key, sql, true, false);
             count += 1;
         }
 

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -1,4 +1,7 @@
-use crate::{backend::SchemaBuilder, prepare::*, types::*, ColumnDef, SchemaStatementBuilder, ForeignKeyCreateStatement, ForeignKeyDropStatement};
+use crate::{
+    backend::SchemaBuilder, prepare::*, types::*, ColumnDef, ForeignKeyCreateStatement,
+    ForeignKeyDropStatement, SchemaStatementBuilder,
+};
 
 /// Alter a table
 ///
@@ -315,8 +318,7 @@ impl TableAlterStatement {
     ///
     /// // Sqlite not support modifying table column
     /// ```
-    pub fn add_foreign_key(&mut self, foreign_key: &ForeignKeyCreateStatement) -> &mut Self
-    {
+    pub fn add_foreign_key(&mut self, foreign_key: &ForeignKeyCreateStatement) -> &mut Self {
         self.add_alter_option(TableAlterOption::AddForeignKey(foreign_key.to_owned()))
     }
 
@@ -363,8 +365,7 @@ impl TableAlterStatement {
     ///
     /// // Sqlite not support modifying table column
     /// ```
-    pub fn drop_foreign_key(&mut self, foreign_key: &ForeignKeyDropStatement) -> &mut Self
-    {
+    pub fn drop_foreign_key(&mut self, foreign_key: &ForeignKeyDropStatement) -> &mut Self {
         self.add_alter_option(TableAlterOption::DropForeignKey(foreign_key.to_owned()))
     }
 

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -1,4 +1,4 @@
-use crate::{backend::SchemaBuilder, prepare::*, types::*, ColumnDef, SchemaStatementBuilder};
+use crate::{backend::SchemaBuilder, prepare::*, types::*, ColumnDef, SchemaStatementBuilder, ForeignKeyCreateStatement, ForeignKeyDropStatement};
 
 /// Alter a table
 ///
@@ -50,6 +50,8 @@ pub enum TableAlterOption {
     ModifyColumn(ColumnDef),
     RenameColumn(DynIden, DynIden),
     DropColumn(DynIden),
+    AddForeignKey(ForeignKeyCreateStatement),
+    DropForeignKey(ForeignKeyDropStatement),
 }
 
 impl Default for TableAlterStatement {
@@ -252,6 +254,118 @@ impl TableAlterStatement {
         T: Iden,
     {
         self.add_alter_option(TableAlterOption::DropColumn(SeaRc::new(col_name)))
+    }
+
+    /// Add a foreign key to existing table
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let foreign_key_char = ForeignKey::create()
+    ///     .name("FK_character_glyph")
+    ///     .from(Char::Table, (Char::FontId, Char::Id))
+    ///     .to(Glyph::Table, (Char::FontId, Glyph::Id))
+    ///     .on_delete(ForeignKeyAction::Cascade)
+    ///     .on_update(ForeignKeyAction::Cascade)
+    ///     .to_owned();
+    ///
+    /// let foreign_key_font = ForeignKey::create()
+    ///     .name("FK_character_font")
+    ///     .from(Char::Table, (Char::FontId))
+    ///     .to(Font::Table, (Font::Id))
+    ///     .on_delete(ForeignKeyAction::Cascade)
+    ///     .on_update(ForeignKeyAction::Cascade)
+    ///     .to_owned();
+    ///
+    /// let table = Table::alter()
+    ///     .table(Character::Table)
+    ///     .add_foreign_key(&foreign_key_char)
+    ///     .add_foreign_key(&foreign_key_font)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     table.to_string(MysqlQueryBuilder),
+    ///     vec![
+    ///         r#"ALTER TABLE `character`"#,
+    ///         r#"ADD CONSTRAINT `FK_character_glyph`"#,
+    ///         r#"FOREIGN KEY (`font_id`, `id`) REFERENCES `glyph` (`font_id`, `id`)"#,
+    ///         r#"ON DELETE CASCADE ON UPDATE CASCADE,"#,
+    ///         r#"ADD CONSTRAINT `FK_character_font`"#,
+    ///         r#"FOREIGN KEY (`font_id`) REFERENCES `font` (`id`)"#,
+    ///         r#"ON DELETE CASCADE ON UPDATE CASCADE"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    ///
+    /// assert_eq!(
+    ///     table.to_string(PostgresQueryBuilder),
+    ///     vec![
+    ///         r#"ALTER TABLE "character""#,
+    ///         r#"ADD CONSTRAINT "FK_character_glyph""#,
+    ///         r#"FOREIGN KEY ("font_id", "id") REFERENCES "glyph" ("font_id", "id")"#,
+    ///         r#"ON DELETE CASCADE ON UPDATE CASCADE,"#,
+    ///         r#"ADD CONSTRAINT "FK_character_font""#,
+    ///         r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
+    ///         r#"ON DELETE CASCADE ON UPDATE CASCADE"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    ///
+    /// // Sqlite not support modifying table column
+    /// ```
+    pub fn add_foreign_key(&mut self, foreign_key: &ForeignKeyCreateStatement) -> &mut Self
+    {
+        self.add_alter_option(TableAlterOption::AddForeignKey(foreign_key.to_owned()))
+    }
+
+    /// Drop a foreign key from existing table
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let foreign_key_char = ForeignKey::drop()
+    ///     .name("FK_character_glyph")
+    ///     .to_owned();
+    ///
+    /// let foreign_key_font = ForeignKey::drop()
+    ///     .name("FK_character_font")
+    ///     .to_owned();
+    ///
+    /// let table = Table::alter()
+    ///     .table(Character::Table)
+    ///     .drop_foreign_key(&foreign_key_char)
+    ///     .drop_foreign_key(&foreign_key_font)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     table.to_string(MysqlQueryBuilder),
+    ///     vec![
+    ///         r#"ALTER TABLE `character`"#,
+    ///         r#"DROP FOREIGN KEY `FK_character_glyph`,"#,
+    ///         r#"DROP FOREIGN KEY `FK_character_font`"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    ///
+    /// assert_eq!(
+    ///     table.to_string(PostgresQueryBuilder),
+    ///     vec![
+    ///         r#"ALTER TABLE "character""#,
+    ///         r#"DROP CONSTRAINT "FK_character_glyph","#,
+    ///         r#"DROP CONSTRAINT "FK_character_font""#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    ///
+    /// // Sqlite not support modifying table column
+    /// ```
+    pub fn drop_foreign_key(&mut self, foreign_key: &ForeignKeyDropStatement) -> &mut Self
+    {
+        self.add_alter_option(TableAlterOption::DropForeignKey(foreign_key.to_owned()))
     }
 
     fn add_alter_option(&mut self, alter_option: TableAlterOption) -> &mut Self {

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -53,7 +53,7 @@ pub enum TableAlterOption {
     RenameColumn(DynIden, DynIden),
     DropColumn(DynIden),
     AddForeignKey(TableForeignKey),
-    DropForeignKey(String),
+    DropForeignKey(DynIden),
 }
 
 impl Default for TableAlterStatement {
@@ -336,8 +336,8 @@ impl TableAlterStatement {
     ///
     /// let table = Table::alter()
     ///     .table(Character::Table)
-    ///     .drop_foreign_key(&"FK_character_glyph".into())
-    ///     .drop_foreign_key(&"FK_character_font".into())
+    ///     .drop_foreign_key(Alias::new("FK_character_glyph"))
+    ///     .drop_foreign_key(Alias::new("FK_character_font"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -362,8 +362,11 @@ impl TableAlterStatement {
     ///
     /// // Sqlite not support modifying table column
     /// ```
-    pub fn drop_foreign_key(&mut self, name: &String) -> &mut Self {
-        self.add_alter_option(TableAlterOption::DropForeignKey(name.to_owned()))
+    pub fn drop_foreign_key<T>(&mut self, name: T) -> &mut Self
+    where
+        T: IntoIden
+    {
+        self.add_alter_option(TableAlterOption::DropForeignKey(name.into_iden()))
     }
 
     fn add_alter_option(&mut self, alter_option: TableAlterOption) -> &mut Self {


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #184 

## Adds

* Ability to alter foreign keys on [TableAlterStatement](https://docs.rs/sea-query/latest/sea_query/table/struct.TableAlterStatement.html)

## Breaking Changes

* Change method signature `prepare_foreign_key_create_statement_internal` of [ForeignKeyBuilder](https://docs.rs/sea-query/latest/sea_query/backend/trait.ForeignKeyBuilder.html) to include `inside_table_single_alter: bool`

## Changes
* Add method `prepare_foreign_key_drop_statement_internal` in [ForeignKeyBuilder](https://docs.rs/sea-query/latest/sea_query/backend/trait.ForeignKeyBuilder.html)
