### PR TITLE
create a feature to support uuid@1 and uuid@0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,8 @@ chrono = { version = "^0", optional = true }
 postgres-types = { version = "^0", optional = true }
 rust_decimal = { version = "^1", optional = true }
 bigdecimal = { version = "^0.2", optional = true }
-uuid = { version = "^0", optional = true }
+uuid-0_8 = { package = "uuid", version = "^0.8", optional = true }
+uuid-1 = { package = "uuid", version = "^1", optional = true }
 proc-macro2 = { version = "1", optional = true }
 quote = { version = "^1", optional = true }
 time = { version = "^0.2", optional = true }
@@ -67,7 +68,9 @@ postgres-chrono = ["with-chrono", "postgres-types/with-chrono-0_4"]
 postgres-json = ["with-json", "postgres-types/with-serde_json-1"]
 postgres-rust_decimal = ["with-rust_decimal", "rust_decimal/db-postgres"]
 postgres-bigdecimal = ["with-bigdecimal"]
-postgres-uuid = ["with-uuid", "postgres-types/with-uuid-0_8"]
+postgres-uuid-0_8 = ["with-uuid-0_8", "postgres-types/with-uuid-0_8"]
+postgres-uuid-1 = ["with-uuid-1", "postgres-types/with-uuid-1"]
+postgres-uuid = ["postgres-uuid-1"]
 postgres-array = ["postgres-types/array-impls", "sea-query-driver?/postgres-array"]
 postgres-interval = ["proc-macro2", "quote"]
 postgres-time = ["with-time", "postgres-types/with-time-0_2"]
@@ -80,7 +83,9 @@ with-chrono = ["chrono", "sea-query-driver?/with-chrono"]
 with-json = ["serde_json", "sea-query-driver?/with-json"]
 with-rust_decimal = ["rust_decimal", "sea-query-driver?/with-rust_decimal"]
 with-bigdecimal = ["bigdecimal", "sea-query-driver?/with-bigdecimal"]
-with-uuid = ["uuid", "sea-query-driver?/with-uuid"]
+with-uuid-0_8 = ["uuid-0_8", "sea-query-driver?/with-uuid"]
+with-uuid-1 = ["uuid-1", "sea-query-driver?/with-uuid"]
+with-uuid = ["with-uuid-1"]
 with-time = ["time", "sea-query-driver?/with-time"]
 
 [[test]]

--- a/examples/postgres_json/Cargo.toml
+++ b/examples/postgres_json/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 chrono = "^0"
 time = "^0.2"
-uuid = { version = "^0", features = ["serde", "v4"] }
+uuid = { version = "^1", features = ["serde", "v4"] }
 serde_json = "^1"
 rust_decimal = { version = "^1" }
 postgres = "^0.19"

--- a/examples/rusqlite/Cargo.toml
+++ b/examples/rusqlite/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 chrono = { version = "^0" }
 time = { version = "^0.2" }
 serde_json = { version = "^1" }
