### PR TITLE
Support LIKE ESCAPE

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -36,6 +36,8 @@ pub enum SimpleExpr {
     Keyword(Keyword),
     AsEnum(DynIden, Box<SimpleExpr>),
     Case(Box<CaseStatement>),
+    Like(Box<SimpleExpr>, LikeExpr),
+    NotLike(Box<SimpleExpr>, LikeExpr),
 }
 
 impl Expr {
@@ -1124,18 +1126,12 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE 'Ours''%'"#
     /// );
     /// ```
-    pub fn like(self, v: &str) -> SimpleExpr {
-        self.bin_oper(
-            BinOper::Like,
-            SimpleExpr::Value(Value::String(Some(Box::new(v.to_owned())))),
-        )
+    pub fn like<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
+        SimpleExpr::Like(Box::new(self.left.unwrap()), like.into_like_expr())
     }
 
-    pub fn not_like(self, v: &str) -> SimpleExpr {
-        self.bin_oper(
-            BinOper::NotLike,
-            SimpleExpr::Value(Value::String(Some(Box::new(v.to_owned())))),
-        )
+    pub fn not_like<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
+        SimpleExpr::NotLike(Box::new(self.left.unwrap()), like.into_like_expr())
     }
 
     /// Express a `IS NULL` expression.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,10 +110,9 @@
 //!         .and_where(Expr::col(Glyph::Id).is_in(vec![1, 2, 3]))
 //!         .build(PostgresQueryBuilder),
 //!     (
-//!         r#"SELECT "image" FROM "glyph" WHERE "image" LIKE $1 AND "id" IN ($2, $3, $4)"#
+//!         r#"SELECT "image" FROM "glyph" WHERE "image" LIKE 'A' AND "id" IN ($1, $2, $3)"#
 //!             .to_owned(),
 //!         Values(vec![
-//!             Value::String(Some(Box::new("A".to_owned()))),
 //!             Value::Int(Some(1)),
 //!             Value::Int(Some(2)),
 //!             Value::Int(Some(3))
@@ -263,7 +262,7 @@
 //!         r#"SELECT "character" FROM "character""#,
 //!         r#"WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#,
 //!         r#"AND "size_w" IN (SELECT ln(2.4 ^ 1.2))"#,
-//!         r#"AND (("character" LIKE 'D') AND ("character" LIKE 'E'))"#,
+//!         r#"AND ("character" LIKE 'D' AND "character" LIKE 'E')"#,
 //!     ]
 //!     .join(" ")
 //! );

--- a/src/types.rs
+++ b/src/types.rs
@@ -106,8 +106,6 @@ pub enum UnOper {
 pub enum BinOper {
     And,
     Or,
-    Like,
-    NotLike,
     Is,
     IsNot,
     In,
@@ -194,6 +192,17 @@ pub struct NullAlias;
 pub enum Keyword {
     Null,
     Custom(DynIden),
+}
+
+/// Like Expression
+#[derive(Debug, Clone)]
+pub struct LikeExpr {
+    pub(crate) pattern: String,
+    pub(crate) escape: Option<char>,
+}
+
+pub trait IntoLikeExpr {
+    fn into_like_expr(self) -> LikeExpr;
 }
 
 // Impl begins
@@ -373,6 +382,40 @@ impl Default for NullAlias {
 
 impl Iden for NullAlias {
     fn unquoted(&self, _s: &mut dyn fmt::Write) {}
+}
+
+impl LikeExpr {
+    pub fn new(pattern: &str) -> Self {
+        Self {
+            pattern: pattern.to_owned(),
+            escape: None,
+        }
+    }
+
+    pub fn escape(self, c: char) -> Self {
+        Self {
+            pattern: self.pattern,
+            escape: Some(c),
+        }
+    }
+}
+
+impl IntoLikeExpr for LikeExpr {
+    fn into_like_expr(self) -> LikeExpr {
+        self
+    }
+}
+
+impl IntoLikeExpr for &str {
+    fn into_like_expr(self) -> LikeExpr {
+        LikeExpr::new(self)
+    }
+}
+
+impl IntoLikeExpr for String {
+    fn into_like_expr(self) -> LikeExpr {
+        LikeExpr::new(&self)
+    }
 }
 
 #[cfg(test)]

--- a/src/value.rs
+++ b/src/value.rs
@@ -1177,7 +1177,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::Float(Some(v)) => (*v).into(),
         Value::Double(Some(v)) => (*v).into(),
         Value::String(Some(s)) => Json::String(s.as_ref().clone()),
-        Value::Char(Some(c)) => Json::String(s.to_string()),
+        Value::Char(Some(v)) => Json::String(v.to_string()),
         Value::Bytes(Some(s)) => Json::String(from_utf8(s).unwrap().to_string()),
         Value::Json(Some(v)) => v.as_ref().clone(),
         #[cfg(feature = "with-chrono")]

--- a/src/value.rs
+++ b/src/value.rs
@@ -1149,7 +1149,6 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         | Value::Double(None)
         | Value::String(None)
         | Value::Char(None)
-        | Value::Char(None)
         | Value::Bytes(None)
         | Value::Json(None) => Json::Null,
         #[cfg(feature = "with-rust_decimal")]

--- a/src/value.rs
+++ b/src/value.rs
@@ -48,6 +48,7 @@ pub enum Value {
     Float(Option<f32>),
     Double(Option<f64>),
     String(Option<Box<String>>),
+    Char(Option<char>),
 
     #[allow(clippy::box_collection)]
     Bytes(Option<Box<Vec<u8>>>),
@@ -263,6 +264,7 @@ type_to_value!(u32, Unsigned, Unsigned(None));
 type_to_value!(u64, BigUnsigned, BigUnsigned(None));
 type_to_value!(f32, Float, Float(None));
 type_to_value!(f64, Double, Double(None));
+type_to_value!(char, Char, Char(None));
 
 impl<'a> From<&'a [u8]> for Value {
     fn from(x: &'a [u8]) -> Value {
@@ -1146,6 +1148,8 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         | Value::Float(None)
         | Value::Double(None)
         | Value::String(None)
+        | Value::Char(None)
+        | Value::Char(None)
         | Value::Bytes(None)
         | Value::Json(None) => Json::Null,
         #[cfg(feature = "with-rust_decimal")]
@@ -1174,6 +1178,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::Float(Some(v)) => (*v).into(),
         Value::Double(Some(v)) => (*v).into(),
         Value::String(Some(s)) => Json::String(s.as_ref().clone()),
+        Value::Char(Some(c)) => Json::String(s.to_string()),
         Value::Bytes(Some(s)) => Json::String(from_utf8(s).unwrap().to_string()),
         Value::Json(Some(v)) => v.as_ref().clone(),
         #[cfg(feature = "with-chrono")]

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -324,7 +324,7 @@ fn select_22() {
                 )
             )
             .to_string(MysqlQueryBuilder),
-        "SELECT `character` FROM `character` WHERE (`character` LIKE 'C' OR ((`character` LIKE 'D') AND (`character` LIKE 'E'))) AND ((`character` LIKE 'F') OR (`character` LIKE 'G'))"
+        "SELECT `character` FROM `character` WHERE (`character` LIKE 'C' OR (`character` LIKE 'D' AND `character` LIKE 'E')) AND (`character` LIKE 'F' OR `character` LIKE 'G')"
     );
 }
 

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -315,7 +315,7 @@ fn select_22() {
                     )
             )
             .to_string(PostgresQueryBuilder),
-        r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR (("character" LIKE 'D') AND ("character" LIKE 'E'))) AND (("character" LIKE 'F') OR ("character" LIKE 'G'))"#
+        r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR ("character" LIKE 'D' AND "character" LIKE 'E')) AND ("character" LIKE 'F' OR "character" LIKE 'G')"#
     );
 }
 

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -315,7 +315,7 @@ fn select_22() {
                     )
             )
             .to_string(SqliteQueryBuilder),
-        r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR (("character" LIKE 'D') AND ("character" LIKE 'E'))) AND (("character" LIKE 'F') OR ("character" LIKE 'G'))"#
+        r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR ("character" LIKE 'D' AND "character" LIKE 'E')) AND ("character" LIKE 'F' OR "character" LIKE 'G')"#
     );
 }
 


### PR DESCRIPTION
## PR Info

- Related:
  - https://github.com/SeaQL/sea-query/pull/94
  - https://github.com/SeaQL/sea-query/pull/318
  - https://github.com/SeaQL/sea-query/pull/352

## Adds

1. Move Like from `BinOp` into `SimpleExpr`
2. Add new struct: `LikeExpr`
3. Add new trait: `IntoLikeExpr`