### PR TITLE
upgrade time dependency version to 0.3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,13 +22,20 @@ jobs:
           toolchain: stable
           components: clippy
           override: true
-          
+
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: >
             --all-targets
-            --all
+            --features backend-mysql,backend-postgres,backend-sqlite,derive,attr,postgres,postgres-chrono,postgres-json,postgres-rust_decimal,postgres-bigdecimal,postgres-uuid,postgres-array,postgres-interval,postgres-time-0_2,rusqlite,sqlx-mysql,sqlx-postgres,sqlx-sqlite,thread-safe,with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time-0_2
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: >
+            --all-targets
+            --features backend-mysql,backend-postgres,backend-sqlite,derive,attr,postgres,postgres-chrono,postgres-json,postgres-rust_decimal,postgres-bigdecimal,postgres-uuid,postgres-array,postgres-interval,postgres-time-0_3,rusqlite,sqlx-mysql,sqlx-postgres,sqlx-sqlite,thread-safe,with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time-0_3
 
   build:
     name: Build
@@ -44,38 +51,21 @@ jobs:
 
       - uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --no-default-features
+          command: install
+          args: cargo-hack
+
+      # By default, when using --each-feature, cargo hack will run with --all-features which is not possible
+      # considering with-time-0_2 and with-time-0_3 are exclusive. Excluding with-time-0_2 solves this but we
+      # need to check it afterward.
+      - uses: actions-rs/cargo@v1
+        with:
+          command: hack
+          args: build --each-feature --exclude-features with-time-0_2
 
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-features
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features=thread-safe
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features=with-chrono
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features=with-json
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features=with-rust_decimal
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --features=with-uuid
+          args: --features with-time-0_3
 
   test:
     name: Unit Test
@@ -92,7 +82,12 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+          args: --features backend-mysql,backend-postgres,backend-sqlite,derive,attr,postgres,postgres-chrono,postgres-json,postgres-rust_decimal,postgres-bigdecimal,postgres-uuid,postgres-array,postgres-interval,postgres-time-0_2,rusqlite,sqlx-mysql,sqlx-postgres,sqlx-sqlite,thread-safe,with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time-0_2
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features backend-mysql,backend-postgres,backend-sqlite,derive,attr,postgres,postgres-chrono,postgres-json,postgres-rust_decimal,postgres-bigdecimal,postgres-uuid,postgres-array,postgres-interval,postgres-time-0_3,rusqlite,sqlx-mysql,sqlx-postgres,sqlx-sqlite,thread-safe,with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time-0_3
 
   derive-test:
     name: Derive Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ bigdecimal = { version = "^0.2", optional = true }
 uuid = { version = "^0", optional = true }
 proc-macro2 = { version = "1", optional = true }
 quote = { version = "^1", optional = true }
