### PR TITLE
issues-118 Add SubQuery operator

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -20,18 +20,13 @@ impl QueryBuilder for PostgresQueryBuilder {
         write!(buffer, "{}", string).unwrap()
     }
 
-    fn prepare_bin_oper(
-        &self,
-        bin_oper: &BinOper,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_bin_oper(&self, bin_oper: &BinOper, sql: &mut SqlWriter) {
         match bin_oper {
             BinOper::Matches => write!(sql, "@@").unwrap(),
             BinOper::Contains => write!(sql, "@>").unwrap(),
             BinOper::Contained => write!(sql, "<@").unwrap(),
             BinOper::Concatenate => write!(sql, "||").unwrap(),
-            _ => self.prepare_bin_oper_common(bin_oper, sql, collector),
+            _ => self.prepare_bin_oper_common(bin_oper, sql),
         }
     }
 

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -313,7 +313,10 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                     self.binary_expr(left, op, right, sql, collector);
                 }
             }
-            SimpleExpr::SubQuery(sel) => {
+            SimpleExpr::SubQuery(oper, sel) => {
+                if let Some(oper) = oper {
+                    self.prepare_sub_query_oper(oper, sql);
+                }
                 write!(sql, "(").unwrap();
                 self.prepare_query_statement(sel.deref(), sql, collector);
                 write!(sql, ")").unwrap();
@@ -579,12 +582,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         .unwrap();
     }
 
-    fn prepare_bin_oper_common(
-        &self,
-        bin_oper: &BinOper,
-        sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_bin_oper_common(&self, bin_oper: &BinOper, sql: &mut SqlWriter) {
         write!(
             sql,
             "{}",
@@ -622,13 +620,23 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`BinOper`] into SQL statement.
-    fn prepare_bin_oper(
-        &self,
-        bin_oper: &BinOper,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        self.prepare_bin_oper_common(bin_oper, sql, collector);
+    fn prepare_bin_oper(&self, bin_oper: &BinOper, sql: &mut SqlWriter) {
+        self.prepare_bin_oper_common(bin_oper, sql);
+    }
+
+    /// Translate [`SubQueryOper`] into SQL statement.
+    fn prepare_sub_query_oper(&self, oper: &SubQueryOper, sql: &mut SqlWriter) {
+        write!(
+            sql,
+            "{}",
+            match oper {
+                SubQueryOper::Exists => "EXISTS",
+                SubQueryOper::Any => "ANY",
+                SubQueryOper::Some => "SOME",
+                SubQueryOper::All => "ALL",
+            }
+        )
+        .unwrap();
     }
 
     /// Translate [`LogicalChainOper`] into SQL statement.
@@ -1498,7 +1506,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             write!(sql, ")").unwrap();
         }
         write!(sql, " ").unwrap();
-        self.prepare_bin_oper(op, sql, collector);
+        self.prepare_bin_oper(op, sql);
         write!(sql, " ").unwrap();
         let no_right_paren = matches!(
             op,

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -54,4 +54,18 @@ impl QueryBuilder for SqliteQueryBuilder {
         // SQLite doesn't support inserting multiple rows with default values
         write!(sql, "DEFAULT VALUES").unwrap()
     }
+
+    fn prepare_sub_query_oper(&self, oper: &SubQueryOper, sql: &mut SqlWriter) {
+        write!(
+            sql,
+            "{}",
+            match oper {
+                SubQueryOper::Exists => "EXISTS",
+                SubQueryOper::Any => panic!("Operator 'ANY' doesnot support"),
+                SubQueryOper::Some => panic!("Operator 'SOME' doesnot support"),
+                SubQueryOper::All => panic!("Operator 'ALL' doesnot support"),
+            }
+        )
+        .unwrap();
+    }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -531,9 +531,9 @@ impl Expr {
     /// ```
     pub fn eq<V>(self, v: V) -> SimpleExpr
     where
-        V: Into<Value>,
+        V: Into<SimpleExpr>,
     {
-        self.bin_oper(BinOper::Equal, SimpleExpr::Value(v.into()))
+        self.bin_oper(BinOper::Equal, v.into())
     }
 
     /// Express a not equal (`<>`) expression.
@@ -565,84 +565,10 @@ impl Expr {
     /// ```
     pub fn ne<V>(self, v: V) -> SimpleExpr
     where
-        V: Into<Value>,
+        V: Into<SimpleExpr>,
     {
-        self.bin_oper(BinOper::NotEqual, v.into().into())
+        self.bin_oper(BinOper::NotEqual, v.into())
     }
-
-    /// Express a equal expression for [`SimpleExpr`]
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .column(Char::Id)
-    ///     .from(Char::Table)
-    ///     .and_where(
-    ///         Expr::col(Char::Id)
-    ///             .eq_expr(
-    ///                 Expr::any(
-    ///                     Query::select().column(Char::Id).from(Char::Table).take()
-    ///                 )
-    ///             )
-    ///     )
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `id` FROM `character` WHERE `id` = ANY(SELECT `id` FROM `character`)"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "id" FROM "character" WHERE "id" = ANY(SELECT "id" FROM "character")"#
-    /// );
-    /// ```
-    pub fn eq_expr<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.bin_oper(BinOper::Equal, expr.into())
-    }
-
-    /// Express a not equal expression for [`SimpleExpr`]
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .column(Char::Id)
-    ///     .from(Char::Table)
-    ///     .and_where(
-    ///         Expr::col(Char::Id)
-    ///             .neq_expr(
-    ///                 Expr::any(
-    ///                     Query::select().column(Char::Id).from(Char::Table).take()
-    ///                 )
-    ///             )
-    ///     )
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `id` FROM `character` WHERE `id` <> ANY(SELECT `id` FROM `character`)"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "id" FROM "character" WHERE "id" <> ANY(SELECT "id" FROM "character")"#
-    /// );
-    /// ```
-
-    pub fn neq_expr<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.bin_oper(BinOper::NotEqual, expr.into())
-    }
-
     /// Express a equal expression between two table columns,
     /// you will mainly use this to relate identical value between two table columns.
     ///
@@ -2280,9 +2206,12 @@ impl From<Expr> for SelectExpr {
     }
 }
 
-impl From<Value> for SimpleExpr {
-    fn from(v: Value) -> Self {
-        SimpleExpr::Value(v)
+impl<T> From<T> for SimpleExpr
+where
+    T: Into<Value>,
+{
+    fn from(v: T) -> Self {
+        SimpleExpr::Value(v.into())
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1909,6 +1909,34 @@ impl Expr {
     }
 
     /// Express a `ANY` sub-query expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Char::Id)
+    ///     .from(Char::Table)
+    ///     .and_where(
+    ///         Expr::col(Char::Id)
+    ///             .eq(
+    ///                 Expr::any(
+    ///                     Query::select().column(Char::Id).from(Char::Table).take()
+    ///                 )
+    ///             )
+    ///     )
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `id` FROM `character` WHERE `id` = ANY(SELECT `id` FROM `character`)"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "id" FROM "character" WHERE "id" = ANY(SELECT "id" FROM "character")"#
+    /// );
+    /// ```
     pub fn any(sel: SelectStatement) -> SimpleExpr {
         SimpleExpr::SubQuery(
             Some(SubQueryOper::Any),
@@ -1917,6 +1945,34 @@ impl Expr {
     }
 
     /// Express a `SOME` sub-query expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Char::Id)
+    ///     .from(Char::Table)
+    ///     .and_where(
+    ///         Expr::col(Char::Id)
+    ///             .ne(
+    ///                 Expr::some(
+    ///                     Query::select().column(Char::Id).from(Char::Table).take()
+    ///                 )
+    ///             )
+    ///     )
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `id` FROM `character` WHERE `id` <> ANY(SELECT `id` FROM `character`)"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "id" FROM "character" WHERE "id" <> ANY(SELECT "id" FROM "character")"#
+    /// );
+    /// ```
     pub fn some(sel: SelectStatement) -> SimpleExpr {
         SimpleExpr::SubQuery(
             Some(SubQueryOper::Some),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -28,7 +28,7 @@ pub enum SimpleExpr {
     Unary(UnOper, Box<SimpleExpr>),
     FunctionCall(Function, Vec<SimpleExpr>),
     Binary(Box<SimpleExpr>, BinOper, Box<SimpleExpr>),
-    SubQuery(Box<SubQueryStatement>),
+    SubQuery(Option<SubQueryOper>, Box<SubQueryStatement>),
     Value(Value),
     Values(Vec<Value>),
     Custom(String),
@@ -1830,9 +1830,10 @@ impl Expr {
     #[allow(clippy::wrong_self_convention)]
     pub fn in_subquery(mut self, sel: SelectStatement) -> SimpleExpr {
         self.bopr = Some(BinOper::In);
-        self.right = Some(SimpleExpr::SubQuery(Box::new(
-            sel.into_sub_query_statement(),
-        )));
+        self.right = Some(SimpleExpr::SubQuery(
+            None,
+            Box::new(sel.into_sub_query_statement()),
+        ));
         self.into()
     }
 
@@ -1869,10 +1870,67 @@ impl Expr {
     #[allow(clippy::wrong_self_convention)]
     pub fn not_in_subquery(mut self, sel: SelectStatement) -> SimpleExpr {
         self.bopr = Some(BinOper::NotIn);
-        self.right = Some(SimpleExpr::SubQuery(Box::new(
-            sel.into_sub_query_statement(),
-        )));
+        self.right = Some(SimpleExpr::SubQuery(
+            None,
+            Box::new(sel.into_sub_query_statement()),
+        ));
         self.into()
+    }
+
+    /// Express a `EXISTS` sub-query expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .expr_as(Expr::exists(Query::select().column(Char::Id).from(Char::Table).take()), Alias::new("character_exists"))
+    ///     .expr_as(Expr::exists(Query::select().column(Glyph::Id).from(Glyph::Table).take()), Alias::new("glyph_exists"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT EXISTS(SELECT `id` FROM `character`) AS `character_exists`, EXISTS(SELECT `id` FROM `glyph`) AS `glyph_exists`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT EXISTS(SELECT "id" FROM "character") AS "character_exists", EXISTS(SELECT "id" FROM "glyph") AS "glyph_exists""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT EXISTS(SELECT "id" FROM "character") AS "character_exists", EXISTS(SELECT "id" FROM "glyph") AS "glyph_exists""#
+    /// );
+    /// ```
+    pub fn exists(sel: SelectStatement) -> SimpleExpr {
+        SimpleExpr::SubQuery(
+            Some(SubQueryOper::Exists),
+            Box::new(sel.into_sub_query_statement()),
+        )
+    }
+
+    /// Express a `ANY` sub-query expression.
+    pub fn any(sel: SelectStatement) -> SimpleExpr {
+        SimpleExpr::SubQuery(
+            Some(SubQueryOper::Any),
+            Box::new(sel.into_sub_query_statement()),
+        )
+    }
+
+    /// Express a `SOME` sub-query expression.
+    pub fn some(sel: SelectStatement) -> SimpleExpr {
+        SimpleExpr::SubQuery(
+            Some(SubQueryOper::Some),
+            Box::new(sel.into_sub_query_statement()),
+        )
+    }
+
+    /// Express a `ALL` sub-query expression.
+    pub fn all(sel: SelectStatement) -> SimpleExpr {
+        SimpleExpr::SubQuery(
+            Some(SubQueryOper::All),
+            Box::new(sel.into_sub_query_statement()),
+        )
     }
 
     /// Express an postgres fulltext search matches (`@@`) expression.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -570,6 +570,79 @@ impl Expr {
         self.bin_oper(BinOper::NotEqual, v.into().into())
     }
 
+    /// Express a equal expression for [`SimpleExpr`]
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Char::Id)
+    ///     .from(Char::Table)
+    ///     .and_where(
+    ///         Expr::col(Char::Id)
+    ///             .eq_expr(
+    ///                 Expr::any(
+    ///                     Query::select().column(Char::Id).from(Char::Table).take()
+    ///                 )
+    ///             )
+    ///     )
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `id` FROM `character` WHERE `id` = ANY(SELECT `id` FROM `character`)"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "id" FROM "character" WHERE "id" = ANY(SELECT "id" FROM "character")"#
+    /// );
+    /// ```
+    pub fn eq_expr<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.bin_oper(BinOper::Equal, expr.into())
+    }
+
+    /// Express a not equal expression for [`SimpleExpr`]
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Char::Id)
+    ///     .from(Char::Table)
+    ///     .and_where(
+    ///         Expr::col(Char::Id)
+    ///             .neq_expr(
+    ///                 Expr::any(
+    ///                     Query::select().column(Char::Id).from(Char::Table).take()
+    ///                 )
+    ///             )
+    ///     )
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `id` FROM `character` WHERE `id` <> ANY(SELECT `id` FROM `character`)"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "id" FROM "character" WHERE "id" <> ANY(SELECT "id" FROM "character")"#
+    /// );
+    /// ```
+
+    pub fn neq_expr<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.bin_oper(BinOper::NotEqual, expr.into())
+    }
+
     /// Express a equal expression between two table columns,
     /// you will mainly use this to relate identical value between two table columns.
     ///
@@ -1910,35 +1983,6 @@ impl Expr {
     }
 
     /// Express a `ANY` sub-query expression.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .column(Char::Id)
-    ///     .from(Char::Table)
-    ///     .and_where(
-    ///         Expr::col(Char::Id)
-    ///             .ne(
-    ///                 Expr::any(
-    ///                     Query::select().column(Char::Id).from(Char::Table).take()
-    ///                 )
-    ///             )
-    ///     )
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `id` FROM `character` WHERE `id` <> ANY(SELECT `id` FROM `character`)"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "id" FROM "character" WHERE "id" <> ANY(SELECT "id" FROM "character")"#
-    /// );
-    /// ```
-
     pub fn any(sel: SelectStatement) -> SimpleExpr {
         SimpleExpr::SubQuery(
             Some(SubQueryOper::Any),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1966,11 +1966,11 @@ impl Expr {
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `id` FROM `character` WHERE `id` <> ANY(SELECT `id` FROM `character`)"#
+    ///     r#"SELECT `id` FROM `character` WHERE `id` <> SOME(SELECT `id` FROM `character`)"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "id" FROM "character" WHERE "id" <> ANY(SELECT "id" FROM "character")"#
+    ///     r#"SELECT "id" FROM "character" WHERE "id" <> SOME(SELECT "id" FROM "character")"#
     /// );
     /// ```
     pub fn some(sel: SelectStatement) -> SimpleExpr {

--- a/src/types.rs
+++ b/src/types.rs
@@ -214,6 +214,15 @@ pub trait IntoLikeExpr {
     fn into_like_expr(self) -> LikeExpr;
 }
 
+/// SubQuery operators
+#[derive(Debug, Copy, Clone)]
+pub enum SubQueryOper {
+    Exists,
+    Any,
+    Some,
+    All,
+}
+
 // Impl begins
 
 impl<T: 'static> IntoIden for T


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-query/issues/118
- https://github.com/SeaQL/sea-query/issues/216

## Adds

- SubQuery operators: `EXISTS`, `ALL`, `ANY`, `SOME`
