### PR TITLE
issues-294 Move escape and unescape string to backend

### DIFF
--- a/src/backend/mysql/mod.rs
+++ b/src/backend/mysql/mod.rs
@@ -26,3 +26,5 @@ impl QuotedBuilder for MysqlQueryBuilder {
         '`'
     }
 }
+
+impl EscapeBuilder for MysqlQueryBuilder {}

--- a/src/backend/postgres/mod.rs
+++ b/src/backend/postgres/mod.rs
@@ -25,3 +25,5 @@ impl QuotedBuilder for PostgresQueryBuilder {
         '"'
     }
 }
+
+impl EscapeBuilder for PostgresQueryBuilder {}

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -11,7 +11,7 @@ impl QueryBuilder for PostgresQueryBuilder {
     }
 
     fn write_string_quoted(&self, string: &str, buffer: &mut String) {
-        let escaped = escape_string(string);
+        let escaped = self.escape_string(string);
         let string = if escaped.find('\\').is_some() {
             "E'".to_owned() + &escaped + "'"
         } else {

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use std::ops::Deref;
 
-pub trait QueryBuilder: QuotedBuilder {
+pub trait QueryBuilder: QuotedBuilder + EscapeBuilder {
     /// The type of placeholder the builder uses for values, and whether it is numbered.
     fn placeholder(&self) -> (&str, bool) {
         ("?", false)
@@ -1435,7 +1435,7 @@ pub trait QueryBuilder: QuotedBuilder {
     #[doc(hidden)]
     /// Write a string surrounded by escaped quotes.
     fn write_string_quoted(&self, string: &str, buffer: &mut String) {
-        write!(buffer, "\'{}\'", escape_string(string)).unwrap()
+        write!(buffer, "\'{}\'", self.escape_string(string)).unwrap()
     }
 
     #[doc(hidden)]
@@ -1487,3 +1487,5 @@ impl QuotedBuilder for CommonSqlQueryBuilder {
         '"'
     }
 }
+
+impl EscapeBuilder for CommonSqlQueryBuilder {}

--- a/src/backend/sqlite/mod.rs
+++ b/src/backend/sqlite/mod.rs
@@ -24,3 +24,5 @@ impl QuotedBuilder for SqliteQueryBuilder {
         '"'
     }
 }
+
+impl EscapeBuilder for SqliteQueryBuilder {}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1102,15 +1102,15 @@ impl Expr {
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`character` LIKE 'Ours\'%'"#
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`character` LIKE 'Ours''%'"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE E'Ours\'%'"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE 'Ours''%'"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE 'Ours\'%'"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE 'Ours''%'"#
     /// );
     /// ```
     pub fn like(self, v: &str) -> SimpleExpr {

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -158,7 +158,7 @@ mod tests {
     fn inject_parameters_6() {
         assert_eq!(
             inject_parameters("WHERE A = $1", vec!["B'C".into()], &PostgresQueryBuilder),
-            "WHERE A = E'B\\'C'"
+            "WHERE A = 'B''C'"
         );
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,5 +1,4 @@
 //! Container for all SQL value types.
-use std::fmt::Write;
 
 #[cfg(feature = "with-json")]
 use serde_json::Value as Json;
@@ -1040,50 +1039,6 @@ where
     }
 }
 
-/// Escape a SQL string literal
-pub fn escape_string(string: &str) -> String {
-    string
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\'', "\\'")
-        .replace('\0', "\\0")
-        .replace('\x08', "\\b")
-        .replace('\x09', "\\t")
-        .replace('\x1a', "\\z")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-}
-
-/// Unescape a SQL string literal
-pub fn unescape_string(input: &str) -> String {
-    let mut escape = false;
-    let mut output = String::new();
-    for c in input.chars() {
-        if !escape && c == '\\' {
-            escape = true;
-        } else if escape {
-            write!(
-                output,
-                "{}",
-                match c {
-                    '0' => '\0',
-                    'b' => '\x08',
-                    't' => '\x09',
-                    'z' => '\x1a',
-                    'n' => '\n',
-                    'r' => '\r',
-                    c => c,
-                }
-            )
-            .unwrap();
-            escape = false;
-        } else {
-            write!(output, "{}", c).unwrap();
-        }
-    }
-    output
-}
-
 /// Convert value to json value
 #[allow(clippy::many_single_char_names)]
 #[cfg(feature = "with-json")]
@@ -1176,34 +1131,6 @@ impl Values {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_escape_1() {
-        let test = r#" "abc" "#;
-        assert_eq!(escape_string(test), r#" \"abc\" "#.to_owned());
-        assert_eq!(unescape_string(escape_string(test).as_str()), test);
-    }
-
-    #[test]
-    fn test_escape_2() {
-        let test = "a\nb\tc";
-        assert_eq!(escape_string(test), "a\\nb\\tc".to_owned());
-        assert_eq!(unescape_string(escape_string(test).as_str()), test);
-    }
-
-    #[test]
-    fn test_escape_3() {
-        let test = "a\\b";
-        assert_eq!(escape_string(test), "a\\\\b".to_owned());
-        assert_eq!(unescape_string(escape_string(test).as_str()), test);
-    }
-
-    #[test]
-    fn test_escape_4() {
-        let test = "a\"b";
-        assert_eq!(escape_string(test), "a\\\"b".to_owned());
-        assert_eq!(unescape_string(escape_string(test).as_str()), test);
-    }
 
     #[test]
     fn test_value() {

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1264,3 +1264,49 @@ fn delete_1() {
         "DELETE FROM `glyph` WHERE `id` = 1 ORDER BY `id` ASC LIMIT 1"
     );
 }
+
+#[test]
+fn escape_1() {
+    let test = r#" "abc" "#;
+    assert_eq!(
+        MysqlQueryBuilder.escape_string(test),
+        r#" \"abc\" "#.to_owned()
+    );
+    assert_eq!(
+        MysqlQueryBuilder.unescape_string(MysqlQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}
+
+#[test]
+fn escape_2() {
+    let test = "a\nb\tc";
+    assert_eq!(
+        MysqlQueryBuilder.escape_string(test),
+        "a\\nb\\tc".to_owned()
+    );
+    assert_eq!(
+        MysqlQueryBuilder.unescape_string(MysqlQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}
+
+#[test]
+fn escape_3() {
+    let test = "a\\b";
+    assert_eq!(MysqlQueryBuilder.escape_string(test), "a\\\\b".to_owned());
+    assert_eq!(
+        MysqlQueryBuilder.unescape_string(MysqlQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}
+
+#[test]
+fn escape_4() {
+    let test = "a\"b";
+    assert_eq!(MysqlQueryBuilder.escape_string(test), "a\\\"b".to_owned());
+    assert_eq!(
+        MysqlQueryBuilder.unescape_string(MysqlQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1276,3 +1276,52 @@ fn delete_1() {
         r#"DELETE FROM "glyph" WHERE "id" = 1"#
     );
 }
+
+#[test]
+fn escape_1() {
+    let test = r#" "abc" "#;
+    assert_eq!(
+        PostgresQueryBuilder.escape_string(test),
+        r#" \"abc\" "#.to_owned()
+    );
+    assert_eq!(
+        PostgresQueryBuilder.unescape_string(PostgresQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}
+
+#[test]
+fn escape_2() {
+    let test = "a\nb\tc";
+    assert_eq!(
+        PostgresQueryBuilder.escape_string(test),
+        "a\\nb\\tc".to_owned()
+    );
+    assert_eq!(
+        PostgresQueryBuilder.unescape_string(PostgresQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}
+
+#[test]
+fn escape_3() {
+    let test = "a\\b";
+    assert_eq!(
+        PostgresQueryBuilder.escape_string(test),
+        "a\\\\b".to_owned()
+    );
+    assert_eq!(
+        PostgresQueryBuilder.unescape_string(PostgresQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}
+
+#[test]
+fn escape_4() {
+    let test = "a\"b";
+    assert_eq!(SqliteQueryBuilder.escape_string(test), "a\\\"b".to_owned());
+    assert_eq!(
+        PostgresQueryBuilder.unescape_string(PostgresQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1215,3 +1215,49 @@ fn delete_1() {
         r#"DELETE FROM "glyph" WHERE "id" = 1"#
     );
 }
+
+#[test]
+fn escape_1() {
+    let test = r#" "abc" "#;
+    assert_eq!(
+        SqliteQueryBuilder.escape_string(test),
+        r#" \"abc\" "#.to_owned()
+    );
+    assert_eq!(
+        SqliteQueryBuilder.unescape_string(SqliteQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}
+
+#[test]
+fn escape_2() {
+    let test = "a\nb\tc";
+    assert_eq!(
+        SqliteQueryBuilder.escape_string(test),
+        "a\\nb\\tc".to_owned()
+    );
+    assert_eq!(
+        SqliteQueryBuilder.unescape_string(SqliteQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}
+
+#[test]
+fn escape_3() {
+    let test = "a\\b";
+    assert_eq!(SqliteQueryBuilder.escape_string(test), "a\\\\b".to_owned());
+    assert_eq!(
+        SqliteQueryBuilder.unescape_string(SqliteQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}
+
+#[test]
+fn escape_4() {
+    let test = "a\"b";
+    assert_eq!(SqliteQueryBuilder.escape_string(test), "a\\\"b".to_owned());
+    assert_eq!(
+        SqliteQueryBuilder.unescape_string(SqliteQueryBuilder.escape_string(test).as_str()),
+        test
+    );
+}


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/294>

## Adds

Add new trait: `EscapeBuilder`

## Breaking Changes

Remove `escape_string` and `unescape_string` functions.
