### PR TITLE
issues-187 Add support for Ip(4,6)Network and MacAddress

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ uuid = { version = "^0", optional = true }
 proc-macro2 = { version = "1", optional = true }
 quote = { version = "^1", optional = true }
 time = { version = "^0.2", optional = true }
+ipnetwork = { version = "^0.17", optional = true }
+mac_address = { version = "^1.1", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
@@ -80,6 +82,8 @@ with-rust_decimal = ["rust_decimal", "sea-query-driver/with-rust_decimal"]
 with-bigdecimal = ["bigdecimal", "sea-query-driver/with-bigdecimal"]
 with-uuid = ["uuid", "sea-query-driver/with-uuid"]
 with-time = ["time", "sea-query-driver/with-time"]
+with-ipnetwork = ["ipnetwork", "sea-query-driver/with-ipnetwork"]
+with-mac_address = ["mac_address", "sea-query-driver/with-mac_address"]
 
 [[test]]
 name = "test-derive"

--- a/sea-query-driver/Cargo.toml
+++ b/sea-query-driver/Cargo.toml
@@ -29,6 +29,8 @@ with-rust_decimal = []
 with-bigdecimal = []
 with-uuid = []
 with-time = []
+with-ipnetwork = []
+with-mac_address = []
 postgres-array = []
 
 [dev-dependencies]

--- a/sea-query-driver/src/sqlx_postgres.rs
+++ b/sea-query-driver/src/sqlx_postgres.rs
@@ -62,6 +62,23 @@ pub fn bind_params_sqlx_postgres_impl(input: TokenStream) -> TokenStream {
         quote! {}
     };
 
+    let with_ipnetwork = if cfg!(feature = "with-ipnetwork") {
+        quote! {
+            Value::Ipv4Network(v) => bind_box!(v),
+            Value::Ipv6Network(v) => bind_box!(v),
+        }
+    } else {
+        quote! {}
+    };
+
+    let with_mac_address = if cfg!(feature = "with-mac_address") {
+        quote! {
+            Value::MacAddress(v) => bind_box!(v),
+        }
+    } else {
+        quote! {}
+    };
+
     let output = quote! {
         {
             let mut query = #query;
@@ -104,6 +121,8 @@ pub fn bind_params_sqlx_postgres_impl(input: TokenStream) -> TokenStream {
                     #with_rust_decimal
                     #with_big_decimal
                     #with_postgres_array
+                    #with_ipnetwork
+                    #with_mac_address
                     #[allow(unreachable_patterns)]
                     _ => unimplemented!(),
                 };

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1076,6 +1076,12 @@ pub trait QueryBuilder: QuotedBuilder {
             Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-ipnetwork")]
+            Value::Ipv4Network(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-ipnetwork")]
+            Value::Ipv6Network(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-mac_address")]
+            Value::MacAddress(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "postgres-array")]
             Value::Array(None) => write!(s, "NULL").unwrap(),
             Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
@@ -1146,6 +1152,12 @@ pub trait QueryBuilder: QuotedBuilder {
                     .join(",")
             )
             .unwrap(),
+            #[cfg(feature = "with-ipnetwork")]
+            Value::Ipv4Network(Some(v)) => write!(s, "{}", v).unwrap(),
+            #[cfg(feature = "with-ipnetwork")]
+            Value::Ipv6Network(Some(v)) => write!(s, "{}", v).unwrap(),
+            #[cfg(feature = "with-mac_address")]
+            Value::MacAddress(Some(v)) => write!(s, "{}", v).unwrap(),
         };
         s
     }


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/187> (but partial)

## Adds

Add support for PostgreSQL ipaddr/macaddress to sqlx driver (next PR add support for **postgresql-types**).

- Dependencies:
  - <https://github.com/SeaQL/sea-query/pull/310>
