### PR TITLE
issues-303 Fix bind_box! for sqlx

### DIFF
--- a/sea-query-driver/src/sqlx_mysql.rs
+++ b/sea-query-driver/src/sqlx_mysql.rs
@@ -69,12 +69,13 @@ pub fn bind_params_sqlx_mysql_impl(input: TokenStream) -> TokenStream {
                     };
                 }
                 macro_rules! bind_box {
-                    ( $v: expr ) => {
-                        match $v {
-                            Some(v) => query.bind(v.as_ref()),
-                            None => query.bind(None::<bool>),
-                        }
-                    };
+                    ( $v: expr ) => {{
+                        let v = match $v {
+                            Some(v) => Some(v.as_ref()),
+                            None => None,
+                        };
+                        query.bind(v)
+                    }};
                 }
                 query = match value {
                     Value::Bool(v) => bind!(v, bool),

--- a/sea-query-driver/src/sqlx_postgres.rs
+++ b/sea-query-driver/src/sqlx_postgres.rs
@@ -75,12 +75,13 @@ pub fn bind_params_sqlx_postgres_impl(input: TokenStream) -> TokenStream {
                     };
                 }
                 macro_rules! bind_box {
-                    ( $v: expr ) => {
-                        match $v {
-                            Some(v) => query.bind(v.as_ref()),
-                            None => query.bind(None::<bool>),
-                        }
-                    };
+                    ( $v: expr ) => {{
+                        let v = match $v {
+                            Some(v) => Some(v.as_ref()),
+                            None => None,
+                        };
+                        query.bind(v)
+                    }};
                 }
                 query = match value {
                     Value::Bool(v) => bind!(v, bool),

--- a/sea-query-driver/src/sqlx_sqlite.rs
+++ b/sea-query-driver/src/sqlx_sqlite.rs
@@ -69,12 +69,13 @@ pub fn bind_params_sqlx_sqlite(input: TokenStream) -> TokenStream {
                     };
                 }
                 macro_rules! bind_box {
-                    ( $v: expr ) => {
-                        match $v {
-                            Some(v) => query.bind(v.as_ref()),
-                            None => query.bind(None::<bool>),
-                        }
-                    };
+                    ( $v: expr ) => {{
+                        let v = match $v {
+                            Some(v) => Some(v.as_ref()),
+                            None => None,
+                        };
+                        query.bind(v)
+                    }};
                 }
                 query = match value {
                     Value::Bool(v) => bind!(v, bool),


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/303>

## Fixes

Fix bind `Option<T>` as `Option::<bool>::None`
