### PR TITLE
Add length check on condition array

### DIFF
--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -233,6 +233,28 @@ impl Condition {
         self.negate = !self.negate;
         self
     }
+
+    /// Whether or not any condition has been added
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// Cond::all().is_empty();
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.conditions.is_empty()
+    }
+
+    /// How many conditions were added
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// Cond::all().len();
+    /// ```
+    pub fn len(&self) -> usize {
+        self.conditions.len()
+    }
 }
 
 impl std::convert::From<Condition> for ConditionExpression {

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -239,7 +239,11 @@ impl Condition {
     /// # Examples
     ///
     /// ```
-    /// Cond::all().is_empty();
+    /// use sea_query::{*, tests_cfg::*};
+    /// 
+    /// let is_empty = Cond::all().is_empty();
+    /// 
+    /// assert!(is_empty);
     /// ```
     pub fn is_empty(&self) -> bool {
         self.conditions.is_empty()
@@ -250,7 +254,14 @@ impl Condition {
     /// # Examples
     ///
     /// ```
-    /// Cond::all().len();
+    /// use sea_query::{*, tests_cfg::*};
+    /// 
+    /// let len = Cond::all().len();
+    /// 
+    /// assert_eq!(
+    ///     len,
+    ///     0
+    /// );
     /// ```
     pub fn len(&self) -> usize {
         self.conditions.len()


### PR DESCRIPTION
## PR Info

I had a function in my codebase that takes a list and constructs a `Condition` object from it. I had a bug in my code though where after the filtering, the Condition objects end up not having any condition added to it which causes issues.

To solve this, I want to be able to check if a `Condition` object actually has any condition associated with it before I execute a query

## Adds

- Ability to check if a `Condition` is empty (and how many conditions it has)