### PR TITLE
Add support for VALUES lists

### DIFF
--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -108,4 +108,8 @@ impl QueryBuilder for MysqlQueryBuilder {
             _ => {}
         };
     }
+
+    fn values_list_tuple_prefix(&self) -> &str {
+        "ROW"
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Base types used throughout sea-query.
 
-use crate::{expr::*, query::*, Values};
+use crate::{expr::*, query::*, ValueTuple, Values};
 use std::fmt;
 
 #[cfg(not(feature = "thread-safe"))]
@@ -89,6 +89,8 @@ pub enum TableRef {
     DatabaseSchemaTableAlias(DynIden, DynIden, DynIden, DynIden),
     /// Subquery with alias
     SubQuery(SelectStatement, DynIden),
+    /// Values list with alias
+    ValuesList(Vec<ValueTuple>, DynIden),
 }
 
 pub trait IntoTableRef {
@@ -343,6 +345,7 @@ impl TableRef {
                 Self::DatabaseSchemaTableAlias(database, schema, table, alias.into_iden())
             }
             Self::SubQuery(statement, _) => Self::SubQuery(statement, alias.into_iden()),
+            Self::ValuesList(values, _) => Self::ValuesList(values, alias.into_iden()),
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -151,7 +151,7 @@ impl std::fmt::Display for ValueTypeErr {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Values(pub Vec<Value>);
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ValueTuple {
     One(Value),
     Two(Value, Value),

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1100,6 +1100,7 @@ fn select_62() {
             r#"FROM "cte""#,
         ]
         .join(" ")
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

As title suggests, add support for VALUES lists. I realized in implementation, this is actually supported by all three databases. Here are the [doc test outputs](https://github.com/SeaQL/sea-query/compare/master...samtay:samtay/support-values-lists?expand=1#diff-a8c210c287ba3601876e953b1aa6476a85a31256a48b47d846740cdc6c00f2c7R875-R886) on dbfiddle:

1. [mysql](https://dbfiddle.uk/?rdbms=mysql_8.0&fiddle=92074c22f017a0840d54c66ae858d9aa)
2. [postgres](https://dbfiddle.uk/?rdbms=postgres_14&fiddle=61088d050a79706d7bda9ca2934a0db5)
3. [sqlite](https://dbfiddle.uk/?rdbms=sqlite_3.27&fiddle=61088d050a79706d7bda9ca2934a0db5)

<!-- mention the related issue -->
- Closes #350 

## Adds

- [x] Support for VALUES lists in FROM clauses.

## Breaking Changes

- [x] Technically yes, I think, because the enum `TableRef` has a new variant.