-time = { version = "^0.2", optional = true }
+time = { version = "^0.3", optional = true, features = ["formatting", "macros", "parsing"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,9 @@ bigdecimal = { version = "^0.2", optional = true }
 uuid = { version = "^0", optional = true }
 proc-macro2 = { version = "1", optional = true }
 quote = { version = "^1", optional = true }
-time = { version = "^0.3", optional = true, features = ["formatting", "macros", "parsing"] }
+time-0_2 = { package = "time", version = "^0.2", optional = true }
+# time-0_3 cannot be used due to a macro referencing `time`
+time = { package = "time", version = "^0.3", optional = true, features = ["formatting", "macros", "parsing"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
@@ -70,7 +72,9 @@ postgres-bigdecimal = ["with-bigdecimal"]
 postgres-uuid = ["with-uuid", "postgres-types/with-uuid-0_8"]
 postgres-array = ["postgres-types/array-impls", "sea-query-driver?/postgres-array"]
 postgres-interval = ["proc-macro2", "quote"]
-postgres-time = ["with-time", "postgres-types/with-time-0_2"]
+postgres-time-0_2 = ["with-time-0_2", "postgres-types/with-time-0_2"]
+postgres-time-0_3 = ["with-time-0_3", "postgres-types/with-time-0_3"]
+postgres-time = ["postgres-time-0_3"]
 rusqlite = ["sea-query-driver/rusqlite"]
 sqlx-mysql = ["sea-query-driver/sqlx-mysql"]
 sqlx-postgres = ["sea-query-driver/sqlx-postgres"]
@@ -81,7 +85,9 @@ with-json = ["serde_json", "sea-query-driver?/with-json"]
 with-rust_decimal = ["rust_decimal", "sea-query-driver?/with-rust_decimal"]
 with-bigdecimal = ["bigdecimal", "sea-query-driver?/with-bigdecimal"]
 with-uuid = ["uuid", "sea-query-driver?/with-uuid"]
-with-time = ["time", "sea-query-driver?/with-time"]
+with-time-0_2 = ["time-0_2", "sea-query-driver?/with-time"]
+with-time-0_3 = ["time", "sea-query-driver?/with-time"]
+with-time = ["with-time-0_3"]
 
 [[test]]
 name = "test-derive"

--- a/examples/cockroach_json/Cargo.toml
+++ b/examples/cockroach_json/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 chrono = "^0"
 time = "^0.2"
 postgres = "^0.19"
-sea-query = { path = "../../", features = ["postgres", "postgres-chrono", "postgres-json", "postgres-uuid", "postgres-time"] }
+sea-query = { path = "../../", features = ["postgres", "postgres-chrono", "postgres-json", "postgres-uuid", "postgres-time-0_2"] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
 # sea-query = { version = "^0", features = ["postgres", "postgres-chrono", "postgres-json", "postgres-time"] }
 serde_json = "^1"

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1,21 +1,7 @@
+#[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
+use crate::deps::time::{FORMAT_DATE, FORMAT_DATETIME, FORMAT_DATETIME_TZ, FORMAT_TIME};
 use crate::*;
 use std::ops::Deref;
-#[cfg(feature = "with-time")]
-use time::macros::format_description;
-
-#[cfg(feature = "with-time")]
-pub static FORMAT_TIME: &'static [time::format_description::FormatItem<'static>] =
-    format_description!("[year]-[month]-[day]");
-#[cfg(feature = "with-time")]
-pub static FORMAT_DATE: &'static [time::format_description::FormatItem<'static>] =
-    format_description!("[hour]:[minute]:[second]");
-#[cfg(feature = "with-time")]
-pub static FORMAT_DATETIME: &'static [time::format_description::FormatItem<'static>] =
-    format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
-#[cfg(feature = "with-time")]
-pub static FORMAT_DATETIME_TZ: &'static [time::format_description::FormatItem<'static>] = format_description!(
-    "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour sign:mandatory][offset_minute]"
-);
 
 pub trait QueryBuilder: QuotedBuilder {
     /// The type of placeholder the builder uses for values, and whether it is numbered.
@@ -1084,13 +1070,13 @@ pub trait QueryBuilder: QuotedBuilder {
             Value::ChronoDateTimeLocal(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
+            #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
             Value::TimeDate(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
+            #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
             Value::TimeTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
+            #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
             Value::TimeDateTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
+            #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
             Value::TimeDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(None) => write!(s, "NULL").unwrap(),
@@ -1146,21 +1132,31 @@ pub trait QueryBuilder: QuotedBuilder {
             Value::ChronoDateTimeWithTimeZone(Some(v)) => {
                 write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
-            #[cfg(feature = "with-time")]
+            #[cfg(feature = "with-time-0_3")]
             Value::TimeDate(Some(v)) => {
                 write!(s, "\'{}\'", v.format(FORMAT_TIME).unwrap()).unwrap()
             }
-            #[cfg(feature = "with-time")]
+            #[cfg(feature = "with-time-0_3")]
             Value::TimeTime(Some(v)) => {
                 write!(s, "\'{}\'", v.format(FORMAT_DATE).unwrap()).unwrap()
             }
-            #[cfg(feature = "with-time")]
+            #[cfg(feature = "with-time-0_3")]
             Value::TimeDateTime(Some(v)) => {
                 write!(s, "\'{}\'", v.format(FORMAT_DATETIME).unwrap()).unwrap()
             }
-            #[cfg(feature = "with-time")]
+            #[cfg(feature = "with-time-0_3")]
             Value::TimeDateTimeWithTimeZone(Some(v)) => {
                 write!(s, "\'{}\'", v.format(FORMAT_DATETIME_TZ).unwrap()).unwrap()
+            }
+            #[cfg(feature = "with-time-0_2")]
+            Value::TimeDate(Some(v)) => write!(s, "\'{}\'", v.format(FORMAT_TIME)).unwrap(),
+            #[cfg(feature = "with-time-0_2")]
+            Value::TimeTime(Some(v)) => write!(s, "\'{}\'", v.format(FORMAT_DATE)).unwrap(),
+            #[cfg(feature = "with-time-0_2")]
+            Value::TimeDateTime(Some(v)) => write!(s, "\'{}\'", v.format(FORMAT_DATETIME)).unwrap(),
+            #[cfg(feature = "with-time-0_2")]
+            Value::TimeDateTimeWithTimeZone(Some(v)) => {
+                write!(s, "\'{}\'", v.format(FORMAT_DATETIME_TZ)).unwrap()
             }
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(Some(v)) => write!(s, "{}", v).unwrap(),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1,5 +1,21 @@
 use crate::*;
 use std::ops::Deref;
+#[cfg(feature = "with-time")]
+use time::macros::format_description;
+
+#[cfg(feature = "with-time")]
+pub static FORMAT_TIME: &'static [time::format_description::FormatItem<'static>] =
+    format_description!("[year]-[month]-[day]");
+#[cfg(feature = "with-time")]
+pub static FORMAT_DATE: &'static [time::format_description::FormatItem<'static>] =
+    format_description!("[hour]:[minute]:[second]");
+#[cfg(feature = "with-time")]
+pub static FORMAT_DATETIME: &'static [time::format_description::FormatItem<'static>] =
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
+#[cfg(feature = "with-time")]
+pub static FORMAT_DATETIME_TZ: &'static [time::format_description::FormatItem<'static>] = format_description!(
+    "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour sign:mandatory][offset_minute]"
+);
 
 pub trait QueryBuilder: QuotedBuilder {
     /// The type of placeholder the builder uses for values, and whether it is numbered.
@@ -1131,16 +1147,20 @@ pub trait QueryBuilder: QuotedBuilder {
                 write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
             #[cfg(feature = "with-time")]
-            Value::TimeDate(Some(v)) => write!(s, "\'{}\'", v.format("%Y-%m-%d")).unwrap(),
+            Value::TimeDate(Some(v)) => {
+                write!(s, "\'{}\'", v.format(FORMAT_TIME).unwrap()).unwrap()
+            }
             #[cfg(feature = "with-time")]
-            Value::TimeTime(Some(v)) => write!(s, "\'{}\'", v.format("%H:%M:%S")).unwrap(),
+            Value::TimeTime(Some(v)) => {
+                write!(s, "\'{}\'", v.format(FORMAT_DATE).unwrap()).unwrap()
+            }
             #[cfg(feature = "with-time")]
             Value::TimeDateTime(Some(v)) => {
-                write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S")).unwrap()
+                write!(s, "\'{}\'", v.format(FORMAT_DATETIME).unwrap()).unwrap()
             }
             #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(Some(v)) => {
-                write!(s, "\'{}\'", v.format("%Y-%m-%d %H:%M:%S %z")).unwrap()
+                write!(s, "\'{}\'", v.format(FORMAT_DATETIME_TZ).unwrap()).unwrap()
             }
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(Some(v)) => write!(s, "{}", v).unwrap(),

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -1,3 +1,6 @@
+#[cfg(all(feature = "with-time-0_3", feature = "with-time-0_2"))]
+compile_error!("features `with-time-0_3` and `with-time-0_2` are mutually exclusive");
+
 #[cfg(feature = "with-time-0_3")]
 pub mod time {
     pub use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -8,13 +8,12 @@ pub mod time {
     use time::format_description::FormatItem;
     use time::macros::format_description;
 
-    pub static FORMAT_TIME: &'static [FormatItem<'static>] =
-        format_description!("[year]-[month]-[day]");
-    pub static FORMAT_DATE: &'static [FormatItem<'static>] =
+    pub static FORMAT_TIME: &[FormatItem<'static>] = format_description!("[year]-[month]-[day]");
+    pub static FORMAT_DATE: &[FormatItem<'static>] =
         format_description!("[hour]:[minute]:[second]");
-    pub static FORMAT_DATETIME: &'static [FormatItem<'static>] =
+    pub static FORMAT_DATETIME: &[FormatItem<'static>] =
         format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
-    pub static FORMAT_DATETIME_TZ: &'static [FormatItem<'static>] = format_description!(
+    pub static FORMAT_DATETIME_TZ: &[FormatItem<'static>] = format_description!(
         "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour sign:mandatory][offset_minute]"
     );
 
@@ -59,10 +58,10 @@ pub mod time {
 pub mod time {
     pub use time_0_2::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
-    pub static FORMAT_TIME: &'static str = "%Y-%m-%d";
-    pub static FORMAT_DATE: &'static str = "%H:%M:%S";
-    pub static FORMAT_DATETIME: &'static str = "%Y-%m-%d %H:%M:%S";
-    pub static FORMAT_DATETIME_TZ: &'static str = "%Y-%m-%d %H:%M:%S %z";
+    pub static FORMAT_TIME: &str = "%Y-%m-%d";
+    pub static FORMAT_DATE: &str = "%H:%M:%S";
+    pub static FORMAT_DATETIME: &str = "%Y-%m-%d %H:%M:%S";
+    pub static FORMAT_DATETIME_TZ: &str = "%Y-%m-%d %H:%M:%S %z";
 
     pub fn offset(hours: i8) -> UtcOffset {
         UtcOffset::hours(hours)

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -1,0 +1,100 @@
+#[cfg(feature = "with-time-0_3")]
+pub mod time {
+    pub use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+
+    use time::format_description::FormatItem;
+    use time::macros::format_description;
+
+    pub static FORMAT_TIME: &'static [FormatItem<'static>] =
+        format_description!("[year]-[month]-[day]");
+    pub static FORMAT_DATE: &'static [FormatItem<'static>] =
+        format_description!("[hour]:[minute]:[second]");
+    pub static FORMAT_DATETIME: &'static [FormatItem<'static>] =
+        format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
+    pub static FORMAT_DATETIME_TZ: &'static [FormatItem<'static>] = format_description!(
+        "[year]-[month]-[day] [hour]:[minute]:[second] [offset_hour sign:mandatory][offset_minute]"
+    );
+
+    pub fn offset(hours: i8) -> UtcOffset {
+        UtcOffset::from_hms(hours, 0, 0).unwrap()
+    }
+
+    pub fn time(hour: u8, minute: u8, second: u8) -> Time {
+        Time::from_hms(hour, minute, second).unwrap()
+    }
+
+    pub fn date(year: i32, month: u8, day: u8) -> time::Date {
+        let month = time::Month::try_from(month).unwrap();
+        Date::from_calendar_date(year, month, day).unwrap()
+    }
+
+    pub fn datetime(
+        year: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+    ) -> PrimitiveDateTime {
+        date(year, month, day).with_time(time(hour, minute, second))
+    }
+
+    pub fn datetimetz(
+        year: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        offset_hours: i8,
+    ) -> OffsetDateTime {
+        datetime(year, month, day, hour, minute, second).assume_offset(offset(offset_hours))
+    }
+}
+
+#[cfg(feature = "with-time-0_2")]
+pub mod time {
+    pub use time_0_2::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+
+    pub static FORMAT_TIME: &'static str = "%Y-%m-%d";
+    pub static FORMAT_DATE: &'static str = "%H:%M:%S";
+    pub static FORMAT_DATETIME: &'static str = "%Y-%m-%d %H:%M:%S";
+    pub static FORMAT_DATETIME_TZ: &'static str = "%Y-%m-%d %H:%M:%S %z";
+
+    pub fn offset(hours: i8) -> UtcOffset {
+        UtcOffset::hours(hours)
+    }
+
+    pub fn time(hour: u8, minute: u8, second: u8) -> Time {
+        Time::try_from_hms(hour, minute, second).unwrap()
+    }
+
+    pub fn date(year: i32, month: u8, day: u8) -> Date {
+        Date::try_from_ymd(year, month, day).unwrap()
+    }
+
+    pub fn datetime(
+        year: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+    ) -> PrimitiveDateTime {
+        date(year, month, day).with_time(time(hour, minute, second))
+    }
+
+    pub fn datetimetz(
+        year: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        offset_hours: i8,
+    ) -> OffsetDateTime {
+        datetime(year, month, day, hour, minute, second)
+            .assume_utc()
+            .to_offset(offset(offset_hours))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,6 +741,7 @@
 )]
 
 pub mod backend;
+pub mod deps;
 pub mod driver;
 pub mod error;
 pub mod expr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,7 +741,7 @@
 )]
 
 pub mod backend;
-pub mod deps;
+mod deps;
 pub mod driver;
 pub mod error;
 pub mod expr;

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -5,6 +5,9 @@ pub use std::fmt::Write as FmtWrite;
 #[cfg(feature = "with-json")]
 pub use serde_json::json;
 
+#[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
+pub use crate::deps::time;
+
 use crate::Iden;
 
 /// Representation of a database table named `Character`.

--- a/src/value.rs
+++ b/src/value.rs
@@ -9,9 +9,6 @@ use std::str::from_utf8;
 #[cfg(feature = "with-chrono")]
 use chrono::{DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 
-#[cfg(feature = "with-time")]
-use time::{OffsetDateTime, PrimitiveDateTime};
-
 #[cfg(feature = "with-rust_decimal")]
 use rust_decimal::Decimal;
 
@@ -81,21 +78,32 @@ pub enum Value {
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDateTimeWithTimeZone(Option<Box<DateTime<FixedOffset>>>),
 
-    #[cfg(feature = "with-time")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
-    TimeDate(Option<Box<time::Date>>),
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "with-time-0_3", feature = "with-time-0_2")))
+    )]
+    TimeDate(Option<Box<crate::deps::time::Date>>),
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "with-time-0_3", feature = "with-time-0_2")))
+    )]
+    TimeTime(Option<Box<crate::deps::time::Time>>),
 
