### PR TITLE
Simple Expression support for Case Statements

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -395,11 +395,7 @@ pub trait QueryBuilder: QuotedBuilder {
         for case in when.iter() {
             write!(sql, " WHEN (").unwrap();
             self.prepare_condition_where(&case.condition, sql, collector);
-            write!(sql, ") ").unwrap();
-            write!(sql, "THEN ").unwrap();
-            // } else {
-            //     write!(sql, " ELSE ").unwrap();
-            // }
+            write!(sql, ") THEN ").unwrap();
 
             self.prepare_simple_expr(&case.result.clone().into(), sql, collector);
         }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -388,10 +388,6 @@ pub trait QueryBuilder: QuotedBuilder {
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     ) {
-        assert!(
-            stmts.conditions.clone().len() >= 2,
-            "Case statements need at least two results"
-        );
         write!(sql, "(CASE").unwrap();
         for case in stmts.conditions.iter() {
             if let Some(when) = case.condition.clone() {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1827,11 +1827,35 @@ impl Expr {
         self.into()
     }
 
-    pub fn case<C>(c: C) -> Self
+    /// Adds new `CASE WHEN` to existing case statement.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .expr_as(
+    ///         Expr::case((
+    ///                 Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![2, 4]),
+    ///                 Expr::val(true)
+    ///              ))
+    ///             .finally(Expr::val(false)),
+    ///          Alias::new("is_even")
+    ///     )
+    ///     .from(Glyph::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT (CASE WHEN ("glyph"."aspect" IN (2, 4)) THEN TRUE ELSE FALSE END) AS "is_even" FROM "glyph""#
+    /// );    
+    /// ```
+    pub fn case<C>(c: C) -> CaseStatement
     where
-        C: Into<CaseStatement>,
+        C: IntoCaseStatement,
     {
-        Self::new_with_left(SimpleExpr::Case(Box::new(c.into())))
+        CaseStatement::new().case(c)
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1836,10 +1836,10 @@ impl Expr {
     ///
     /// let query = Query::select()
     ///     .expr_as(
-    ///         Expr::case((
+    ///         Expr::case(
     ///                 Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![2, 4]),
     ///                 Expr::val(true)
-    ///              ))
+    ///              )
     ///             .finally(Expr::val(false)),
     ///          Alias::new("is_even")
     ///     )
@@ -1851,11 +1851,12 @@ impl Expr {
     ///     r#"SELECT (CASE WHEN ("glyph"."aspect" IN (2, 4)) THEN TRUE ELSE FALSE END) AS "is_even" FROM "glyph""#
     /// );    
     /// ```
-    pub fn case<C>(c: C) -> CaseStatement
+    pub fn case<C, T>(cond: C, then: T) -> CaseStatement
     where
-        C: IntoCaseStatement,
+        C: IntoCondition,
+        T: Into<Expr>,
     {
-        CaseStatement::new().case(c)
+        CaseStatement::new().case(cond, then)
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -4,7 +4,6 @@
 //!
 //! [`SimpleExpr`] is the expression common among select fields, where clauses and many other places.
 
-
 use crate::{func::*, query::*, types::*, value::*};
 
 /// Helper to build a [`SimpleExpr`].
@@ -36,7 +35,7 @@ pub enum SimpleExpr {
     CustomWithValues(String, Vec<Value>),
     Keyword(Keyword),
     AsEnum(DynIden, Box<SimpleExpr>),
-    Case(Vec<(Option<SimpleExpr>, SimpleExpr)>)
+    Case(Box<CaseStatement>),
 }
 
 impl Expr {
@@ -1826,6 +1825,13 @@ impl Expr {
     /// `Into::<SimpleExpr>::into()` when type inference is impossible
     pub fn into_simple_expr(self) -> SimpleExpr {
         self.into()
+    }
+
+    pub fn case<C>(c: C) -> Self
+    where
+        C: Into<CaseStatement>,
+    {
+        Self::new_with_left(SimpleExpr::Case(Box::new(c.into())))
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -4,6 +4,7 @@
 //!
 //! [`SimpleExpr`] is the expression common among select fields, where clauses and many other places.
 
+
 use crate::{func::*, query::*, types::*, value::*};
 
 /// Helper to build a [`SimpleExpr`].
@@ -35,6 +36,7 @@ pub enum SimpleExpr {
     CustomWithValues(String, Vec<Value>),
     Keyword(Keyword),
     AsEnum(DynIden, Box<SimpleExpr>),
+    Case(Vec<(Option<SimpleExpr>, SimpleExpr)>)
 }
 
 impl Expr {

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -1,0 +1,61 @@
+use crate::{ConditionExpression, Expr, SimpleExpr};
+
+#[derive(Debug, Clone)]
+pub(crate) struct CaseStatementCondition {
+    condition: Option<ConditionExpression>,
+    result: Expr,
+}
+
+pub(crate) struct CaseStatement {
+    pub(crate) conditions: Vec<CaseStatementCondition>,
+}
+
+impl CaseStatement {
+    pub fn new() -> Self {
+        Self {
+            conditions: Vec::new(),
+        }
+    }
+
+    pub fn case<C, E>(mut self, when: C, then: E) -> Self
+    where
+        C: Into<ConditionExpression>,
+        E: Into<Expr>,
+    {
+        self.conditions.push(CaseStatementCondition {
+            condition: Some(when.into()),
+            result: then.into(),
+        });
+        self
+    }
+
+    pub fn finally<E>(mut self, r#else: E) -> Self
+    where
+        E: Into<Expr>,
+    {
+        self.conditions.push(CaseStatementCondition {
+            condition: None,
+            result: r#else.into(),
+        });
+        self
+    }
+
+    pub fn then<E>(mut self, result: E) -> Self
+    where
+        E: Into<Expr>,
+    {
+        (*self
+            .conditions
+            .last_mut()
+            .expect("`then` cannot be called before loading conditions on case statements."))
+        .result = result.into();
+        self
+    }
+}
+
+impl From<CaseStatement> for SimpleExpr {
+    fn from(val: CaseStatement) -> Self {
+        let r = val.conditions.into_iter().map(|x| (x.condition.map_or(None, |x| Some(x.into())), x.result)).collect();
+        SimpleExpr::Case()
+    }
+}

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -1,25 +1,84 @@
-use crate::{ConditionExpression, Expr, SimpleExpr};
+use crate::{Condition, Expr, SimpleExpr};
 
 #[derive(Debug, Clone)]
 pub(crate) struct CaseStatementCondition {
-    condition: Option<ConditionExpression>,
-    result: Expr,
+    pub(crate) condition: Option<Condition>,
+    pub(crate) result: Expr,
 }
 
-pub(crate) struct CaseStatement {
+#[derive(Debug, Clone)]
+pub struct CaseStatement {
     pub(crate) conditions: Vec<CaseStatementCondition>,
 }
 
 impl CaseStatement {
+    /// Creates a new case statement expression
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .expr_as(
+    ///         CaseStatement::new()
+    ///             .case(
+    ///                 Cond::any()
+    ///                     .add(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![2, 4])),
+    ///                 Expr::val(true)
+    ///              )
+    ///             .finally(Expr::val(false)),
+    ///          Alias::new("is_even")
+    ///     )
+    ///     .from(Glyph::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT (CASE WHEN ("glyph"."aspect" IN (2, 4)) THEN TRUE ELSE FALSE END) AS "is_even" FROM "glyph""#
+    /// );    
+    /// ```
     pub fn new() -> Self {
         Self {
             conditions: Vec::new(),
         }
     }
 
+    /// Adds new `CASE WHEN` to existing case statement.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .expr_as(
+    ///         CaseStatement::new()
+    ///             .case(
+    ///                 Cond::any()
+    ///                     .add(Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0)),
+    ///                 Expr::val("positive")
+    ///              )
+    ///             .case(
+    ///                 Cond::any()
+    ///                     .add(Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0)),
+    ///                 Expr::val("negative")
+    ///              )    
+    ///             .finally(Expr::val("zero")),
+    ///          Alias::new("polarity")
+    ///     )
+    ///     .from(Glyph::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT (CASE WHEN ("glyph"."aspect" > 0) THEN 'positive' WHEN ("glyph"."aspect" < 0) THEN 'negative' ELSE 'zero' END) AS "polarity" FROM "glyph""#
+    /// );    
+    /// ```
+
     pub fn case<C, E>(mut self, when: C, then: E) -> Self
     where
-        C: Into<ConditionExpression>,
+        C: Into<Condition>,
         E: Into<Expr>,
     {
         self.conditions.push(CaseStatementCondition {
@@ -29,6 +88,7 @@ impl CaseStatement {
         self
     }
 
+    /// Ends the case statement with the final `ELSE` result.
     pub fn finally<E>(mut self, r#else: E) -> Self
     where
         E: Into<Expr>,
@@ -39,23 +99,10 @@ impl CaseStatement {
         });
         self
     }
-
-    pub fn then<E>(mut self, result: E) -> Self
-    where
-        E: Into<Expr>,
-    {
-        (*self
-            .conditions
-            .last_mut()
-            .expect("`then` cannot be called before loading conditions on case statements."))
-        .result = result.into();
-        self
-    }
 }
 
-impl From<CaseStatement> for SimpleExpr {
-    fn from(val: CaseStatement) -> Self {
-        let r = val.conditions.into_iter().map(|x| (x.condition.map_or(None, |x| Some(x.into())), x.result)).collect();
-        SimpleExpr::Case()
+impl Into<SimpleExpr> for CaseStatement {
+    fn into(self) -> SimpleExpr {
+        SimpleExpr::Case(Box::new(self))
     }
 }

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -2,7 +2,12 @@ use crate::{Condition, Expr, SimpleExpr};
 
 #[derive(Debug, Clone)]
 pub(crate) struct CaseStatementCondition {
+    /// The condition in the `WHEN` clause of a case statement.
+    /// If None, query builder will infer this to be the closing
+    /// `ELSE` clause. Note that `ELSE` is optional and will return NULL
+    /// if `ELSE` is not present but the condition is met.
     pub(crate) condition: Option<Condition>,
+    /// The result if the condition is met. This is the `THEN` clause.
     pub(crate) result: Expr,
 }
 

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -1,7 +1,7 @@
 use crate::{Condition, Expr, IntoCondition, SimpleExpr};
 
 #[derive(Debug, Clone)]
-pub struct CaseStatementCondition {
+pub(crate) struct CaseStatementCondition {
     pub(crate) condition: Condition,
     pub(crate) result: Expr,
 }
@@ -23,7 +23,7 @@ impl CaseStatement {
     /// let query = Query::select()
     ///     .expr_as(
     ///         CaseStatement::new()
-    ///             .case((Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![2, 4]), Expr::val(true)))
+    ///             .case(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![2, 4]), Expr::val(true))
     ///             .finally(Expr::val(false)),
     ///          Alias::new("is_even")
     ///     )
@@ -48,14 +48,14 @@ impl CaseStatement {
     ///
     /// let query = Query::select()
     ///     .expr_as(
-    ///             Expr::case((
+    ///             Expr::case(
     ///                 Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
     ///                 Expr::val("positive")
-    ///              ))
-    ///             .case((
+    ///              )
+    ///             .case(
     ///                 Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
     ///                 Expr::val("negative")
-    ///              ))
+    ///              )
     ///             .finally(Expr::val("zero")),
     ///          Alias::new("polarity")
     ///     )
@@ -67,15 +67,56 @@ impl CaseStatement {
     ///     r#"SELECT (CASE WHEN ("glyph"."aspect" > 0) THEN 'positive' WHEN ("glyph"."aspect" < 0) THEN 'negative' ELSE 'zero' END) AS "polarity" FROM "glyph""#
     /// );    
     /// ```
-    pub fn case<C>(mut self, case: C) -> Self
+    pub fn case<C, T>(mut self, cond: C, then: T) -> Self
     where
-        C: IntoCaseStatement,
+        C: IntoCondition,
+        T: Into<Expr>,
     {
-        self.when.push(case.into_case_statement());
+        self.when.push(CaseStatementCondition {
+            condition: cond.into_condition(),
+            result: then.into(),
+        });
         self
     }
 
     /// Ends the case statement with the final `ELSE` result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .expr_as(
+    ///         Expr::case(
+    ///             Cond::any()
+    ///                 .add(Expr::tbl(Character::Table, Character::FontSize).gt(48))
+    ///                 .add(Expr::tbl(Character::Table, Character::SizeW).gt(500)),
+    ///             Expr::val("large")
+    ///         )
+    ///         .case(
+    ///             Cond::any()
+    ///                 .add(Expr::tbl(Character::Table, Character::FontSize).between(24,48).into_condition())
+    ///                 .add(Expr::tbl(Character::Table, Character::SizeW).between(300,500).into_condition()),
+    ///             Expr::val("medium")
+    ///         )
+    ///         .finally(Expr::val("small")),
+    ///         Alias::new("char_size"))
+    ///     .from(Character::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     [
+    ///         r#"SELECT"#,
+    ///         r#"(CASE WHEN ("character"."font_size" > 48 OR "character"."size_w" > 500) THEN 'large'"#,
+    ///         r#"WHEN (("character"."font_size" BETWEEN 24 AND 48) OR ("character"."size_w" BETWEEN 300 AND 500)) THEN 'medium'"#,
+    ///         r#"ELSE 'small' END) AS "char_size""#,
+    ///         r#"FROM "character""#
+    ///     ]
+    ///     .join(" ")
+    /// );    
+    /// ```
     pub fn finally<E>(mut self, r#else: E) -> Self
     where
         E: Into<Expr>,
@@ -85,41 +126,8 @@ impl CaseStatement {
     }
 }
 
-impl<C> From<C> for CaseStatement
-where
-    C: IntoCaseStatement,
-{
-    fn from(c: C) -> CaseStatement {
-        CaseStatement::new().case(c.into_case_statement())
-    }
-}
-
 impl Into<SimpleExpr> for CaseStatement {
     fn into(self) -> SimpleExpr {
         SimpleExpr::Case(Box::new(self))
-    }
-}
-
-pub trait IntoCaseStatement {
-    fn into_case_statement(self) -> CaseStatementCondition;
-}
-
-impl IntoCaseStatement for CaseStatementCondition {
-    fn into_case_statement(self) -> CaseStatementCondition {
-        self
-    }
-}
-
-impl<C: 'static, T: 'static> IntoCaseStatement for (C, T)
-where
-    C: IntoCondition,
-    T: Into<Expr>,
-{
-    fn into_case_statement(self) -> CaseStatementCondition {
-        let (c, t) = self;
-        CaseStatementCondition {
-            condition: c.into_condition(),
-            result: t.into(),
-        }
     }
 }

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -48,8 +48,7 @@ impl CaseStatement {
     ///
     /// let query = Query::select()
     ///     .expr_as(
-    ///         CaseStatement::new()
-    ///             .case((
+    ///             Expr::case((
     ///                 Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
     ///                 Expr::val("positive")
     ///              ))
@@ -68,7 +67,6 @@ impl CaseStatement {
     ///     r#"SELECT (CASE WHEN ("glyph"."aspect" > 0) THEN 'positive' WHEN ("glyph"."aspect" < 0) THEN 'negative' ELSE 'zero' END) AS "polarity" FROM "glyph""#
     /// );    
     /// ```
-
     pub fn case<C>(mut self, case: C) -> Self
     where
         C: IntoCaseStatement,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -7,6 +7,7 @@
 //! - Query Update, see [`UpdateStatement`]
 //! - Query Delete, see [`DeleteStatement`]
 
+mod case;
 mod condition;
 mod delete;
 mod insert;
@@ -18,8 +19,8 @@ mod traits;
 mod update;
 mod window;
 mod with;
-mod case;
 
+pub use case::*;
 pub use condition::*;
 pub use delete::*;
 pub use insert::*;
@@ -30,7 +31,6 @@ pub use traits::*;
 pub use update::*;
 pub use window::*;
 pub use with::*;
-pub use case::*;
 
 /// Shorthand for constructing any table query
 #[derive(Debug, Clone)]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -18,6 +18,7 @@ mod traits;
 mod update;
 mod window;
 mod with;
+mod case;
 
 pub use condition::*;
 pub use delete::*;
@@ -29,6 +30,7 @@ pub use traits::*;
 pub use update::*;
 pub use window::*;
 pub use with::*;
+pub use case::*;
 
 /// Shorthand for constructing any table query
 #[derive(Debug, Clone)]

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -977,14 +977,14 @@ fn select_57() {
     let query = Query::select()
         .expr_as(
             CaseStatement::new()
-                .case((
+                .case(
                     Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
                     Expr::val("positive"),
-                ))
-                .case((
+                )
+                .case(
                     Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
                     Expr::val("negative"),
-                ))
+                )
                 .finally(Expr::val("zero")),
             Alias::new("polarity"),
         )

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -973,6 +973,31 @@ fn select_56() {
 }
 
 #[test]
+fn select_57() {
+    let query = Query::select()
+        .expr_as(
+            CaseStatement::new()
+                .case((
+                    Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
+                    Expr::val("positive"),
+                ))
+                .case((
+                    Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
+                    Expr::val("negative"),
+                ))
+                .finally(Expr::val("zero")),
+            Alias::new("polarity"),
+        )
+        .from(Glyph::Table)
+        .to_owned();
+
+    assert_eq!(
+        query.to_string(MysqlQueryBuilder),
+        r#"SELECT (CASE WHEN (`glyph`.`aspect` > 0) THEN 'positive' WHEN (`glyph`.`aspect` < 0) THEN 'negative' ELSE 'zero' END) AS `polarity` FROM `glyph`"#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -992,14 +992,14 @@ fn select_58() {
     let query = Query::select()
         .expr_as(
             CaseStatement::new()
-                .case((
+                .case(
                     Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
                     Expr::val("positive"),
-                ))
-                .case((
+                )
+                .case(
                     Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
                     Expr::val("negative"),
-                ))
+                )
                 .finally(Expr::val("zero")),
             Alias::new("polarity"),
         )

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -988,6 +988,31 @@ fn select_57() {
 }
 
 #[test]
+fn select_58() {
+    let query = Query::select()
+        .expr_as(
+            CaseStatement::new()
+                .case((
+                    Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
+                    Expr::val("positive"),
+                ))
+                .case((
+                    Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
+                    Expr::val("negative"),
+                ))
+                .finally(Expr::val("zero")),
+            Alias::new("polarity"),
+        )
+        .from(Glyph::Table)
+        .to_owned();
+
+    assert_eq!(
+        query.to_string(PostgresQueryBuilder),
+        r#"SELECT (CASE WHEN ("glyph"."aspect" > 0) THEN 'positive' WHEN ("glyph"."aspect" < 0) THEN 'negative' ELSE 'zero' END) AS "polarity" FROM "glyph""#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -961,6 +961,31 @@ fn select_56() {
 }
 
 #[test]
+fn select_57() {
+    let query = Query::select()
+        .expr_as(
+            CaseStatement::new()
+                .case((
+                    Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
+                    Expr::val("positive"),
+                ))
+                .case((
+                    Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
+                    Expr::val("negative"),
+                ))
+                .finally(Expr::val("zero")),
+            Alias::new("polarity"),
+        )
+        .from(Glyph::Table)
+        .to_owned();
+
+    assert_eq!(
+        query.to_string(SqliteQueryBuilder),
+        r#"SELECT (CASE WHEN ("glyph"."aspect" > 0) THEN 'positive' WHEN ("glyph"."aspect" < 0) THEN 'negative' ELSE 'zero' END) AS "polarity" FROM "glyph""#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -965,14 +965,14 @@ fn select_57() {
     let query = Query::select()
         .expr_as(
             CaseStatement::new()
-                .case((
+                .case(
                     Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
                     Expr::val("positive"),
-                ))
-                .case((
+                )
+                .case(
                     Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
                     Expr::val("negative"),
-                ))
+                )
                 .finally(Expr::val("zero")),
             Alias::new("polarity"),
         )


### PR DESCRIPTION
## PR Info

Adding support for the use of SQL case statements. This is a first attempt. Because CASE statements are more of an expression that can be used as columns, group bys, order bys, joins etc, I built a new option into `SimpleExpr` to keep them very portable. Pending approval for moving along with this PR, I will add further unit tests, but I have put two doc string tests to illustrate the usage.


## Adds

A new struct called `CaseStatement` and a new option, `SimpleExpr::Case`, and a new method `Expr::case`. Since case statements essentially are a series of `IF/ELSE` statements, the basic logic is to build a vector of a `Option<Condition>` and a resulting `Expr`.  We would use `None` for the condition if it is the `ELSE` clause. It is not required as any conditions met that aren't explicit in the `WHEN ... THEN..` are null.
