### PR TITLE
Add `CURRENT_TIMESTAMP` function

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -280,7 +280,9 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder {
             }
             SimpleExpr::FunctionCall(func, exprs) => {
                 self.prepare_function(func, sql, collector);
-                self.prepare_tuple(exprs, sql, collector);
+                if !exprs.is_empty() {
+                    self.prepare_tuple(exprs, sql, collector);
+                }
             }
             SimpleExpr::Binary(left, op, right) => {
                 if *op == BinOper::In && right.is_values() && right.get_values().is_empty() {
@@ -713,6 +715,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder {
                     Function::Lower => "LOWER",
                     Function::Upper => "UPPER",
                     Function::Custom(_) => "",
+                    Function::CurrentTimestamp => "CURRENT_TIMESTAMP",
                     #[cfg(feature = "backend-postgres")]
                     Function::PgFunction(_) => unimplemented!(),
                 }

--- a/src/func.rs
+++ b/src/func.rs
@@ -21,6 +21,7 @@ pub enum Function {
     Coalesce,
     Lower,
     Upper,
+    CurrentTimestamp,
     #[cfg(feature = "backend-postgres")]
     PgFunction(PgFunction),
 }
@@ -465,5 +466,34 @@ impl Func {
         T: Into<SimpleExpr>,
     {
         Expr::func(Function::Upper).arg(expr)
+    }
+
+    /// Call `CURRENT_TIMESTAMP` function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::tests_cfg::Character::Character;
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Func::current_timestamp())
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT CURRENT_TIMESTAMP"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT CURRENT_TIMESTAMP"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT CURRENT_TIMESTAMP"#
+    /// );
+    /// ```
+    pub fn current_timestamp() -> SimpleExpr {
+        Expr::func(Function::CurrentTimestamp).into()
     }
 }

--- a/src/func.rs
+++ b/src/func.rs
@@ -476,9 +476,7 @@ impl Func {
     /// use sea_query::tests_cfg::Character::Character;
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let query = Query::select()
-    ///     .expr(Func::current_timestamp())
-    ///     .to_owned();
+    /// let query = Query::select().expr(Func::current_timestamp()).to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),


### PR DESCRIPTION
## PR Info

- Dependents:
  - https://github.com/SeaQL/sea-orm/pull/790

## Adds

- [x] Add `CURRENT_TIMESTAMP` function

## Breaking Changes

- [x] `SimpleExpr::FunctionCall(Function, Vec<SimpleExpr>)` with empty `Vec<SimpleExpr>` now would not generate the empty tuple, i.e. `()`