### PR TITLE
Add is / is_not to Expr

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1169,6 +1169,40 @@ impl Expr {
         self.bin_oper(BinOper::Is, SimpleExpr::Keyword(Keyword::Null))
     }
 
+    /// Express a `IS` expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::tbl(Char::Table, Char::Id).is(1))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`id` IS 1"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."id" IS 1"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."id" IS 1"#
+    /// );
+    /// ```
+    #[cfg(feature = "backend-sqlite")]
+    pub fn is<V>(self, v: V) -> SimpleExpr
+    where
+        V: Into<Value>,
+    {
+        self.bin_oper(BinOper::Is, SimpleExpr::Value(v.into()))
+    }
+
     /// Express a `IS NOT NULL` expression.
     ///
     /// # Examples
@@ -1198,6 +1232,40 @@ impl Expr {
     #[allow(clippy::wrong_self_convention)]
     pub fn is_not_null(self) -> SimpleExpr {
         self.bin_oper(BinOper::IsNot, SimpleExpr::Keyword(Keyword::Null))
+    }
+
+    /// Express a `IS NOT` expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::tbl(Char::Table, Char::Id).is_not(1))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`id` IS NOT 1"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."id" IS NOT 1"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."id" IS NOT 1"#
+    /// );
+    /// ```
+    #[cfg(feature = "backend-sqlite")]
+    pub fn is_not<V>(self, v: V) -> SimpleExpr
+    where
+        V: Into<Value>,
+    {
+        self.bin_oper(BinOper::IsNot, SimpleExpr::Value(v.into()))
     }
 
     /// Create any binary operation

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1179,23 +1179,22 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::tbl(Char::Table, Char::Id).is(1))
+    ///     .and_where(Expr::tbl(Char::Table, Char::Ascii).is(true))
     ///     .to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`id` IS 1"#
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`ascii` IS TRUE"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."id" IS 1"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."ascii" IS TRUE"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."id" IS 1"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."ascii" IS TRUE"#
     /// );
     /// ```
-    #[cfg(feature = "backend-sqlite")]
     pub fn is<V>(self, v: V) -> SimpleExpr
     where
         V: Into<Value>,
@@ -1260,7 +1259,6 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."id" IS NOT 1"#
     /// );
     /// ```
-    #[cfg(feature = "backend-sqlite")]
     pub fn is_not<V>(self, v: V) -> SimpleExpr
     where
         V: Into<Value>,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1243,20 +1243,20 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::tbl(Char::Table, Char::Id).is_not(1))
+    ///     .and_where(Expr::tbl(Char::Table, Char::Ascii).is_not(true))
     ///     .to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`id` IS NOT 1"#
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`ascii` IS NOT TRUE"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."id" IS NOT 1"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."ascii" IS NOT TRUE"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."id" IS NOT 1"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."ascii" IS NOT TRUE"#
     /// );
     /// ```
     pub fn is_not<V>(self, v: V) -> SimpleExpr

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -21,6 +21,7 @@ pub enum Character {
     SizeW,
     SizeH,
     FontId,
+    Ascii,
     CreatedAt,
 }
 
@@ -40,6 +41,7 @@ impl Iden for Character {
                 Self::SizeW => "size_w",
                 Self::SizeH => "size_h",
                 Self::FontId => "font_id",
+                Self::Ascii => "ascii",
                 Self::CreatedAt => "created_at",
             }
         )


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->
For Sqlite, they are the same as `eq` and `neq` but treat NULL differently.
I put them behind a flag since I don't think other DBMS allow random values with those operators.

## Adds

- `IS` and `IS NOT` operators for `Sqlite`
