### PR TITLE
Fix clippy warnings for manual map

### DIFF
--- a/sea-query-driver/src/sqlx_postgres.rs
+++ b/sea-query-driver/src/sqlx_postgres.rs
@@ -85,19 +85,12 @@ pub fn bind_params_sqlx_postgres_impl(input: TokenStream) -> TokenStream {
             for value in #params.iter() {
                 macro_rules! bind {
                     ( $v: expr, $ty: ty ) => {
-                        match $v {
-                            Some(v) => query.bind(*v as $ty),
-                            None => query.bind(None::<$ty>),
-                        }
+                        query.bind($v.map(|v| v as $ty))
                     };
                 }
                 macro_rules! bind_box {
                     ( $v: expr ) => {{
-                        let v = match $v {
-                            Some(v) => Some(v.as_ref()),
-                            None => None,
-                        };
-                        query.bind(v)
+                        query.bind($v.as_ref().map(|v| v.as_ref()))
                     }};
                 }
                 query = match value {


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## Fixes

- [x] Some clippy warnings originating from the driver macro:
```
warning: manual implementation of `Option::map`
  --> examples/sqlx_postgres/src/main.rs:10:1
   |
10 | sea_query::sea_query_driver_postgres!();
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `sea_query::sea_query_driver_postgres!().as_ref().map(|v| sea_query::sea_query_driver_postgres!())`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_map
   = note: this warning originates in the macro `bind_box` (in Nightly builds, run with -Z macro-backtrace for more info)
```