### PR TITLE
sea-query-binder: fix i64 conversion

### DIFF
--- a/sea-query-binder/src/sqlx_any.rs
+++ b/sea-query-binder/src/sqlx_any.rs
@@ -32,7 +32,7 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::any::Any> for SqlxValues {
                     args.add(i.map(Into::<i64>::into));
                 }
                 Value::BigUnsigned(i) => {
-                    args.add(i as i64);
+                    args.add(i.map(|u| u as i64));
                 }
                 Value::Float(f) => {
                     args.add(f);

--- a/sea-query-binder/src/sqlx_postgres.rs
+++ b/sea-query-binder/src/sqlx_postgres.rs
@@ -32,7 +32,7 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::postgres::Postgres> for SqlxValues {
                     args.add(i.map(|i| i as i64));
                 }
                 Value::BigUnsigned(i) => {
-                    args.add(i as i64);
+                    args.add(i.map(|u| u as i64));
                 }
                 Value::Float(f) => {
                     args.add(f);

--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -32,7 +32,7 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                     args.add(i);
                 }
                 Value::BigUnsigned(i) => {
-                    args.add(i as i64);
+                    args.add(i.map(|u| u as i64));
                 }
                 Value::Float(f) => {
                     args.add(f);


### PR DESCRIPTION
## PR Info

## Fixes

- Fixes compilation error on https://github.com/SeaQL/sea-query/pull/371

This time I checked by building the example, not just the binder crate.