### PR TITLE
fix index create statement

### DIFF
--- a/src/backend/mysql/index.rs
+++ b/src/backend/mysql/index.rs
@@ -24,9 +24,9 @@ impl IndexBuilder for MysqlQueryBuilder {
             table.prepare(sql, self.quote());
         }
 
-        self.prepare_index_type(&create.index_type, sql);
-
         self.prepare_index_columns(&create.index.columns, sql);
+
+        self.prepare_index_type(&create.index_type, sql);
     }
 
     fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut SqlWriter) {


### PR DESCRIPTION

## PR Info

fix too old create index statement

https://github.com/SeaQL/sea-orm/issues/682

## Fixes

move index columns before index type

index statement: [https://dev.mysql.com/doc/refman/5.6/en/create-index.html](https://dev.mysql.com/doc/refman/5.6/en/create-index.html)
