### PR TITLE
Getter methods under "getters" feature for Statements.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,12 @@ uuid = { version = "^0", optional = true }
 proc-macro2 = { version = "1", optional = true }
 quote = { version = "^1", optional = true }
 time = { version = "^0.2", optional = true }
+getset = { version = "^0.1.2", optional = true}
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
 pretty_assertions = { version = "^1" }
+
 
 [features]
 backend-mysql = []
@@ -82,6 +84,7 @@ with-rust_decimal = ["rust_decimal", "sea-query-driver/with-rust_decimal"]
 with-bigdecimal = ["bigdecimal", "sea-query-driver/with-bigdecimal"]
 with-uuid = ["uuid", "sea-query-driver/with-uuid"]
 with-time = ["time", "sea-query-driver/with-time"]
+getters = ["getset"]
 
 [[test]]
 name = "test-derive"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -7,6 +7,7 @@
 use crate::{func::*, query::*, types::*, value::*};
 
 /// Helper to build a [`SimpleExpr`].
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct Expr {
     pub(crate) left: Option<SimpleExpr>,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -7,7 +7,11 @@
 use crate::{func::*, query::*, types::*, value::*};
 
 /// Helper to build a [`SimpleExpr`].
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct Expr {
     pub(crate) left: Option<SimpleExpr>,

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -4,7 +4,11 @@ use crate::{backend::QueryBuilder, prepare::*, types::*, value::*};
 #[derive(Debug)]
 pub struct Type;
 
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct TypeCreateStatement {
     pub(crate) name: Option<DynIden>,
@@ -21,7 +25,11 @@ pub enum TypeAs {
      * Array, */
 }
 
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct TypeDropStatement {
     pub(crate) names: Vec<DynIden>,
@@ -29,7 +37,11 @@ pub struct TypeDropStatement {
     pub(crate) if_exists: bool,
 }
 
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct TypeAlterStatement {
     pub(crate) name: Option<DynIden>,

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -4,6 +4,7 @@ use crate::{backend::QueryBuilder, prepare::*, types::*, value::*};
 #[derive(Debug)]
 pub struct Type;
 
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct TypeCreateStatement {
     pub(crate) name: Option<DynIden>,
@@ -20,6 +21,7 @@ pub enum TypeAs {
      * Array, */
 }
 
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct TypeDropStatement {
     pub(crate) names: Vec<DynIden>,
@@ -27,6 +29,7 @@ pub struct TypeDropStatement {
     pub(crate) if_exists: bool,
 }
 
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct TypeAlterStatement {
     pub(crate) name: Option<DynIden>,

--- a/src/foreign_key/common.rs
+++ b/src/foreign_key/common.rs
@@ -132,9 +132,13 @@ impl TableForeignKey {
     }
 }
 
-#[cfg(feature="getters")]
+#[cfg(feature = "getters")]
 impl TableForeignKey {
-    pub fn get_name(&self) -> &Option<String> { &self.name }
+    pub fn get_name(&self) -> &Option<String> {
+        &self.name
+    }
 
-    pub fn get_table(&self) -> &Option<DynIden> { &self.table }
+    pub fn get_table(&self) -> &Option<DynIden> {
+        &self.table
+    }
 }

--- a/src/foreign_key/common.rs
+++ b/src/foreign_key/common.rs
@@ -131,3 +131,10 @@ impl TableForeignKey {
         }
     }
 }
+
+#[cfg(feature="getters")]
+impl TableForeignKey {
+    pub fn get_name(&self) -> &Option<String> { &self.name }
+
+    pub fn get_table(&self) -> &Option<DynIden> { &self.table }
+}

--- a/src/foreign_key/drop.rs
+++ b/src/foreign_key/drop.rs
@@ -24,7 +24,11 @@ use crate::{
 /// );
 /// // Sqlite does not support modification of foreign key constraints to existing tables
 /// ```
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct ForeignKeyDropStatement {
     pub(crate) foreign_key: TableForeignKey,

--- a/src/foreign_key/drop.rs
+++ b/src/foreign_key/drop.rs
@@ -24,6 +24,7 @@ use crate::{
 /// );
 /// // Sqlite does not support modification of foreign key constraints to existing tables
 /// ```
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct ForeignKeyDropStatement {
     pub(crate) foreign_key: TableForeignKey,

--- a/src/index/common.rs
+++ b/src/index/common.rs
@@ -1,13 +1,22 @@
 use crate::types::*;
 
 /// Specification of a table index
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct TableIndex {
     pub(crate) name: Option<String>,
     pub(crate) columns: Vec<IndexColumn>,
 }
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct IndexColumn {
     pub(crate) name: DynIden,

--- a/src/index/common.rs
+++ b/src/index/common.rs
@@ -1,12 +1,13 @@
 use crate::types::*;
 
 /// Specification of a table index
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct TableIndex {
     pub(crate) name: Option<String>,
     pub(crate) columns: Vec<IndexColumn>,
 }
-
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct IndexColumn {
     pub(crate) name: DynIden,

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -96,7 +96,11 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect" ASC)"#
 /// );
 /// ```
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct IndexCreateStatement {
     pub(crate) table: Option<DynIden>,

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -96,6 +96,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect" ASC)"#
 /// );
 /// ```
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct IndexCreateStatement {
     pub(crate) table: Option<DynIden>,

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -25,7 +25,11 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"DROP INDEX "idx-glyph-aspect" ON "glyph""#
 /// );
 /// ```
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct IndexDropStatement {
     pub(crate) table: Option<DynIden>,

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -25,6 +25,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     r#"DROP INDEX "idx-glyph-aspect" ON "glyph""#
 /// );
 /// ```
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct IndexDropStatement {
     pub(crate) table: Option<DynIden>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,11 +208,11 @@
 //! ```rust
 //! #[cfg(feature = "attr")]
 //! # fn test() {
-//! use sea_query::{Iden, enum_def};
+//! use sea_query::{enum_def, Iden};
 //!
 //! #[enum_def]
 //! struct Character {
-//!   pub foo: u64,
+//!     pub foo: u64,
 //! }
 //!
 //! // It generates the following along with Iden impl

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -1,16 +1,19 @@
 use crate::{Condition, Expr, IntoCondition, SimpleExpr};
 
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
-pub(crate) struct CaseStatementCondition {
+pub struct CaseStatementCondition {
     pub(crate) condition: Condition,
     pub(crate) result: Expr,
 }
 
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct CaseStatement {
     pub(crate) when: Vec<CaseStatementCondition>,
     pub(crate) r#else: Option<Expr>,
 }
+
 
 impl CaseStatement {
     /// Creates a new case statement expression

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -1,19 +1,26 @@
 use crate::{Condition, Expr, IntoCondition, SimpleExpr};
 
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct CaseStatementCondition {
     pub(crate) condition: Condition,
     pub(crate) result: Expr,
 }
 
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct CaseStatement {
     pub(crate) when: Vec<CaseStatementCondition>,
     pub(crate) r#else: Option<Expr>,
 }
-
 
 impl CaseStatement {
     /// Creates a new case statement expression

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -7,6 +7,7 @@ pub enum ConditionType {
 }
 
 /// Represents the value of an [`Condition::any`] or [`Condition::all`]: a set of disjunctive or conjunctive conditions.
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct Condition {
     pub(crate) negate: bool,

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -7,7 +7,11 @@ pub enum ConditionType {
 }
 
 /// Represents the value of an [`Condition::any`] or [`Condition::all`]: a set of disjunctive or conjunctive conditions.
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct Condition {
     pub(crate) negate: bool,
@@ -240,7 +244,7 @@ impl Condition {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*};
+    /// use sea_query::{tests_cfg::*, *};
     ///
     /// let is_empty = Cond::all().is_empty();
     ///
@@ -255,14 +259,11 @@ impl Condition {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*};
+    /// use sea_query::{tests_cfg::*, *};
     ///
     /// let len = Cond::all().len();
     ///
-    /// assert_eq!(
-    ///     len,
-    ///     0
-    /// );
+    /// assert_eq!(len, 0);
     /// ```
     pub fn len(&self) -> usize {
         self.conditions.len()

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -34,7 +34,11 @@ use crate::{
 ///     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 /// );
 /// ```
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct DeleteStatement {
     pub(crate) table: Option<Box<TableRef>>,

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -34,6 +34,7 @@ use crate::{
 ///     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 /// );
 /// ```
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct DeleteStatement {
     pub(crate) table: Option<Box<TableRef>>,

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -41,7 +41,11 @@ pub enum InsertValueSource {
 ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (5.15, '12A'), (4.21, '123')"#
 /// );
 /// ```
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Default, Clone)]
 pub struct InsertStatement {
     pub(crate) replace: bool,

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -9,7 +9,7 @@ use crate::{
 /// [`InsertValueSource`] is a node in the expression tree and can represent a raw value set
 /// ('VALUES') or a select query.
 #[derive(Debug, Clone)]
-pub(crate) enum InsertValueSource {
+pub enum InsertValueSource {
     Values(Vec<Vec<SimpleExpr>>),
     Select(Box<SelectStatement>),
 }
@@ -41,6 +41,7 @@ pub(crate) enum InsertValueSource {
 ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (5.15, '12A'), (4.21, '123')"#
 /// );
 /// ```
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Default, Clone)]
 pub struct InsertStatement {
     pub(crate) replace: bool,

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -1,5 +1,6 @@
 use crate::{DynIden, Expr, IntoIden, SimpleExpr, Value};
 
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct OnConflict {
     pub(crate) target: Option<OnConflictTarget>,

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -1,6 +1,10 @@
 use crate::{DynIden, Expr, IntoIden, SimpleExpr, Value};
 
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct OnConflict {
     pub(crate) target: Option<OnConflictTarget>,

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -38,7 +38,11 @@ use crate::{
 ///     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" WHERE "size_w" IN (3, 4) AND "character" LIKE 'A%'"#
 /// );
 /// ```
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct SelectStatement {
     pub(crate) distinct: Option<SelectDistinct>,
@@ -109,7 +113,11 @@ pub enum LockBehavior {
     SkipLocked,
 }
 
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct LockClause {
     pub(crate) r#type: LockType,
@@ -328,7 +336,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .distinct_on(vec![Char::Character, ])
+    ///     .distinct_on(vec![Char::Character])
     ///     .column(Char::Character)
     ///     .column(Char::SizeW)
     ///     .column(Char::SizeH)
@@ -357,7 +365,6 @@ impl SelectStatement {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character""#
     /// )
     /// ```
-    ///
     pub fn distinct_on<T, I>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -38,6 +38,7 @@ use crate::{
 ///     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" WHERE "size_w" IN (3, 4) AND "character" LIKE 'A%'"#
 /// );
 /// ```
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct SelectStatement {
     pub(crate) distinct: Option<SelectDistinct>,
@@ -108,6 +109,7 @@ pub enum LockBehavior {
     SkipLocked,
 }
 
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct LockClause {
     pub(crate) r#type: LockType,

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -38,6 +38,7 @@ use crate::{
 ///     r#"UPDATE "glyph" SET "aspect" = 1.23, "image" = '123' WHERE "id" = 1"#
 /// );
 /// ```
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct UpdateStatement {
     pub(crate) table: Option<Box<TableRef>>,

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -38,7 +38,11 @@ use crate::{
 ///     r#"UPDATE "glyph" SET "aspect" = 1.23, "image" = '123' WHERE "id" = 1"#
 /// );
 /// ```
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct UpdateStatement {
     pub(crate) table: Option<Box<TableRef>>,

--- a/src/query/window.rs
+++ b/src/query/window.rs
@@ -54,6 +54,7 @@ pub enum FrameType {
 }
 
 /// Frame clause
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct FrameClause {
     pub(crate) r#type: FrameType,
@@ -68,6 +69,7 @@ pub struct FrameClause {
 /// 1. <https://dev.mysql.com/doc/refman/8.0/en/window-function-descriptions.html>
 /// 2. <https://www.sqlite.org/windowfunctions.html>
 /// 3. <https://www.postgresql.org/docs/current/tutorial-window.html>
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct WindowStatement {
     pub(crate) partition_by: Vec<SimpleExpr>,

--- a/src/query/window.rs
+++ b/src/query/window.rs
@@ -54,7 +54,11 @@ pub enum FrameType {
 }
 
 /// Frame clause
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct FrameClause {
     pub(crate) r#type: FrameType,
@@ -69,7 +73,11 @@ pub struct FrameClause {
 /// 1. <https://dev.mysql.com/doc/refman/8.0/en/window-function-descriptions.html>
 /// 2. <https://www.sqlite.org/windowfunctions.html>
 /// 3. <https://www.postgresql.org/docs/current/tutorial-window.html>
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct WindowStatement {
     pub(crate) partition_by: Vec<SimpleExpr>,

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -54,6 +54,7 @@ use std::ops::Deref;
 ///     DELETE FROM table WHERE table.a = cte_name.a)
 ///
 /// It is mandatory to set the [Self::table_name] and the [Self::query].
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct CommonTableExpression {
     pub(crate) table_name: Option<DynIden>,
@@ -216,6 +217,7 @@ pub enum SearchOrder {
 ///
 /// Setting [Self::order] and [Self::expr] is mandatory. The [SelectExpr] used must specify an alias
 /// which will be the name that you can use to order the result of the [CommonTableExpression].
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct Search {
     pub(crate) order: Option<SearchOrder>,
@@ -274,6 +276,7 @@ impl Search {
 /// A query can have both SEARCH and CYCLE clauses.
 ///
 /// Setting [Self::set], [Self::expr] and [Self::using] is mandatory.
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct Cycle {
     pub(crate) expr: Option<SimpleExpr>,
@@ -438,6 +441,7 @@ impl Cycle {
 ///     r#"WITH RECURSIVE "cte_traversal" ("id", "depth", "next", "value") AS (SELECT "id", 1, "next", "value" FROM "table" UNION ALL SELECT "id", "depth" + 1, "next", "value" FROM "table" INNER JOIN "cte_traversal" ON "cte_traversal"."next" = "table"."id") SELECT * FROM "cte_traversal""#
 /// );
 /// ```
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct WithClause {
     pub(crate) recursive: bool,
@@ -538,6 +542,7 @@ impl WithClause {
 ///     DELETE FROM table WHERE table.a = cte_name.a)
 ///
 /// It is mandatory to set the [Self::cte] and the [Self::query].
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone, Default)]
 pub struct WithQuery {
     pub(crate) with_clause: WithClause,

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -54,7 +54,11 @@ use std::ops::Deref;
 ///     DELETE FROM table WHERE table.a = cte_name.a)
 ///
 /// It is mandatory to set the [Self::table_name] and the [Self::query].
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct CommonTableExpression {
     pub(crate) table_name: Option<DynIden>,
@@ -217,7 +221,11 @@ pub enum SearchOrder {
 ///
 /// Setting [Self::order] and [Self::expr] is mandatory. The [SelectExpr] used must specify an alias
 /// which will be the name that you can use to order the result of the [CommonTableExpression].
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct Search {
     pub(crate) order: Option<SearchOrder>,
@@ -276,7 +284,11 @@ impl Search {
 /// A query can have both SEARCH and CYCLE clauses.
 ///
 /// Setting [Self::set], [Self::expr] and [Self::using] is mandatory.
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct Cycle {
     pub(crate) expr: Option<SimpleExpr>,
@@ -441,7 +453,11 @@ impl Cycle {
 ///     r#"WITH RECURSIVE "cte_traversal" ("id", "depth", "next", "value") AS (SELECT "id", 1, "next", "value" FROM "table" UNION ALL SELECT "id", "depth" + 1, "next", "value" FROM "table" INNER JOIN "cte_traversal" ON "cte_traversal"."next" = "table"."id") SELECT * FROM "cte_traversal""#
 /// );
 /// ```
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct WithClause {
     pub(crate) recursive: bool,
@@ -542,7 +558,11 @@ impl WithClause {
 ///     DELETE FROM table WHERE table.a = cte_name.a)
 ///
 /// It is mandatory to set the [Self::cte] and the [Self::query].
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone, Default)]
 pub struct WithQuery {
     pub(crate) with_clause: WithClause,

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -33,6 +33,7 @@ use crate::{
 ///     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#,
 /// );
 /// ```
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct TableAlterStatement {
     pub(crate) table: Option<DynIden>,
@@ -40,6 +41,7 @@ pub struct TableAlterStatement {
 }
 
 /// table alter add column options
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct AddColumnOption {
     pub(crate) column: ColumnDef,

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -33,7 +33,11 @@ use crate::{
 ///     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#,
 /// );
 /// ```
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct TableAlterStatement {
     pub(crate) table: Option<DynIden>,
@@ -41,7 +45,11 @@ pub struct TableAlterStatement {
 }
 
 /// table alter add column options
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct AddColumnOption {
     pub(crate) column: ColumnDef,

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -1,7 +1,11 @@
 use crate::{types::*, value::*};
 
 /// Specification of a table column
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct ColumnDef {
     pub(crate) table: Option<TableRef>,

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -1,6 +1,7 @@
 use crate::{types::*, value::*};
 
 /// Specification of a table column
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct ColumnDef {
     pub(crate) table: Option<TableRef>,

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -77,6 +77,7 @@ use crate::{
 /// );
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 pub struct TableCreateStatement {
     pub(crate) table: Option<TableRef>,
     pub(crate) columns: Vec<ColumnDef>,

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -77,7 +77,11 @@ use crate::{
 /// );
 /// ```
 #[derive(Debug, Clone)]
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 pub struct TableCreateStatement {
     pub(crate) table: Option<TableRef>,
     pub(crate) columns: Vec<ColumnDef>,

--- a/src/table/drop.rs
+++ b/src/table/drop.rs
@@ -26,6 +26,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 /// );
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 pub struct TableDropStatement {
     pub(crate) tables: Vec<TableRef>,
     pub(crate) options: Vec<TableDropOpt>,

--- a/src/table/drop.rs
+++ b/src/table/drop.rs
@@ -26,7 +26,11 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 /// );
 /// ```
 #[derive(Debug, Clone)]
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 pub struct TableDropStatement {
     pub(crate) tables: Vec<TableRef>,
     pub(crate) options: Vec<TableDropOpt>,

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -25,7 +25,11 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 /// );
 /// ```
 #[derive(Debug, Clone)]
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 pub struct TableRenameStatement {
     pub(crate) from_name: Option<DynIden>,
     pub(crate) to_name: Option<DynIden>,

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -25,6 +25,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 /// );
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 pub struct TableRenameStatement {
     pub(crate) from_name: Option<DynIden>,
     pub(crate) to_name: Option<DynIden>,

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -23,7 +23,11 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 /// );
 /// ```
 #[derive(Debug, Clone)]
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 pub struct TableTruncateStatement {
     pub(crate) table: Option<DynIden>,
 }

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -23,6 +23,7 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 /// );
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 pub struct TableTruncateStatement {
     pub(crate) table: Option<DynIden>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -159,7 +159,11 @@ pub enum NullOrdering {
 }
 
 /// Order expression
-#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
+#[cfg_attr(
+    feature = "getters",
+    derive(getset::Getters),
+    getset(get = "pub with_prefix")
+)]
 #[derive(Debug, Clone)]
 pub struct OrderExpr {
     pub(crate) expr: SimpleExpr,

--- a/src/types.rs
+++ b/src/types.rs
@@ -159,6 +159,7 @@ pub enum NullOrdering {
 }
 
 /// Order expression
+#[cfg_attr(feature="getters",derive(getset::Getters),getset(get="pub with_prefix"))]
 #[derive(Debug, Clone)]
 pub struct OrderExpr {
     pub(crate) expr: SimpleExpr,


### PR DESCRIPTION
## PR Info

## Adds

The "getters" feature which adds getter methods on statements via a getters derive attribute configured with the feature flag.

## Changes

This getter methods derived from the getset Getter derive look like
```rust
impl STRUCT_NAME {
    pub fn get_FIELD_NAME(&self) -> &FIELD_TYPE {&self.FIELD_NAME}
}
```
When a structure has pre-existing and thus conflicting getter methods the impl was written manually under a #[cfg(feature="getters")] attribute.
When a structure had fields whose type was a pub(crate) struct, the struct was made pub to allow for getting from within it's parents related getter method. As far as I know there isn't a way to change visibility based on features currently.
