### PR TITLE
CTE optional columns

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -804,7 +804,9 @@ pub trait QueryBuilder: QuotedBuilder {
     ) {
         cte.table_name.as_ref().unwrap().prepare(sql, self.quote());
 
-        if !cte.cols.is_empty() {
+        if cte.cols.is_empty() {
+            write!(sql," ").unwrap();
+        } else {
             write!(sql, " (").unwrap();
 
             let mut col_first = true;

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -961,6 +961,34 @@ fn select_56() {
 }
 
 #[test]
+fn select_57() {
+    let select = SelectStatement::new()
+        .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
+        .from(Glyph::Table)
+        .to_owned();
+    let cte = CommonTableExpression::new()
+        .query(select)
+        .table_name(Alias::new("cte"))
+        .to_owned();
+    let with_clause = WithClause::new().cte(cte).to_owned();
+    let select = SelectStatement::new()
+        .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
+        .from(Alias::new("cte"))
+        .to_owned();
+    assert_eq!(
+        select.with(with_clause)
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"WITH "cte" AS"#,
+            r#"(SELECT "id", "image", "aspect""#,
+            r#"FROM "glyph")"#,
+            r#"SELECT "id", "image", "aspect" FROM "cte""#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

The definition of Common Table Expressions (CTE) allow for optional column definition, allowing for using the table
name as the identifier for columns.:

```sql
-- Should be equal
-- Case 1
WITH "cte" ("id") AS (SELECT "tbl"."id" FROM "tbl")
SELECT "cte"."id" FROM "cte";
-- Case 2
WITH "cte" AS (SELECT "tbl"."id" FROM "tbl")
SELECT "cte"."id" FROM "cte";
```


## Fixes

Currently, the query building will squish the cte name against the `AS` keyword like:
```sql
WITH "cte"AS (Select ...
```
so I added a simple fix to add a space:
```sql
WITH "cte" AS (Select ...
```

Additionally I added simple unit test to illustrate.



## Changes

<!-- any other non-breaking changes to the codebase -->
