### PR TITLE
Add `VarBinary` column type

### DIFF
--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -81,6 +81,7 @@ impl TableBuilder for MysqlQueryBuilder {
                     Some(length) => format!("binary({})", length),
                     None => "blob".into(),
                 },
+                ColumnType::VarBinary(length) => format!("varbinary({})", length),
                 ColumnType::Boolean => "bool".into(),
                 ColumnType::Money(precision) => match precision {
                     Some((precision, scale)) => format!("money({}, {})", precision, scale),

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -89,6 +89,7 @@ impl TableBuilder for PostgresQueryBuilder {
                 ColumnType::Binary(length) => match length {
                     Some(_) | None => "bytea".into(),
                 },
+                ColumnType::VarBinary(length) => format!("bit varying({})", length),
                 ColumnType::Boolean => "bool".into(),
                 ColumnType::Money(precision) => match precision {
                     Some((precision, scale)) => format!("money({}, {})", precision, scale),

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -101,6 +101,7 @@ impl TableBuilder for SqliteQueryBuilder {
                     Some(length) => format!("binary({})", length),
                     None => "binary".into(),
                 },
+                ColumnType::VarBinary(length) => format!("binary({})", length),
                 ColumnType::Boolean => "integer".into(),
                 ColumnType::Money(precision) => match precision {
                     Some((precision, scale)) => format!("integer({}, {})", precision, scale),

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -34,6 +34,7 @@ pub enum ColumnType {
     Date,
     Interval(Option<PgInterval>, Option<u32>),
     Binary(Option<u32>),
+    VarBinary(u32),
     Boolean,
     Money(Option<(u32, u32)>),
     Json,
@@ -426,6 +427,12 @@ impl ColumnDef {
     /// Set column type as binary
     pub fn binary(&mut self) -> &mut Self {
         self.types = Some(ColumnType::Binary(None));
+        self
+    }
+
+    /// Set column type as binary with variable length
+    pub fn var_binary(&mut self, length: u32) -> &mut Self {
+        self.types = Some(ColumnType::VarBinary(length));
         self
     }
 

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -151,6 +151,26 @@ fn create_5() {
 }
 
 #[test]
+fn create_6() {
+    assert_eq!(
+        Table::create()
+            .table(Char::Table)
+            .col(ColumnDef::new(Char::Character).binary())
+            .col(ColumnDef::new(Char::FontSize).binary_len(10))
+            .col(ColumnDef::new(Char::SizeW).var_binary(10))
+            .to_string(MysqlQueryBuilder),
+        vec![
+            "CREATE TABLE `character` (",
+            "`character` blob,",
+            "`font_size` binary(10),",
+            "`size_w` varbinary(10)",
+            ")",
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Table::drop()

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -253,6 +253,26 @@ fn create_11() {
 }
 
 #[test]
+fn create_12() {
+    assert_eq!(
+        Table::create()
+            .table(Char::Table)
+            .col(ColumnDef::new(Char::Character).binary())
+            .col(ColumnDef::new(Char::FontSize).binary_len(10))
+            .col(ColumnDef::new(Char::SizeW).var_binary(10))
+            .to_string(PostgresQueryBuilder),
+        vec![
+            r#"CREATE TABLE "character" ("#,
+            r#""character" bytea,"#,
+            r#""font_size" bytea,"#,
+            r#""size_w" bit varying(10)"#,
+            r#")"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Table::drop()

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -100,6 +100,26 @@ fn create_3() {
 }
 
 #[test]
+fn create_4() {
+    assert_eq!(
+        Table::create()
+            .table(Char::Table)
+            .col(ColumnDef::new(Char::Character).binary())
+            .col(ColumnDef::new(Char::FontSize).binary_len(10))
+            .col(ColumnDef::new(Char::SizeW).var_binary(10))
+            .to_string(SqliteQueryBuilder),
+        vec![
+            r#"CREATE TABLE "character" ("#,
+            r#""character" binary,"#,
+            r#""font_size" binary(10),"#,
+            r#""size_w" binary(10)"#,
+            r#")"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn create_with_unique_index() {
     assert_eq!(
         Table::create()


### PR DESCRIPTION
## PR Info

- Closes SeaQL/sea-orm#704

- Dependents:
  - SeaQL/sea-schema#67

## Adds

- [x] Add `VarBinary` column type as two out of three db backend support this datatype. Only SQLite doesn't support it

## References
- https://mariadb.com/kb/en/varbinary/
- https://dev.mysql.com/doc/refman/8.0/en/binary-varbinary.html
- https://www.postgresql.org/docs/current/datatype-bit.html