### PR TITLE
Add method to make a column nullable

### DIFF
--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -142,6 +142,12 @@ impl ColumnDef {
         self
     }
 
+    /// Set column null
+    pub fn null(&mut self) -> &mut Self {
+        self.spec.push(ColumnSpec::Null);
+        self
+    }
+
     /// Set default value of a column
     pub fn default<T>(&mut self, value: T) -> &mut Self
     where


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
Context: https://github.com/SeaQL/sea-orm/discussions/824

## Adds

- added method to make a column nullable