-    #[cfg(feature = "with-time")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
-    TimeTime(Option<Box<time::Time>>),
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "with-time-0_3", feature = "with-time-0_2")))
+    )]
+    TimeDateTime(Option<Box<crate::deps::time::PrimitiveDateTime>>),
 
-    #[cfg(feature = "with-time")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
-    TimeDateTime(Option<Box<PrimitiveDateTime>>),
-
-    #[cfg(feature = "with-time")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
-    TimeDateTimeWithTimeZone(Option<Box<OffsetDateTime>>),
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "with-time-0_3", feature = "with-time-0_2")))
+    )]
+    TimeDateTimeWithTimeZone(Option<Box<crate::deps::time::OffsetDateTime>>),
 
     #[cfg(feature = "with-uuid")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
@@ -427,28 +435,35 @@ mod with_chrono {
     }
 }
 
-#[cfg(feature = "with-time")]
-#[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+#[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "with-time-0_3", feature = "with-time-0_2")))
+)]
 mod with_time {
     use super::*;
 
-    type_to_box_value!(time::Date, TimeDate, Date);
-    type_to_box_value!(time::Time, TimeTime, Time(None));
-    type_to_box_value!(PrimitiveDateTime, TimeDateTime, DateTime(None));
+    type_to_box_value!(crate::deps::time::Date, TimeDate, Date);
+    type_to_box_value!(crate::deps::time::Time, TimeTime, Time(None));
+    type_to_box_value!(
+        crate::deps::time::PrimitiveDateTime,
+        TimeDateTime,
+        DateTime(None)
+    );
 
-    impl From<OffsetDateTime> for Value {
-        fn from(v: OffsetDateTime) -> Value {
+    impl From<crate::deps::time::OffsetDateTime> for Value {
+        fn from(v: crate::deps::time::OffsetDateTime) -> Value {
             Value::TimeDateTimeWithTimeZone(Some(Box::new(v)))
         }
     }
 
-    impl Nullable for OffsetDateTime {
+    impl Nullable for crate::deps::time::OffsetDateTime {
         fn null() -> Value {
             Value::TimeDateTimeWithTimeZone(None)
         }
     }
 
-    impl ValueType for OffsetDateTime {
+    impl ValueType for crate::deps::time::OffsetDateTime {
         fn try_from(v: Value) -> Result<Self, ValueTypeErr> {
             match v {
                 Value::TimeDateTimeWithTimeZone(Some(x)) => Ok(*x),
@@ -457,7 +472,7 @@ mod with_time {
         }
 
         fn type_name() -> String {
-            stringify!(OffsetDateTime).to_owned()
+            stringify!(crate::deps::time::OffsetDateTime).to_owned()
         }
 
         fn column_type() -> ColumnType {
@@ -527,17 +542,17 @@ mod with_array {
     #[cfg(feature = "with-chrono")]
     impl<Tz> NotU8 for DateTime<Tz> where Tz: chrono::TimeZone {}
 
-    #[cfg(feature = "with-time")]
-    impl NotU8 for time::Date {}
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
+    impl NotU8 for crate::deps::time::Date {}
 
-    #[cfg(feature = "with-time")]
-    impl NotU8 for time::Time {}
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
+    impl NotU8 for crate::deps::time::Time {}
 
-    #[cfg(feature = "with-time")]
-    impl NotU8 for PrimitiveDateTime {}
+    #[cfg(any(feature = "with-time_0_3", feature = "with-time-0_2"))]
+    impl NotU8 for crate::deps::time::PrimitiveDateTime {}
 
-    #[cfg(feature = "with-time")]
-    impl NotU8 for OffsetDateTime {}
+    #[cfg(any(feature = "with-time_0_3", feature = "with-time-0_2"))]
+    impl NotU8 for crate::deps::time::OffsetDateTime {}
 
     #[cfg(feature = "with-rust_decimal")]
     impl NotU8 for Decimal {}
@@ -626,13 +641,13 @@ impl Value {
     }
 }
 
-#[cfg(feature = "with-time")]
+#[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
 impl Value {
     pub fn is_time_date(&self) -> bool {
         matches!(self, Self::TimeDate(_))
     }
 
-    pub fn as_ref_time_date(&self) -> Option<&time::Date> {
+    pub fn as_ref_time_date(&self) -> Option<&crate::deps::time::Date> {
         match self {
             Self::TimeDate(v) => box_to_opt_ref!(v),
             _ => panic!("not Value::TimeDate"),
@@ -654,13 +669,13 @@ impl Value {
     }
 }
 
-#[cfg(feature = "with-time")]
+#[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
 impl Value {
     pub fn is_time_time(&self) -> bool {
         matches!(self, Self::TimeTime(_))
     }
 
-    pub fn as_ref_time_time(&self) -> Option<&time::Time> {
+    pub fn as_ref_time_time(&self) -> Option<&crate::deps::time::Time> {
         match self {
             Self::TimeTime(v) => box_to_opt_ref!(v),
             _ => panic!("not Value::TimeTime"),
@@ -682,13 +697,13 @@ impl Value {
     }
 }
 
-#[cfg(feature = "with-time")]
+#[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
 impl Value {
     pub fn is_time_date_time(&self) -> bool {
         matches!(self, Self::TimeDateTime(_))
     }
 
-    pub fn as_ref_time_date_time(&self) -> Option<&PrimitiveDateTime> {
+    pub fn as_ref_time_date_time(&self) -> Option<&crate::deps::time::PrimitiveDateTime> {
         match self {
             Self::TimeDateTime(v) => box_to_opt_ref!(v),
             _ => panic!("not Value::TimeDateTime"),
@@ -738,13 +753,15 @@ impl Value {
     }
 }
 
-#[cfg(feature = "with-time")]
+#[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
 impl Value {
     pub fn is_time_date_time_with_time_zone(&self) -> bool {
         matches!(self, Self::TimeDateTimeWithTimeZone(_))
     }
 
-    pub fn as_ref_time_date_time_with_time_zone(&self) -> Option<&OffsetDateTime> {
+    pub fn as_ref_time_date_time_with_time_zone(
+        &self,
+    ) -> Option<&crate::deps::time::OffsetDateTime> {
         match self {
             Self::TimeDateTimeWithTimeZone(v) => box_to_opt_ref!(v),
             _ => panic!("not Value::TimeDateTimeWithTimeZone"),
@@ -767,23 +784,41 @@ impl Value {
     }
 }
 
-#[cfg(feature = "with-time")]
+#[cfg(feature = "with-time-0_3")]
 impl Value {
     pub fn time_as_naive_utc_in_string(&self) -> Option<String> {
         match self {
             Self::TimeDate(v) => v
                 .as_ref()
-                .and_then(|v| v.format(crate::backend::FORMAT_DATE).ok()),
+                .and_then(|v| v.format(crate::deps::time::FORMAT_DATE).ok()),
             Self::TimeTime(v) => v
                 .as_ref()
-                .and_then(|v| v.format(crate::backend::FORMAT_TIME).ok()),
+                .and_then(|v| v.format(crate::deps::time::FORMAT_TIME).ok()),
             Self::TimeDateTime(v) => v
                 .as_ref()
-                .and_then(|v| v.format(crate::backend::FORMAT_DATETIME).ok()),
+                .and_then(|v| v.format(crate::deps::time::FORMAT_DATETIME).ok()),
             Self::TimeDateTimeWithTimeZone(v) => v.as_ref().and_then(|v| {
-                v.to_offset(time::macros::offset!(+0))
-                    .format(crate::backend::FORMAT_DATETIME)
+                v.to_offset(crate::deps::time::UtcOffset::UTC)
+                    .format(crate::deps::time::FORMAT_DATETIME)
                     .ok()
+            }),
+            _ => panic!("not time Value"),
+        }
+    }
+}
+
+#[cfg(feature = "with-time-0_2")]
+impl Value {
+    pub fn time_as_naive_utc_in_string(&self) -> Option<String> {
+        match self {
+            Self::TimeDate(v) => v.as_ref().map(|v| v.format(crate::deps::time::FORMAT_DATE)),
+            Self::TimeTime(v) => v.as_ref().map(|v| v.format(crate::deps::time::FORMAT_TIME)),
+            Self::TimeDateTime(v) => v
+                .as_ref()
+                .map(|v| v.format(crate::deps::time::FORMAT_DATETIME)),
+            Self::TimeDateTimeWithTimeZone(v) => v.as_ref().map(|v| {
+                v.to_offset(crate::deps::time::UtcOffset::UTC)
+                    .format(crate::deps::time::FORMAT_DATETIME)
             }),
             _ => panic!("not time Value"),
         }
@@ -1605,55 +1640,58 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "with-time")]
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
     fn test_time_value() {
-        use time::macros::{date, time};
-        let timestamp = date!(2020 - 01 - 01).with_time(time!(2:2:2));
+        use crate::deps::time::{datetime, PrimitiveDateTime};
+
+        let timestamp = datetime(2020, 1, 1, 2, 2, 2);
         let value: Value = timestamp.into();
         let out: PrimitiveDateTime = value.unwrap();
         assert_eq!(out, timestamp);
     }
 
     #[test]
-    #[cfg(feature = "with-time")]
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
     fn test_time_utc_value() {
-        use time::macros::{date, time};
-        let timestamp = date!(2022 - 01 - 02).with_time(time!(3:04:05)).assume_utc();
+        use crate::deps::time::{datetime, OffsetDateTime};
+
+        let timestamp = datetime(2022, 1, 2, 3, 4, 5).assume_utc();
         let value: Value = timestamp.into();
         let out: OffsetDateTime = value.unwrap();
         assert_eq!(out, timestamp);
     }
 
     #[test]
-    #[cfg(feature = "with-time")]
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
     fn test_time_local_value() {
-        use time::macros::{date, offset, time};
-        let timestamp_utc = date!(2022 - 01 - 02).with_time(time!(3:04:05)).assume_utc();
-        let timestamp_local: OffsetDateTime = timestamp_utc.to_offset(offset!(+3));
+        use crate::deps::time::{datetime, offset, OffsetDateTime};
+
+        let timestamp_utc = datetime(2022, 1, 2, 3, 4, 5).assume_utc();
+        let timestamp_local: OffsetDateTime = timestamp_utc.to_offset(offset(3));
         let value: Value = timestamp_local.into();
         let out: OffsetDateTime = value.unwrap();
         assert_eq!(out, timestamp_local);
     }
 
     #[test]
-    #[cfg(feature = "with-time")]
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
     fn test_time_timezone_value() {
-        use time::macros::{date, offset, time};
-        let timestamp = date!(2022 - 01 - 02)
-            .with_time(time!(3:04:05))
-            .assume_offset(offset!(+8));
+        use crate::deps::time::{datetimetz, OffsetDateTime};
+
+        let timestamp = datetimetz(2022, 1, 2, 3, 4, 5, 8);
         let value: Value = timestamp.into();
         let out: OffsetDateTime = value.unwrap();
         assert_eq!(out, timestamp);
     }
 
     #[test]
-    #[cfg(feature = "with-time")]
+    #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
     fn test_time_query() {
+        use crate::deps::time::{OffsetDateTime, FORMAT_DATETIME_TZ};
         use crate::*;
 
         let string = "2020-01-01 02:02:02 +0800";
-        let timestamp = OffsetDateTime::parse(string, crate::backend::FORMAT_DATETIME_TZ).unwrap();
+        let timestamp = OffsetDateTime::parse(string, FORMAT_DATETIME_TZ).unwrap();
 
         let query = Query::select().expr(Expr::val(timestamp)).to_owned();
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1276,13 +1276,13 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::ChronoDateTimeUtc(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeLocal(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(feature = "with-time")]
+        #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
         Value::TimeDate(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(feature = "with-time")]
+        #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
         Value::TimeTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(feature = "with-time")]
+        #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
         Value::TimeDateTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(feature = "with-time")]
+        #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
         Value::TimeDateTimeWithTimeZone(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-rust_decimal")]
         Value::Decimal(Some(v)) => {

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1053,16 +1053,15 @@ fn insert_4() {
 }
 
 #[test]
-#[cfg(feature = "with-time")]
+#[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
 fn insert_8() {
-    use time::macros::{date, time};
+    use crate::deps::time::datetime;
+
     assert_eq!(
         Query::insert()
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
-            .values_panic(vec![date!(1970 - 01 - 01)
-                .with_time(time!(00:00:00))
-                .into()])
+            .values_panic(vec![datetime(1970, 1, 1, 0, 0, 0).into()])
             .to_string(MysqlQueryBuilder),
         "INSERT INTO `glyph` (`image`) VALUES ('1970-01-01 00:00:00')"
     );

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1055,7 +1055,7 @@ fn insert_4() {
 #[test]
 #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
 fn insert_8() {
-    use crate::deps::time::datetime;
+    use crate::tests_cfg::time::datetime;
 
     assert_eq!(
         Query::insert()

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1055,7 +1055,7 @@ fn insert_4() {
 #[test]
 #[cfg(feature = "with-time")]
 fn insert_8() {
-    use time::{date, time};
+    use time::macros::{date, time};
     assert_eq!(
         Query::insert()
             .into_table(Glyph::Table)

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1107,16 +1107,15 @@ fn insert_4() {
 }
 
 #[test]
-#[cfg(feature = "with-time")]
+#[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
 fn insert_9() {
-    use time::macros::{date, time};
+    use crate::deps::time::datetime;
+
     assert_eq!(
         Query::insert()
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
-            .values_panic(vec![date!(1970 - 01 - 01)
-                .with_time(time!(00:00:00))
-                .into()])
+            .values_panic(vec![datetime(1970, 1, 1, 0, 0, 0).into()])
             .to_string(PostgresQueryBuilder),
         "INSERT INTO \"glyph\" (\"image\") VALUES ('1970-01-01 00:00:00')"
     );

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1109,7 +1109,7 @@ fn insert_4() {
 #[test]
 #[cfg(feature = "with-time")]
 fn insert_9() {
-    use time::{date, time};
+    use time::macros::{date, time};
     assert_eq!(
         Query::insert()
             .into_table(Glyph::Table)

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1109,7 +1109,7 @@ fn insert_4() {
 #[test]
 #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
 fn insert_9() {
-    use crate::deps::time::datetime;
+    use crate::tests_cfg::time::datetime;
 
     assert_eq!(
         Query::insert()

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1034,7 +1034,7 @@ fn insert_4() {
 #[test]
 #[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
 fn insert_8() {
-    use crate::deps::time::datetime;
+    use crate::tests_cfg::time::datetime;
 
     assert_eq!(
         Query::insert()

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1032,16 +1032,15 @@ fn insert_4() {
 }
 
 #[test]
-#[cfg(feature = "with-time")]
+#[cfg(any(feature = "with-time-0_3", feature = "with-time-0_2"))]
 fn insert_8() {
-    use time::macros::{date, time};
+    use crate::deps::time::datetime;
+
     assert_eq!(
         Query::insert()
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
-            .values_panic(vec![date!(1970 - 01 - 01)
-                .with_time(time!(00:00:00))
-                .into()])
+            .values_panic(vec![datetime(1970, 1, 1, 0, 0, 0).into()])
             .to_string(SqliteQueryBuilder),
         r#"INSERT INTO "glyph" ("image") VALUES ('1970-01-01 00:00:00')"#
     );

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1034,7 +1034,7 @@ fn insert_4() {
 #[test]
 #[cfg(feature = "with-time")]
 fn insert_8() {
-    use time::{date, time};
+    use time::macros::{date, time};
     assert_eq!(
         Query::insert()
             .into_table(Glyph::Table)


### PR DESCRIPTION
The [time](https://crates.io/crates/time) crate version 0.3.x as been released for a while now and sea-orm is still on version 0.2, blocking the integration with tools like async-graphql which relies on 0.3.x.

## PR Info

<!-- mention the related issue -->
- Closes #340

## Adds

- [x] create a feature `with-time-0_2` to use `time@^0.2`
- [x] create a feature `with-time-0_3` to use `time@^0.3`