-uuid = { version = "^0", features = ["serde", "v4"] }
+uuid = { version = "^1", features = ["serde", "v4"] }
 sea-query = { path = "../../", features = [
     "rusqlite",
     "with-chrono",

--- a/examples/sqlx_mysql/Cargo.toml
+++ b/examples/sqlx_mysql/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 chrono = "^0"
 time = "^0.2"
-uuid = { version = "^0", features = ["serde", "v4"] }
+uuid = { version = "^1", features = ["serde", "v4"] }
 serde_json = "^1"
 rust_decimal = { version = "^1" }
 bigdecimal = { version = "^0.2" }

--- a/examples/sqlx_postgres/Cargo.toml
+++ b/examples/sqlx_postgres/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 chrono = "^0"
 time = "^0.2"
-uuid = { version = "^0", features = ["serde", "v4"] }
+uuid = { version = "^1", features = ["serde", "v4"] }
 serde_json = "^1"
 rust_decimal = { version = "^1" }
 bigdecimal = { version = "^0.2" }

--- a/examples/sqlx_sqlite/Cargo.toml
+++ b/examples/sqlx_sqlite/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 chrono = "^0"
 time = "^0.2"
-uuid = { version = "^0", features = ["serde", "v4"] }
+uuid = { version = "^1", features = ["serde", "v4"] }
 serde_json = "^1"
 async-std = { version = "1.8", features = [ "attributes" ] }
 sea-query = { path = "../../", features = [

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1080,7 +1080,7 @@ pub trait QueryBuilder: QuotedBuilder {
             Value::Decimal(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-bigdecimal")]
             Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-uuid")]
+            #[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
             Value::Uuid(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-ipnetwork")]
             Value::Ipv4Network(None) => write!(s, "NULL").unwrap(),
@@ -1146,7 +1146,7 @@ pub trait QueryBuilder: QuotedBuilder {
             Value::Decimal(Some(v)) => write!(s, "{}", v).unwrap(),
             #[cfg(feature = "with-bigdecimal")]
             Value::BigDecimal(Some(v)) => write!(s, "{}", v).unwrap(),
-            #[cfg(feature = "with-uuid")]
+            #[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
             Value::Uuid(Some(v)) => write!(s, "\'{}\'", v).unwrap(),
             #[cfg(feature = "postgres-array")]
             Value::Array(Some(v)) => write!(

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "with-uuid-0_8")]
+pub use uuid_0_8 as uuid;
+
+#[cfg(feature = "with-uuid-1")]
+pub use uuid_1 as uuid;

--- a/src/driver/postgres.rs
+++ b/src/driver/postgres.rs
@@ -72,7 +72,7 @@ impl ToSql for Value {
             #[cfg(feature = "postgres-bigdecimal")]
             Value::BigDecimal(_) => unimplemented!("Not supported"),
             #[cfg(feature = "postgres-uuid")]
-            Value::Uuid(v) => box_to_sql!(v, uuid::Uuid),
+            Value::Uuid(v) => box_to_sql!(v, crate::deps::uuid::Uuid),
             #[cfg(feature = "postgres-array")]
             Value::Array(v) => box_to_sql!(v, Vec<Value>),
             #[allow(unreachable_patterns)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,6 +741,7 @@
 )]
 
 pub mod backend;
+mod deps;
 pub mod driver;
 pub mod error;
 pub mod expr;

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -5,6 +5,9 @@ pub use std::fmt::Write as FmtWrite;
 #[cfg(feature = "with-json")]
 pub use serde_json::json;
 
+#[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
+pub use crate::deps::uuid;
+
 use crate::Iden;
 
 /// Representation of a database table named `Character`.

--- a/src/value.rs
+++ b/src/value.rs
@@ -18,8 +18,8 @@ use rust_decimal::Decimal;
 #[cfg(feature = "with-bigdecimal")]
 use bigdecimal::BigDecimal;
 
-#[cfg(feature = "with-uuid")]
-use uuid::Uuid;
+#[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
+use crate::deps::uuid::Uuid;
 
 #[cfg(feature = "with-ipnetwork")]
 use ipnetwork::{Ipv4Network, Ipv6Network};
@@ -97,8 +97,11 @@ pub enum Value {
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeDateTimeWithTimeZone(Option<Box<OffsetDateTime>>),
 
-    #[cfg(feature = "with-uuid")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
+    #[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1")))
+    )]
     Uuid(Option<Box<Uuid>>),
 
     #[cfg(feature = "with-rust_decimal")]
@@ -482,8 +485,11 @@ mod with_bigdecimal {
     type_to_box_value!(BigDecimal, BigDecimal, Decimal(None));
 }
 
-#[cfg(feature = "with-uuid")]
-#[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
+#[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1")))
+)]
 mod with_uuid {
     use super::*;
 
@@ -545,7 +551,7 @@ mod with_array {
     #[cfg(feature = "with-bigdecimal")]
     impl NotU8 for BigDecimal {}
 
-    #[cfg(feature = "with-uuid")]
+    #[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
     impl NotU8 for Uuid {}
 
     impl<T> From<Vec<T>> for Value
@@ -821,7 +827,7 @@ impl Value {
     }
 }
 
-#[cfg(feature = "with-uuid")]
+#[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
 impl Value {
     pub fn is_uuid(&self) -> bool {
         matches!(self, Self::Uuid(_))
@@ -1197,7 +1203,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::Decimal(None) => Json::Null,
         #[cfg(feature = "with-bigdecimal")]
         Value::BigDecimal(None) => Json::Null,
-        #[cfg(feature = "with-uuid")]
+        #[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
         Value::Uuid(None) => Json::Null,
         #[cfg(feature = "postgres-array")]
         Value::Array(None) => Json::Null,
@@ -1251,7 +1257,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
             use bigdecimal::ToPrimitive;
             v.as_ref().to_f64().unwrap().into()
         }
-        #[cfg(feature = "with-uuid")]
+        #[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
         Value::Uuid(Some(v)) => Json::String(v.to_string()),
         #[cfg(feature = "postgres-array")]
         Value::Array(Some(v)) => {
@@ -1666,11 +1672,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "with-uuid")]
+    #[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
     fn test_uuid_value() {
-        let uuid = uuid::Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap();
+        let uuid = crate::deps::uuid::Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap();
         let value: Value = uuid.into();
-        let out: uuid::Uuid = value.unwrap();
+        let out: crate::deps::uuid::Uuid = value.unwrap();
         assert_eq!(out, uuid);
     }
 

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1069,13 +1069,13 @@ fn insert_8() {
 }
 
 #[test]
-#[cfg(feature = "with-uuid")]
+#[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
 fn insert_5() {
     assert_eq!(
         Query::insert()
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
-            .values_panic(vec![uuid::Uuid::nil().into()])
+            .values_panic(vec![crate::tests_cfg::uuid::Uuid::nil().into()])
             .to_string(MysqlQueryBuilder),
         "INSERT INTO `glyph` (`image`) VALUES ('00000000-0000-0000-0000-000000000000')"
     );

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1123,13 +1123,13 @@ fn insert_9() {
 }
 
 #[test]
-#[cfg(feature = "with-uuid")]
+#[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
 fn insert_5() {
     assert_eq!(
         Query::insert()
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
-            .values_panic(vec![uuid::Uuid::nil().into()])
+            .values_panic(vec![crate::tests_cfg::uuid::Uuid::nil().into()])
             .to_string(PostgresQueryBuilder),
         "INSERT INTO \"glyph\" (\"image\") VALUES ('00000000-0000-0000-0000-000000000000')"
     );

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1077,13 +1077,13 @@ fn insert_from_select() {
 }
 
 #[test]
-#[cfg(feature = "with-uuid")]
+#[cfg(any(feature = "with-uuid-0_8", feature = "with-uuid-1"))]
 fn insert_5() {
     assert_eq!(
         Query::insert()
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
-            .values_panic(vec![uuid::Uuid::nil().into()])
+            .values_panic(vec![crate::tests_cfg::uuid::Uuid::nil().into()])
             .to_string(SqliteQueryBuilder),
         r#"INSERT INTO "glyph" ("image") VALUES ('00000000-0000-0000-0000-000000000000')"#
     );


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-query/issues/325

## Adds

- [ ] Support for Uuid v1.0

## Breaking Changes

- [ ] Every downstream project using uuid@0.8 will need to use the feature `with-uuid-0_8`
