### PR TITLE
Make sea-query-driver an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ path = "src/lib.rs"
 [dependencies]
 sea-query-attr = { version = "^0.1.1", path = "sea-query-attr", optional = true }
 sea-query-derive = { version = "0.2.0", path = "sea-query-derive", optional = true }
-sea-query-driver = { version = "^0.1.1", path = "sea-query-driver" }
+sea-query-driver = { version = "^0.1.1", path = "sea-query-driver", optional = true }
 serde_json = { version = "^1", optional = true }
 bytes = { version = "^1", optional = true }
 chrono = { version = "^0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -782,4 +782,5 @@ pub use sea_query_derive::Iden;
 #[cfg(feature = "attr")]
 pub use sea_query_attr::enum_def;
 
+#[cfg(feature = "sea-query-driver")]
 pub use sea_query_driver::*;


### PR DESCRIPTION
Fixes #323

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #323

## Fixes

- [x] sea-query-driver being built even with all default features disabled
