### PR TITLE
Add support Value::Char to backends

### DIFF
--- a/sea-query-driver/src/rusqlite.rs
+++ b/sea-query-driver/src/rusqlite.rs
@@ -106,6 +106,7 @@ pub fn sea_query_driver_rusqlite_impl(input: TokenStream) -> TokenStream {
                         Value::Float(v) => v.to_sql(),
                         Value::Double(v) => v.to_sql(),
                         Value::String(v) => box_to_sql!(v),
+                        Value::Char(v) => opt_string_to_sql!(v.map(|v| v.to_string())),
                         Value::Bytes(v) => box_to_sql!(v),
                         #with_json
                         #with_chrono

--- a/sea-query-driver/src/sqlx_mysql.rs
+++ b/sea-query-driver/src/sqlx_mysql.rs
@@ -90,6 +90,7 @@ pub fn bind_params_sqlx_mysql_impl(input: TokenStream) -> TokenStream {
                     Value::Float(v) => bind!(v, f32),
                     Value::Double(v) => bind!(v, f64),
                     Value::String(v) => bind_box!(v),
+                    Value::Char(v) => query.bind(v.map(|v|v.to_string())),
                     Value::Bytes(v) => bind_box!(v),
                     #with_json
                     #with_chrono

--- a/sea-query-driver/src/sqlx_postgres.rs
+++ b/sea-query-driver/src/sqlx_postgres.rs
@@ -106,6 +106,7 @@ pub fn bind_params_sqlx_postgres_impl(input: TokenStream) -> TokenStream {
                     Value::Float(v) => bind!(v, f32),
                     Value::Double(v) => bind!(v, f64),
                     Value::String(v) => bind_box!(v),
+                    Value::Char(v) => query.bind(v.map(|v|v.to_string())),
                     Value::Bytes(v) => bind_box!(v),
                     #with_json
                     #with_chrono

--- a/sea-query-driver/src/sqlx_sqlite.rs
+++ b/sea-query-driver/src/sqlx_sqlite.rs
@@ -90,6 +90,7 @@ pub fn bind_params_sqlx_sqlite(input: TokenStream) -> TokenStream {
                     Value::Float(v) => bind!(v, f32),
                     Value::Double(v) => bind!(v, f64),
                     Value::String(v) => bind_box!(v),
+                    Value::Char(v) => query.bind(v.map(|v|v.to_string())),
                     Value::Bytes(v) => bind_box!(v),
                     #with_json
                     #with_chrono

--- a/src/driver/postgres.rs
+++ b/src/driver/postgres.rs
@@ -16,8 +16,14 @@ impl ToSql for Value {
         macro_rules! to_sql {
             ( $v: expr, $ty: ty ) => {
                 match $v {
-                    Some(v) => (*v as $ty).to_sql(ty, out),
+                    Some(v) => (v as $ty).to_sql(ty, out),
                     None => None::<$ty>.to_sql(ty, out),
+                }
+            };
+            ( $v: expr ) => {
+                match $v {
+                    Some(v) => v.to_sql(ty, out),
+                    None => None.to_sql(ty, out),
                 }
             };
         }
@@ -30,18 +36,19 @@ impl ToSql for Value {
             };
         }
         match self {
-            Value::Bool(v) => to_sql!(v, bool),
-            Value::TinyInt(v) => to_sql!(v, i8),
-            Value::SmallInt(v) => to_sql!(v, i16),
-            Value::Int(v) => to_sql!(v, i32),
-            Value::BigInt(v) => to_sql!(v, i64),
-            Value::TinyUnsigned(v) => to_sql!(v, u32),
-            Value::SmallUnsigned(v) => to_sql!(v, u32),
-            Value::Unsigned(v) => to_sql!(v, u32),
-            Value::BigUnsigned(v) => to_sql!(v, i64),
-            Value::Float(v) => to_sql!(v, f32),
-            Value::Double(v) => to_sql!(v, f64),
+            Value::Bool(v) => to_sql!(*v, bool),
+            Value::TinyInt(v) => to_sql!(*v, i8),
+            Value::SmallInt(v) => to_sql!(*v, i16),
+            Value::Int(v) => to_sql!(*v, i32),
+            Value::BigInt(v) => to_sql!(*v, i64),
+            Value::TinyUnsigned(v) => to_sql!(*v, u32),
+            Value::SmallUnsigned(v) => to_sql!(*v, u32),
+            Value::Unsigned(v) => to_sql!(*v, u32),
+            Value::BigUnsigned(v) => to_sql!(*v, i64),
+            Value::Float(v) => to_sql!(*v, f32),
+            Value::Double(v) => to_sql!(*v, f64),
             Value::String(v) => box_to_sql!(v, String),
+            Value::Char(v) => to_sql!(v.map(|v| v.to_string()), String),
             Value::Bytes(v) => box_to_sql!(v, Vec<u8>),
             #[cfg(feature = "postgres-json")]
             Value::Json(v) => box_to_sql!(v, serde_json::Value),


### PR DESCRIPTION
## PR Info

Continue work on: https://github.com/SeaQL/sea-query/pull/353#discussion_r901134034

## Adds

- Add support `Value::Char` to backends.
