### PR TITLE
Add escape to SimpleExpr

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -637,6 +637,7 @@ pub trait QueryBuilder: QuotedBuilder {
                 BinOper::Mul => "*",
                 BinOper::Div => "/",
                 BinOper::As => "AS",
+                BinOper::Escape => "ESCAPE",
                 #[allow(unreachable_patterns)]
                 _ => unimplemented!(),
             }
@@ -1464,7 +1465,7 @@ pub trait QueryBuilder: QuotedBuilder {
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     ) {
-        let no_paren = matches!(op, BinOper::Equal | BinOper::NotEqual);
+        let no_paren = matches!(op, BinOper::Equal | BinOper::NotEqual | BinOper::Escape);
         let left_paren = left.need_parentheses()
             && left.is_binary()
             && *op != left.get_bin_oper().unwrap()

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2108,6 +2108,36 @@ impl SimpleExpr {
         self.binary(BinOper::Sub, right.into())
     }
 
+    /// Select an espace character in a LIKE.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::tbl(Char::Table, Char::Character).like(r"|_Our|_").escape('|'))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`character` LIKE '|_Our|_' ESCAPE '|'"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE '|_Our|_' ESCAPE '|'"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE '|_Our|_' ESCAPE '|'"#
+    /// );
+    /// ```
+    pub fn escape(self, character: char) -> Self {
+        self.binary(BinOper::Escape, Self::Custom(format!("\'{character}\'")))
+    }
+
     pub(crate) fn binary(self, op: BinOper, right: SimpleExpr) -> Self {
         SimpleExpr::Binary(Box::new(self), op, Box::new(right))
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -125,6 +125,7 @@ pub enum BinOper {
     Mul,
     Div,
     As,
+    Escape,
     #[cfg(feature = "backend-postgres")]
     Matches,
     #[cfg(feature = "backend-postgres")]

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -998,6 +998,18 @@ fn select_57() {
 }
 
 #[test]
+fn select_58() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).like("A").escape('\\'))
+            .to_string(MysqlQueryBuilder),
+        r#"SELECT `character` FROM `character` WHERE `character` LIKE 'A' ESCAPE '\'"#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1061,6 +1061,18 @@ fn select_60() {
 }
 
 #[test]
+fn select_61() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).like("A").escape('\\'))
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "character" FROM "character" WHERE "character" LIKE 'A' ESCAPE '\'"#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -986,6 +986,18 @@ fn select_57() {
 }
 
 #[test]
+fn select_58() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).like("A").escape('\\'))
+            .to_string(SqliteQueryBuilder),
+        r#"SELECT "character" FROM "character" WHERE "character" LIKE 'A' ESCAPE '\'"#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

- Related:
  - https://github.com/SeaQL/sea-query/pull/94
  - https://github.com/SeaQL/sea-query/pull/318

## Adds

Adds `.escape` to `SimpleExpr`, this allows `LIKE` statements to contain literal characters such as `%`.

As we discussed on [Discord](https://discord.com/channels/873880840487206962/900758332187484160/985904392697946192) and in the linked PR, we will start with this simple escape implementation and maybe down the line we will rework the structure of sea-query to be based on traits that we can easily add to specific structures (for example `.like()` would return a `LikeQueryPart` which implements the `.escape()` method and a trait `Joinable` to get the `.or()`, `.and()`, etc.).

For the now, the responsibility is on the user to not do stupid syntax.
