### PR TITLE
issues-336 Init array support

### DIFF
--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime};
 use postgres::{Client, NoTls, Row};
 use rust_decimal::Decimal;
-use sea_query::{ColumnDef, Iden, Order, PostgresQueryBuilder, Query, Table};
+use sea_query::{ColumnDef, ColumnType, Iden, Order, PostgresQueryBuilder, Query, Table};
 use sea_query_postgres::PostgresBinder;
 use time::{
     macros::{date, offset, time},
@@ -34,7 +34,7 @@ fn main() {
             .col(ColumnDef::new(Document::Timestamp).timestamp())
             .col(ColumnDef::new(Document::TimestampWithTimeZone).timestamp_with_time_zone())
             .col(ColumnDef::new(Document::Decimal).decimal())
-            .col(ColumnDef::new(Document::Array).array("integer".into()))
+            .col(ColumnDef::new(Document::Array).array(ColumnType::Integer(None)))
             .build(PostgresQueryBuilder),
     ]
     .join("; ");

--- a/sea-query-binder/src/sqlx_any.rs
+++ b/sea-query-binder/src/sqlx_any.rs
@@ -67,70 +67,104 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::any::Any> for SqlxValues {
                 Value::ChronoDate(d) => {
                     args.add(d.map(|d| *d));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoTime(t) => {
                     args.add(t.map(|t| *t));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoTimeArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTime(t) => {
                     args.add(t.map(|t| *t));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeUtc(t) => {
                     args.add(t.map(|t| *t));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeUtcArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeLocal(t) => {
                     args.add(t.map(|t| *t));
+                }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeLocalArray(_) => {
+                    panic!("Array support not implemented for Any")
                 }
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeWithTimeZone(t) => {
                     args.add(Value::ChronoDateTimeWithTimeZone(t).chrono_as_naive_utc_in_string());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeWithTimeZoneArray(_) => {
+                    panic!("Array support not implemented for Any")
+                }
                 #[cfg(feature = "with-time")]
                 Value::TimeDate(t) => {
                     args.add(Value::TimeDate(t).time_as_naive_utc_in_string());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeDateArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-time")]
                 Value::TimeTime(t) => {
                     args.add(Value::TimeTime(t).time_as_naive_utc_in_string());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeTimeArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTime(t) => {
                     args.add(Value::TimeDateTime(t).time_as_naive_utc_in_string());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeDateTimeArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => {
                     args.add(Value::TimeDateTimeWithTimeZone(t).time_as_naive_utc_in_string());
+                }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeDateTimeWithTimeZoneArray(_) => {
+                    panic!("Array support not implemented for Any")
                 }
                 #[cfg(feature = "with-uuid")]
                 Value::Uuid(_) => {
                     panic!("UUID support not implemented for Any");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::UuidArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(_) => {
                     panic!("Sqlite doesn't support decimal arguments");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::DecimalArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-bigdecimal")]
                 Value::BigDecimal(_) => {
                     panic!("Sqlite doesn't support bigdecimal arguments");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::BigDecimalArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-json")]
                 Value::Json(_) => {
                     panic!("Json support not implemented for Any");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::JsonArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-ipnetwork")]
                 Value::IpNetwork(_) => {
                     panic!("SeaQuery doesn't support IpNetwork arguments for Any");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::IpNetworkArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-mac_address")]
                 Value::MacAddress(_) => {
                     panic!("SeaQuery doesn't support MacAddress arguments for Any");
                 }
-                #[cfg(feature = "postgres-array")]
-                Value::Array(_) => {
-                    panic!("SeaQuery doesn't support array arguments for Any");
-                }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::MacAddressArray(_) => panic!("Array support not implemented for Any"),
             }
         }
         args

--- a/sea-query-binder/src/sqlx_any.rs
+++ b/sea-query-binder/src/sqlx_any.rs
@@ -49,7 +49,7 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::any::Any> for SqlxValues {
                 Value::Bytes(b) => {
                     args.add(b.map(|b| *b));
                 }
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::BoolArray(_)
                 | Value::TinyIntArray(_)
                 | Value::SmallIntArray(_)
@@ -67,31 +67,31 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::any::Any> for SqlxValues {
                 Value::ChronoDate(d) => {
                     args.add(d.map(|d| *d));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoTime(t) => {
                     args.add(t.map(|t| *t));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoTimeArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTime(t) => {
                     args.add(t.map(|t| *t));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeUtc(t) => {
                     args.add(t.map(|t| *t));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeUtcArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeLocal(t) => {
                     args.add(t.map(|t| *t));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeLocalArray(_) => {
                     panic!("Array support not implemented for Any")
                 }
@@ -99,7 +99,7 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::any::Any> for SqlxValues {
                 Value::ChronoDateTimeWithTimeZone(t) => {
                     args.add(Value::ChronoDateTimeWithTimeZone(t).chrono_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeWithTimeZoneArray(_) => {
                     panic!("Array support not implemented for Any")
                 }
@@ -107,25 +107,25 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::any::Any> for SqlxValues {
                 Value::TimeDate(t) => {
                     args.add(Value::TimeDate(t).time_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeDateArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-time")]
                 Value::TimeTime(t) => {
                     args.add(Value::TimeTime(t).time_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeTimeArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTime(t) => {
                     args.add(Value::TimeDateTime(t).time_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeDateTimeArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => {
                     args.add(Value::TimeDateTimeWithTimeZone(t).time_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeDateTimeWithTimeZoneArray(_) => {
                     panic!("Array support not implemented for Any")
                 }
@@ -133,37 +133,37 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::any::Any> for SqlxValues {
                 Value::Uuid(_) => {
                     panic!("UUID support not implemented for Any");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::UuidArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(_) => {
                     panic!("Sqlite doesn't support decimal arguments");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::DecimalArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-bigdecimal")]
                 Value::BigDecimal(_) => {
                     panic!("Sqlite doesn't support bigdecimal arguments");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::BigDecimalArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-json")]
                 Value::Json(_) => {
                     panic!("Json support not implemented for Any");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::JsonArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-ipnetwork")]
                 Value::IpNetwork(_) => {
                     panic!("SeaQuery doesn't support IpNetwork arguments for Any");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::IpNetworkArray(_) => panic!("Array support not implemented for Any"),
                 #[cfg(feature = "with-mac_address")]
                 Value::MacAddress(_) => {
                     panic!("SeaQuery doesn't support MacAddress arguments for Any");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::MacAddressArray(_) => panic!("Array support not implemented for Any"),
             }
         }

--- a/sea-query-binder/src/sqlx_any.rs
+++ b/sea-query-binder/src/sqlx_any.rs
@@ -49,6 +49,20 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::any::Any> for SqlxValues {
                 Value::Bytes(b) => {
                     args.add(b.map(|b| *b));
                 }
+                #[cfg(feature = "with-array")]
+                Value::BoolArray(_)
+                | Value::TinyIntArray(_)
+                | Value::SmallIntArray(_)
+                | Value::IntArray(_)
+                | Value::BigIntArray(_)
+                | Value::SmallUnsignedArray(_)
+                | Value::UnsignedArray(_)
+                | Value::BigUnsignedArray(_)
+                | Value::FloatArray(_)
+                | Value::DoubleArray(_)
+                | Value::StringArray(_)
+                | Value::CharArray(_) => panic!("Array support not implemented for Any"),
+
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDate(d) => {
                     args.add(d.map(|d| *d));

--- a/sea-query-binder/src/sqlx_mysql.rs
+++ b/sea-query-binder/src/sqlx_mysql.rs
@@ -62,70 +62,103 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::mysql::MySql> for SqlxValues {
                 | Value::DoubleArray(_)
                 | Value::StringArray(_)
                 | Value::CharArray(_) => panic!("Mysql doesn't support array arguments"),
+
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDate(d) => {
                     args.add(d.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoTime(t) => {
                     args.add(t.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoTimeArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTime(t) => {
                     args.add(t.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeUtc(t) => {
                     args.add(t.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeUtcArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeLocal(t) => {
                     args.add(t.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeLocalArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeWithTimeZone(t) => {
                     args.add(Value::ChronoDateTimeWithTimeZone(t).chrono_as_naive_utc_in_string());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeWithTimeZoneArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDate(t) => {
                     args.add(t.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeDateArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeTime(t) => {
                     args.add(t.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeTimeArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTime(t) => {
                     args.add(t.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeDateTimeArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => {
                     args.add(t.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeDateTimeWithTimeZoneArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-uuid")]
                 Value::Uuid(uuid) => {
                     args.add(uuid.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::UuidArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(d) => {
                     args.add(d.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::DecimalArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-bigdecimal")]
                 Value::BigDecimal(d) => {
                     args.add(d.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::BigDecimalArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-json")]
                 Value::Json(j) => {
                     args.add(j.as_deref());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::JsonArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-ipnetwork")]
                 Value::IpNetwork(_) => {
                     panic!("Mysql doesn't support IpNetwork arguments");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::IpNetworkArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-mac_address")]
                 Value::MacAddress(_) => {
                     panic!("Mysql doesn't support MacAddress arguments");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::MacAddressArray(_) => panic!("Mysql doesn't support array"),
             }
         }
         args

--- a/sea-query-binder/src/sqlx_mysql.rs
+++ b/sea-query-binder/src/sqlx_mysql.rs
@@ -49,7 +49,7 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::mysql::MySql> for SqlxValues {
                 Value::Bytes(b) => {
                     args.add(b.as_deref());
                 }
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::BoolArray(_)
                 | Value::TinyIntArray(_)
                 | Value::SmallIntArray(_)
@@ -67,97 +67,97 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::mysql::MySql> for SqlxValues {
                 Value::ChronoDate(d) => {
                     args.add(d.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoTime(t) => {
                     args.add(t.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoTimeArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTime(t) => {
                     args.add(t.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeUtc(t) => {
                     args.add(t.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeUtcArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeLocal(t) => {
                     args.add(t.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeLocalArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeWithTimeZone(t) => {
                     args.add(Value::ChronoDateTimeWithTimeZone(t).chrono_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeWithTimeZoneArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDate(t) => {
                     args.add(t.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeDateArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeTime(t) => {
                     args.add(t.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeTimeArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTime(t) => {
                     args.add(t.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeDateTimeArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => {
                     args.add(t.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeDateTimeWithTimeZoneArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-uuid")]
                 Value::Uuid(uuid) => {
                     args.add(uuid.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::UuidArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(d) => {
                     args.add(d.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::DecimalArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-bigdecimal")]
                 Value::BigDecimal(d) => {
                     args.add(d.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::BigDecimalArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-json")]
                 Value::Json(j) => {
                     args.add(j.as_deref());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::JsonArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-ipnetwork")]
                 Value::IpNetwork(_) => {
                     panic!("Mysql doesn't support IpNetwork arguments");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::IpNetworkArray(_) => panic!("Mysql doesn't support array"),
                 #[cfg(feature = "with-mac_address")]
                 Value::MacAddress(_) => {
                     panic!("Mysql doesn't support MacAddress arguments");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::MacAddressArray(_) => panic!("Mysql doesn't support array"),
             }
         }

--- a/sea-query-binder/src/sqlx_mysql.rs
+++ b/sea-query-binder/src/sqlx_mysql.rs
@@ -49,6 +49,71 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::mysql::MySql> for SqlxValues {
                 Value::Bytes(b) => {
                     args.add(b.as_deref());
                 }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoDate(d) => {
+                    args.add(d.as_deref());
+                }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoTime(t) => {
+                    args.add(t.as_deref());
+                }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoDateTime(t) => {
+                    args.add(t.as_deref());
+                }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoDateTimeUtc(t) => {
+                    args.add(t.as_deref());
+                }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoDateTimeLocal(t) => {
+                    args.add(t.as_deref());
+                }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoDateTimeWithTimeZone(t) => {
+                    args.add(Value::ChronoDateTimeWithTimeZone(t).chrono_as_naive_utc_in_string());
+                }
+                #[cfg(feature = "with-time")]
+                Value::TimeDate(t) => {
+                    args.add(t.as_deref());
+                }
+                #[cfg(feature = "with-time")]
+                Value::TimeTime(t) => {
+                    args.add(t.as_deref());
+                }
+                #[cfg(feature = "with-time")]
+                Value::TimeDateTime(t) => {
+                    args.add(t.as_deref());
+                }
+                #[cfg(feature = "with-time")]
+                Value::TimeDateTimeWithTimeZone(t) => {
+                    args.add(t.as_deref());
+                }
+                #[cfg(feature = "with-uuid")]
+                Value::Uuid(uuid) => {
+                    args.add(uuid.as_deref());
+                }
+                #[cfg(feature = "with-rust_decimal")]
+                Value::Decimal(d) => {
+                    args.add(d.as_deref());
+                }
+                #[cfg(feature = "with-bigdecimal")]
+                Value::BigDecimal(d) => {
+                    args.add(d.as_deref());
+                }
+                #[cfg(feature = "with-json")]
+                Value::Json(j) => {
+                    args.add(j.as_deref());
+                }
+                #[cfg(feature = "with-ipnetwork")]
+                Value::IpNetwork(_) => {
+                    panic!("Mysql doesn't support IpNetwork arguments");
+                }
+                #[cfg(feature = "with-mac_address")]
+                Value::MacAddress(_) => {
+                    panic!("Mysql doesn't support MacAddress arguments");
+                }
+
                 #[cfg(feature = "postgres-array")]
                 Value::BoolArray(_)
                 | Value::TinyIntArray(_)
@@ -62,102 +127,33 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::mysql::MySql> for SqlxValues {
                 | Value::DoubleArray(_)
                 | Value::StringArray(_)
                 | Value::CharArray(_) => panic!("Mysql doesn't support array arguments"),
-
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoDate(d) => {
-                    args.add(d.as_deref());
-                }
                 #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoDateArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoTime(t) => {
-                    args.add(t.as_deref());
+                Value::ChronoDateArray(_)
+                | Value::ChronoTimeArray(_)
+                | Value::ChronoDateTimeArray(_)
+                | Value::ChronoDateTimeUtcArray(_)
+                | Value::ChronoDateTimeLocalArray(_)
+                | Value::ChronoDateTimeWithTimeZoneArray(_) => {
+                    panic!("Mysql doesn't support array")
                 }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoTimeArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTime(t) => {
-                    args.add(t.as_deref());
+                #[cfg(all(feature = "with-time", feature = "postgres-array"))]
+                Value::TimeDateArray(_)
+                | Value::TimeTimeArray(_)
+                | Value::TimeDateTimeArray(_)
+                | Value::TimeDateTimeWithTimeZoneArray(_) => {
+                    panic!("Mysql doesn't support array")
                 }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoDateTimeArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTimeUtc(t) => {
-                    args.add(t.as_deref());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoDateTimeUtcArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTimeLocal(t) => {
-                    args.add(t.as_deref());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoDateTimeLocalArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTimeWithTimeZone(t) => {
-                    args.add(Value::ChronoDateTimeWithTimeZone(t).chrono_as_naive_utc_in_string());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoDateTimeWithTimeZoneArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-time")]
-                Value::TimeDate(t) => {
-                    args.add(t.as_deref());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::TimeDateArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-time")]
-                Value::TimeTime(t) => {
-                    args.add(t.as_deref());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::TimeTimeArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-time")]
-                Value::TimeDateTime(t) => {
-                    args.add(t.as_deref());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::TimeDateTimeArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-time")]
-                Value::TimeDateTimeWithTimeZone(t) => {
-                    args.add(t.as_deref());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::TimeDateTimeWithTimeZoneArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-uuid")]
-                Value::Uuid(uuid) => {
-                    args.add(uuid.as_deref());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
                 Value::UuidArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-rust_decimal")]
-                Value::Decimal(d) => {
-                    args.add(d.as_deref());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-rust_decimal", feature = "postgres-array"))]
                 Value::DecimalArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-bigdecimal")]
-                Value::BigDecimal(d) => {
-                    args.add(d.as_deref());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-bigdecimal", feature = "postgres-array"))]
                 Value::BigDecimalArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-json")]
-                Value::Json(j) => {
-                    args.add(j.as_deref());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-json", feature = "postgres-array"))]
                 Value::JsonArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-ipnetwork")]
-                Value::IpNetwork(_) => {
-                    panic!("Mysql doesn't support IpNetwork arguments");
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-ipnetwork", feature = "postgres-array"))]
                 Value::IpNetworkArray(_) => panic!("Mysql doesn't support array"),
-                #[cfg(feature = "with-mac_address")]
-                Value::MacAddress(_) => {
-                    panic!("Mysql doesn't support MacAddress arguments");
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-mac_address", feature = "postgres-array"))]
                 Value::MacAddressArray(_) => panic!("Mysql doesn't support array"),
             }
         }

--- a/sea-query-binder/src/sqlx_mysql.rs
+++ b/sea-query-binder/src/sqlx_mysql.rs
@@ -49,6 +49,19 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::mysql::MySql> for SqlxValues {
                 Value::Bytes(b) => {
                     args.add(b.as_deref());
                 }
+                #[cfg(feature = "with-array")]
+                Value::BoolArray(_)
+                | Value::TinyIntArray(_)
+                | Value::SmallIntArray(_)
+                | Value::IntArray(_)
+                | Value::BigIntArray(_)
+                | Value::SmallUnsignedArray(_)
+                | Value::UnsignedArray(_)
+                | Value::BigUnsignedArray(_)
+                | Value::FloatArray(_)
+                | Value::DoubleArray(_)
+                | Value::StringArray(_)
+                | Value::CharArray(_) => panic!("Mysql doesn't support array arguments"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDate(d) => {
                     args.add(d.as_deref());
@@ -104,10 +117,6 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::mysql::MySql> for SqlxValues {
                 #[cfg(feature = "with-json")]
                 Value::Json(j) => {
                     args.add(j.as_deref());
-                }
-                #[cfg(feature = "postgres-array")]
-                Value::Array(_) => {
-                    panic!("Mysql doesn't support array arguments");
                 }
                 #[cfg(feature = "with-ipnetwork")]
                 Value::IpNetwork(_) => {

--- a/sea-query-binder/src/sqlx_postgres.rs
+++ b/sea-query-binder/src/sqlx_postgres.rs
@@ -83,71 +83,82 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::postgres::Postgres> for SqlxValues {
                 Value::CharArray(v) => {
                     args.add(v.map(|v| v.iter().map(|c| c.to_string()).collect::<Vec<String>>()))
                 }
-
                 #[cfg(feature = "with-chrono")]
-                Value::ChronoDate(d) => {
-                    args.add(d.as_deref());
-                }
+                Value::ChronoDate(d) => args.add(d.as_deref()),
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-chrono")]
-                Value::ChronoTime(t) => {
-                    args.add(t.as_deref());
-                }
+                Value::ChronoTime(d) => args.add(d.as_deref()),
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoTimeArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTime(t) => {
-                    args.add(t.as_deref());
-                }
+                Value::ChronoDateTime(d) => args.add(d.as_deref()),
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTimeUtc(t) => {
-                    args.add(t.as_deref());
-                }
+                Value::ChronoDateTimeUtc(d) => args.add(d.as_deref()),
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeUtcArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTimeLocal(t) => {
-                    args.add(t.as_deref());
-                }
+                Value::ChronoDateTimeLocal(d) => args.add(d.as_deref()),
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeLocalArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTimeWithTimeZone(t) => {
-                    args.add(t.as_deref());
-                }
+                Value::ChronoDateTimeWithTimeZone(d) => args.add(d.as_deref()),
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeWithTimeZoneArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-time")]
-                Value::TimeDate(t) => {
-                    args.add(t.as_deref());
-                }
+                Value::TimeDate(t) => args.add(t.as_deref()),
+                #[cfg(all(feature = "with-time", feature = "with-array"))]
+                Value::TimeDateArray(t) => args.add(t.as_deref()),
                 #[cfg(feature = "with-time")]
-                Value::TimeTime(t) => {
-                    args.add(t.as_deref());
-                }
+                Value::TimeTime(t) => args.add(t.as_deref()),
+                #[cfg(all(feature = "with-time", feature = "with-array"))]
+                Value::TimeTimeArray(t) => args.add(t.as_deref()),
                 #[cfg(feature = "with-time")]
-                Value::TimeDateTime(t) => {
-                    args.add(t.as_deref());
-                }
+                Value::TimeDateTime(t) => args.add(t.as_deref()),
+                #[cfg(all(feature = "with-time", feature = "with-array"))]
+                Value::TimeDateTimeArray(t) => args.add(t.as_deref()),
                 #[cfg(feature = "with-time")]
-                Value::TimeDateTimeWithTimeZone(t) => {
-                    args.add(t.as_deref());
-                }
+                Value::TimeDateTimeWithTimeZone(t) => args.add(t.as_deref()),
+                #[cfg(all(feature = "with-time", feature = "with-array"))]
+                Value::TimeDateTimeWithTimeZoneArray(t) => args.add(t.as_deref()),
                 #[cfg(feature = "with-uuid")]
                 Value::Uuid(uuid) => {
                     args.add(uuid.as_deref());
                 }
+                #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+                Value::UuidArray(uuid) => args.add(uuid.as_deref()),
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(d) => {
                     args.add(d.as_deref());
                 }
+                #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+                Value::DecimalArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-bigdecimal")]
                 Value::BigDecimal(d) => {
                     args.add(d.as_deref());
                 }
+                #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
+                Value::BigDecimalArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-json")]
                 Value::Json(j) => {
                     args.add(j.as_deref());
                 }
+                #[cfg(all(feature = "with-json", feature = "with-array"))]
+                Value::JsonArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-ipnetwork")]
                 Value::IpNetwork(ip) => {
                     args.add(ip.as_deref());
                 }
+                #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+                Value::IpNetworkArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-mac_address")]
                 Value::MacAddress(mac) => {
                     args.add(mac.as_deref());
                 }
+                #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
+                Value::MacAddressArray(d) => args.add(d.as_deref()),
             }
         }
         args

--- a/sea-query-binder/src/sqlx_postgres.rs
+++ b/sea-query-binder/src/sqlx_postgres.rs
@@ -49,6 +49,41 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::postgres::Postgres> for SqlxValues {
                 Value::Bytes(b) => {
                     args.add(b.as_deref());
                 }
+                #[cfg(feature = "with-array")]
+                Value::BoolArray(v) => args.add(v.as_deref()),
+                #[cfg(feature = "with-array")]
+                Value::TinyIntArray(v) => args.add(v.as_deref()),
+                #[cfg(feature = "with-array")]
+                Value::SmallIntArray(v) => args.add(v.as_deref()),
+                #[cfg(feature = "with-array")]
+                Value::IntArray(v) => args.add(v.as_deref()),
+                #[cfg(feature = "with-array")]
+                Value::BigIntArray(v) => args.add(v.as_deref()),
+                #[cfg(feature = "with-array")]
+                Value::SmallUnsignedArray(v) => {
+                    args.add(v.map(|v| v.iter().map(|&i| i as i32).collect::<Vec<i32>>()))
+                }
+                #[cfg(feature = "with-array")]
+                Value::UnsignedArray(v) => {
+                    args.add(v.map(|v| v.iter().map(|&i| i as i64).collect::<Vec<i64>>()))
+                }
+                #[cfg(feature = "with-array")]
+                Value::BigUnsignedArray(v) => args.add(v.map(|v| {
+                    v.iter()
+                        .map(|&i| <i64 as std::convert::TryFrom<u64>>::try_from(i).unwrap())
+                        .collect::<Vec<i64>>()
+                })),
+                #[cfg(feature = "with-array")]
+                Value::FloatArray(v) => args.add(v.as_deref()),
+                #[cfg(feature = "with-array")]
+                Value::DoubleArray(v) => args.add(v.as_deref()),
+                #[cfg(feature = "with-array")]
+                Value::StringArray(v) => args.add(v.as_deref()),
+                #[cfg(feature = "with-array")]
+                Value::CharArray(v) => {
+                    args.add(v.map(|v| v.iter().map(|c| c.to_string()).collect::<Vec<String>>()))
+                }
+
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDate(d) => {
                     args.add(d.as_deref());
@@ -104,10 +139,6 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::postgres::Postgres> for SqlxValues {
                 #[cfg(feature = "with-json")]
                 Value::Json(j) => {
                     args.add(j.as_deref());
-                }
-                #[cfg(feature = "postgres-array")]
-                Value::Array(_) => {
-                    panic!("SeaQuery doesn't support array arguments for Postgresql");
                 }
                 #[cfg(feature = "with-ipnetwork")]
                 Value::IpNetwork(ip) => {

--- a/sea-query-binder/src/sqlx_postgres.rs
+++ b/sea-query-binder/src/sqlx_postgres.rs
@@ -49,115 +49,115 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::postgres::Postgres> for SqlxValues {
                 Value::Bytes(b) => {
                     args.add(b.as_deref());
                 }
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::BoolArray(v) => args.add(v.as_deref()),
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::TinyIntArray(v) => args.add(v.as_deref()),
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::SmallIntArray(v) => args.add(v.as_deref()),
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::IntArray(v) => args.add(v.as_deref()),
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::BigIntArray(v) => args.add(v.as_deref()),
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::SmallUnsignedArray(v) => {
                     args.add(v.map(|v| v.iter().map(|&i| i as i32).collect::<Vec<i32>>()))
                 }
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::UnsignedArray(v) => {
                     args.add(v.map(|v| v.iter().map(|&i| i as i64).collect::<Vec<i64>>()))
                 }
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::BigUnsignedArray(v) => args.add(v.map(|v| {
                     v.iter()
                         .map(|&i| <i64 as std::convert::TryFrom<u64>>::try_from(i).unwrap())
                         .collect::<Vec<i64>>()
                 })),
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::FloatArray(v) => args.add(v.as_deref()),
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::DoubleArray(v) => args.add(v.as_deref()),
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::StringArray(v) => args.add(v.as_deref()),
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::CharArray(v) => {
                     args.add(v.map(|v| v.iter().map(|c| c.to_string()).collect::<Vec<String>>()))
                 }
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDate(d) => args.add(d.as_deref()),
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoTime(d) => args.add(d.as_deref()),
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoTimeArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTime(d) => args.add(d.as_deref()),
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeUtc(d) => args.add(d.as_deref()),
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeUtcArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeLocal(d) => args.add(d.as_deref()),
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeLocalArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeWithTimeZone(d) => args.add(d.as_deref()),
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeWithTimeZoneArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-time")]
                 Value::TimeDate(t) => args.add(t.as_deref()),
-                #[cfg(all(feature = "with-time", feature = "with-array"))]
+                #[cfg(all(feature = "with-time", feature = "postgres-array"))]
                 Value::TimeDateArray(t) => args.add(t.as_deref()),
                 #[cfg(feature = "with-time")]
                 Value::TimeTime(t) => args.add(t.as_deref()),
-                #[cfg(all(feature = "with-time", feature = "with-array"))]
+                #[cfg(all(feature = "with-time", feature = "postgres-array"))]
                 Value::TimeTimeArray(t) => args.add(t.as_deref()),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTime(t) => args.add(t.as_deref()),
-                #[cfg(all(feature = "with-time", feature = "with-array"))]
+                #[cfg(all(feature = "with-time", feature = "postgres-array"))]
                 Value::TimeDateTimeArray(t) => args.add(t.as_deref()),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => args.add(t.as_deref()),
-                #[cfg(all(feature = "with-time", feature = "with-array"))]
+                #[cfg(all(feature = "with-time", feature = "postgres-array"))]
                 Value::TimeDateTimeWithTimeZoneArray(t) => args.add(t.as_deref()),
                 #[cfg(feature = "with-uuid")]
                 Value::Uuid(uuid) => {
                     args.add(uuid.as_deref());
                 }
-                #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+                #[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
                 Value::UuidArray(uuid) => args.add(uuid.as_deref()),
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(d) => {
                     args.add(d.as_deref());
                 }
-                #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+                #[cfg(all(feature = "with-rust_decimal", feature = "postgres-array"))]
                 Value::DecimalArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-bigdecimal")]
                 Value::BigDecimal(d) => {
                     args.add(d.as_deref());
                 }
-                #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
+                #[cfg(all(feature = "with-bigdecimal", feature = "postgres-array"))]
                 Value::BigDecimalArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-json")]
                 Value::Json(j) => {
                     args.add(j.as_deref());
                 }
-                #[cfg(all(feature = "with-json", feature = "with-array"))]
+                #[cfg(all(feature = "with-json", feature = "postgres-array"))]
                 Value::JsonArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-ipnetwork")]
                 Value::IpNetwork(ip) => {
                     args.add(ip.as_deref());
                 }
-                #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+                #[cfg(all(feature = "with-ipnetwork", feature = "postgres-array"))]
                 Value::IpNetworkArray(d) => args.add(d.as_deref()),
                 #[cfg(feature = "with-mac_address")]
                 Value::MacAddress(mac) => {
                     args.add(mac.as_deref());
                 }
-                #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
+                #[cfg(all(feature = "with-mac_address", feature = "postgres-array"))]
                 Value::MacAddressArray(d) => args.add(d.as_deref()),
             }
         }

--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -62,70 +62,103 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 | Value::DoubleArray(_)
                 | Value::StringArray(_)
                 | Value::CharArray(_) => panic!("Sqlite doesn't support array arguments"),
+
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDate(d) => {
                     args.add(d.map(|d| *d));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoTime(t) => {
                     args.add(t.map(|t| *t));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoTimeArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTime(t) => {
                     args.add(t.map(|t| *t));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeUtc(t) => {
                     args.add(t.map(|t| *t));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeUtcArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeLocal(t) => {
                     args.add(t.map(|t| *t));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeLocalArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeWithTimeZone(t) => {
                     args.add(t.map(|t| *t));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::ChronoDateTimeWithTimeZoneArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDate(t) => {
                     args.add(Value::TimeDate(t).time_as_naive_utc_in_string());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeDateArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeTime(t) => {
                     args.add(Value::TimeTime(t).time_as_naive_utc_in_string());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeTimeArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTime(t) => {
                     args.add(Value::TimeDateTime(t).time_as_naive_utc_in_string());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeDateTimeArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => {
                     args.add(Value::TimeDateTimeWithTimeZone(t).time_as_naive_utc_in_string());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::TimeDateTimeWithTimeZoneArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-uuid")]
                 Value::Uuid(uuid) => {
                     args.add(uuid.map(|uuid| *uuid));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::UuidArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(_) => {
                     panic!("Sqlite doesn't support decimal arguments");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::DecimalArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-bigdecimal")]
                 Value::BigDecimal(_) => {
                     panic!("Sqlite doesn't support bigdecimal arguments");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::BigDecimalArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-json")]
                 Value::Json(j) => {
                     args.add(j.map(|j| *j));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::JsonArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-ipnetwork")]
                 Value::IpNetwork(_) => {
                     panic!("Sqlite doesn't support IpNetwork arguments");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::IpNetworkArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-mac_address")]
                 Value::MacAddress(_) => {
                     panic!("Sqlite doesn't support MacAddress arguments");
                 }
+                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                Value::MacAddressArray(_) => panic!("Sqlite doesn't support array"),
             }
         }
         args

--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -49,6 +49,19 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 Value::Bytes(b) => {
                     args.add(b.map(|b| *b));
                 }
+                #[cfg(feature = "with-array")]
+                Value::BoolArray(_)
+                | Value::TinyIntArray(_)
+                | Value::SmallIntArray(_)
+                | Value::IntArray(_)
+                | Value::BigIntArray(_)
+                | Value::SmallUnsignedArray(_)
+                | Value::UnsignedArray(_)
+                | Value::BigUnsignedArray(_)
+                | Value::FloatArray(_)
+                | Value::DoubleArray(_)
+                | Value::StringArray(_)
+                | Value::CharArray(_) => panic!("Sqlite doesn't support array arguments"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDate(d) => {
                     args.add(d.map(|d| *d));
@@ -112,10 +125,6 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 #[cfg(feature = "with-mac_address")]
                 Value::MacAddress(_) => {
                     panic!("Sqlite doesn't support MacAddress arguments");
-                }
-                #[cfg(feature = "postgres-array")]
-                Value::Array(_) => {
-                    panic!("Sqlite doesn't support array arguments");
                 }
             }
         }

--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -49,7 +49,7 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 Value::Bytes(b) => {
                     args.add(b.map(|b| *b));
                 }
-                #[cfg(feature = "with-array")]
+                #[cfg(feature = "postgres-array")]
                 Value::BoolArray(_)
                 | Value::TinyIntArray(_)
                 | Value::SmallIntArray(_)
@@ -67,97 +67,97 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 Value::ChronoDate(d) => {
                     args.add(d.map(|d| *d));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoTime(t) => {
                     args.add(t.map(|t| *t));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoTimeArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTime(t) => {
                     args.add(t.map(|t| *t));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeUtc(t) => {
                     args.add(t.map(|t| *t));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeUtcArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeLocal(t) => {
                     args.add(t.map(|t| *t));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeLocalArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-chrono")]
                 Value::ChronoDateTimeWithTimeZone(t) => {
                     args.add(t.map(|t| *t));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::ChronoDateTimeWithTimeZoneArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDate(t) => {
                     args.add(Value::TimeDate(t).time_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeDateArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeTime(t) => {
                     args.add(Value::TimeTime(t).time_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeTimeArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTime(t) => {
                     args.add(Value::TimeDateTime(t).time_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeDateTimeArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => {
                     args.add(Value::TimeDateTimeWithTimeZone(t).time_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::TimeDateTimeWithTimeZoneArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-uuid")]
                 Value::Uuid(uuid) => {
                     args.add(uuid.map(|uuid| *uuid));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::UuidArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(_) => {
                     panic!("Sqlite doesn't support decimal arguments");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::DecimalArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-bigdecimal")]
                 Value::BigDecimal(_) => {
                     panic!("Sqlite doesn't support bigdecimal arguments");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::BigDecimalArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-json")]
                 Value::Json(j) => {
                     args.add(j.map(|j| *j));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::JsonArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-ipnetwork")]
                 Value::IpNetwork(_) => {
                     panic!("Sqlite doesn't support IpNetwork arguments");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::IpNetworkArray(_) => panic!("Sqlite doesn't support array"),
                 #[cfg(feature = "with-mac_address")]
                 Value::MacAddress(_) => {
                     panic!("Sqlite doesn't support MacAddress arguments");
                 }
-                #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
                 Value::MacAddressArray(_) => panic!("Sqlite doesn't support array"),
             }
         }

--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -32,7 +32,7 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                     args.add(i);
                 }
                 Value::BigUnsigned(i) => {
-                    args.add(i.map(|i| <i64 as std::convert::TryFrom<u64>>::try_from(i).unwrap()));
+                    args.add(i.map(|i| <i64 as TryFrom<u64>>::try_from(i).unwrap()));
                 }
                 Value::Float(f) => {
                     args.add(f);
@@ -49,6 +49,70 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 Value::Bytes(b) => {
                     args.add(b.map(|b| *b));
                 }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoDate(d) => {
+                    args.add(d.map(|d| *d));
+                }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoTime(t) => {
+                    args.add(t.map(|t| *t));
+                }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoDateTime(t) => {
+                    args.add(t.map(|t| *t));
+                }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoDateTimeUtc(t) => {
+                    args.add(t.map(|t| *t));
+                }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoDateTimeLocal(t) => {
+                    args.add(t.map(|t| *t));
+                }
+                #[cfg(feature = "with-chrono")]
+                Value::ChronoDateTimeWithTimeZone(t) => {
+                    args.add(t.map(|t| *t));
+                }
+                #[cfg(feature = "with-time")]
+                Value::TimeDate(t) => {
+                    args.add(Value::TimeDate(t).time_as_naive_utc_in_string());
+                }
+                #[cfg(feature = "with-time")]
+                Value::TimeTime(t) => {
+                    args.add(Value::TimeTime(t).time_as_naive_utc_in_string());
+                }
+                #[cfg(feature = "with-time")]
+                Value::TimeDateTime(t) => {
+                    args.add(Value::TimeDateTime(t).time_as_naive_utc_in_string());
+                }
+                #[cfg(feature = "with-time")]
+                Value::TimeDateTimeWithTimeZone(t) => {
+                    args.add(Value::TimeDateTimeWithTimeZone(t).time_as_naive_utc_in_string());
+                }
+                #[cfg(feature = "with-uuid")]
+                Value::Uuid(uuid) => {
+                    args.add(uuid.map(|uuid| *uuid));
+                }
+                #[cfg(feature = "with-rust_decimal")]
+                Value::Decimal(_) => {
+                    panic!("Sqlite doesn't support decimal arguments");
+                }
+                #[cfg(feature = "with-bigdecimal")]
+                Value::BigDecimal(_) => {
+                    panic!("Sqlite doesn't support bigdecimal arguments");
+                }
+                #[cfg(feature = "with-json")]
+                Value::Json(j) => {
+                    args.add(j.map(|j| *j));
+                }
+                #[cfg(feature = "with-ipnetwork")]
+                Value::IpNetwork(_) => {
+                    panic!("Sqlite doesn't support IpNetwork arguments");
+                }
+                #[cfg(feature = "with-mac_address")]
+                Value::MacAddress(_) => {
+                    panic!("Sqlite doesn't support MacAddress arguments");
+                }
                 #[cfg(feature = "postgres-array")]
                 Value::BoolArray(_)
                 | Value::TinyIntArray(_)
@@ -62,102 +126,33 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 | Value::DoubleArray(_)
                 | Value::StringArray(_)
                 | Value::CharArray(_) => panic!("Sqlite doesn't support array arguments"),
-
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoDate(d) => {
-                    args.add(d.map(|d| *d));
-                }
                 #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoDateArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoTime(t) => {
-                    args.add(t.map(|t| *t));
+                Value::ChronoDateArray(_)
+                | Value::ChronoTimeArray(_)
+                | Value::ChronoDateTimeArray(_)
+                | Value::ChronoDateTimeUtcArray(_)
+                | Value::ChronoDateTimeLocalArray(_)
+                | Value::ChronoDateTimeWithTimeZoneArray(_) => {
+                    panic!("Sqlite doesn't support array")
                 }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoTimeArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTime(t) => {
-                    args.add(t.map(|t| *t));
+                #[cfg(all(feature = "with-time", feature = "postgres-array"))]
+                Value::TimeDateArray(_)
+                | Value::TimeTimeArray(_)
+                | Value::TimeDateTimeArray(_)
+                | Value::TimeDateTimeWithTimeZoneArray(_) => {
+                    panic!("Sqlite doesn't support array")
                 }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoDateTimeArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTimeUtc(t) => {
-                    args.add(t.map(|t| *t));
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoDateTimeUtcArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTimeLocal(t) => {
-                    args.add(t.map(|t| *t));
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoDateTimeLocalArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-chrono")]
-                Value::ChronoDateTimeWithTimeZone(t) => {
-                    args.add(t.map(|t| *t));
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::ChronoDateTimeWithTimeZoneArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-time")]
-                Value::TimeDate(t) => {
-                    args.add(Value::TimeDate(t).time_as_naive_utc_in_string());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::TimeDateArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-time")]
-                Value::TimeTime(t) => {
-                    args.add(Value::TimeTime(t).time_as_naive_utc_in_string());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::TimeTimeArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-time")]
-                Value::TimeDateTime(t) => {
-                    args.add(Value::TimeDateTime(t).time_as_naive_utc_in_string());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::TimeDateTimeArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-time")]
-                Value::TimeDateTimeWithTimeZone(t) => {
-                    args.add(Value::TimeDateTimeWithTimeZone(t).time_as_naive_utc_in_string());
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
-                Value::TimeDateTimeWithTimeZoneArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-uuid")]
-                Value::Uuid(uuid) => {
-                    args.add(uuid.map(|uuid| *uuid));
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
                 Value::UuidArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-rust_decimal")]
-                Value::Decimal(_) => {
-                    panic!("Sqlite doesn't support decimal arguments");
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-rust_decimal", feature = "postgres-array"))]
                 Value::DecimalArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-bigdecimal")]
-                Value::BigDecimal(_) => {
-                    panic!("Sqlite doesn't support bigdecimal arguments");
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-bigdecimal", feature = "postgres-array"))]
                 Value::BigDecimalArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-json")]
-                Value::Json(j) => {
-                    args.add(j.map(|j| *j));
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-json", feature = "postgres-array"))]
                 Value::JsonArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-ipnetwork")]
-                Value::IpNetwork(_) => {
-                    panic!("Sqlite doesn't support IpNetwork arguments");
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-ipnetwork", feature = "postgres-array"))]
                 Value::IpNetworkArray(_) => panic!("Sqlite doesn't support array"),
-                #[cfg(feature = "with-mac_address")]
-                Value::MacAddress(_) => {
-                    panic!("Sqlite doesn't support MacAddress arguments");
-                }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+                #[cfg(all(feature = "with-mac_address", feature = "postgres-array"))]
                 Value::MacAddressArray(_) => panic!("Sqlite doesn't support array"),
             }
         }

--- a/sea-query-postgres/Cargo.toml
+++ b/sea-query-postgres/Cargo.toml
@@ -29,6 +29,7 @@ with-rust_decimal = ["sea-query/with-rust_decimal", "rust_decimal/db-postgres"]
 with-bigdecimal = ["sea-query/with-bigdecimal"]
 with-uuid = ["postgres-types/with-uuid-1", "sea-query/with-uuid"]
 with-time = ["postgres-types/with-time-0_3", "sea-query/with-time"]
-postgres-array = ["postgres-types/array-impls", "sea-query/postgres-array"]
 with-ipnetwork = ["sea-query/with-ipnetwork"]
 with-mac_address = ["sea-query/with-mac_address"]
+postgres-array = ["postgres-types/array-impls", "sea-query/postgres-array"]
+

--- a/sea-query-postgres/src/lib.rs
+++ b/sea-query-postgres/src/lib.rs
@@ -73,41 +73,99 @@ impl ToSql for PostgresValue {
             Value::Double(v) => to_sql!(v, f64),
             Value::String(v) => v.as_deref().to_sql(ty, out),
             Value::Char(v) => v.map(|v| v.to_string()).to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::BoolArray(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::TinyIntArray(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::SmallIntArray(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::IntArray(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::BigIntArray(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::SmallUnsignedArray(v) => v
+                .as_deref()
+                .map(|v| v.iter().map(|&i| i as u32).collect::<Vec<u32>>())
+                .to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::UnsignedArray(v) => v
+                .as_deref()
+                .map(|v| v.iter().map(|&i| i as i64).collect::<Vec<i64>>())
+                .to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::BigUnsignedArray(v) => v
+                .as_ref()
+                .map(|v| {
+                    v.iter()
+                        .map(|&i| <i64 as TryFrom<u64>>::try_from(i).unwrap())
+                        .collect::<Vec<i64>>()
+                })
+                .to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::FloatArray(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::DoubleArray(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::StringArray(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(feature = "with-array")]
+            Value::CharArray(v) => v
+                .as_ref()
+                .map(|v| v.iter().map(|c| c.to_string()).collect::<Vec<String>>())
+                .to_sql(ty, out),
             Value::Bytes(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-json")]
             Value::Json(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-json", feature = "with-array"))]
+            Value::JsonArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDate(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoTime(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoTimeArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTime(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeUtc(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeUtcArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeLocal(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeLocalArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeWithTimeZoneArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-time")]
             Value::TimeDate(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeDateArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-time")]
             Value::TimeTime(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeTimeArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-time")]
             Value::TimeDateTime(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeDateTimeArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeDateTimeWithTimeZoneArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(all(feature = "postgres-rust_decimal", feature = "with-array"))]
+            Value::DecimalArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(feature = "postgres-array")]
-            Value::Array(Some(v)) => v
-                .iter()
-                .map(|v| PostgresValue(v.clone()))
-                .collect::<Vec<PostgresValue>>()
-                .to_sql(ty, out),
-            #[cfg(feature = "postgres-array")]
-            Value::Array(None) => Ok(IsNull::Yes),
+            #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+            Value::UuidArray(v) => v.as_deref().to_sql(ty, out),
             #[allow(unreachable_patterns)]
             _ => unimplemented!(),
         }

--- a/sea-query-postgres/src/lib.rs
+++ b/sea-query-postgres/src/lib.rs
@@ -160,7 +160,7 @@ impl ToSql for PostgresValue {
             Value::TimeDateTimeWithTimeZoneArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "postgres-rust_decimal", feature = "postgres-array"))]
+            #[cfg(all(feature = "with-rust_decimal", feature = "postgres-array"))]
             Value::DecimalArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(v) => v.as_deref().to_sql(ty, out),

--- a/sea-query-postgres/src/lib.rs
+++ b/sea-query-postgres/src/lib.rs
@@ -73,27 +73,27 @@ impl ToSql for PostgresValue {
             Value::Double(v) => to_sql!(v, f64),
             Value::String(v) => v.as_deref().to_sql(ty, out),
             Value::Char(v) => v.map(|v| v.to_string()).to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::BoolArray(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::TinyIntArray(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::SmallIntArray(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::IntArray(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::BigIntArray(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::SmallUnsignedArray(v) => v
                 .as_deref()
                 .map(|v| v.iter().map(|&i| i as u32).collect::<Vec<u32>>())
                 .to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::UnsignedArray(v) => v
                 .as_deref()
                 .map(|v| v.iter().map(|&i| i as i64).collect::<Vec<i64>>())
                 .to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::BigUnsignedArray(v) => v
                 .as_ref()
                 .map(|v| {
@@ -102,13 +102,13 @@ impl ToSql for PostgresValue {
                         .collect::<Vec<i64>>()
                 })
                 .to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::FloatArray(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::DoubleArray(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::StringArray(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::CharArray(v) => v
                 .as_ref()
                 .map(|v| v.iter().map(|c| c.to_string()).collect::<Vec<String>>())
@@ -116,55 +116,55 @@ impl ToSql for PostgresValue {
             Value::Bytes(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-json")]
             Value::Json(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-json", feature = "with-array"))]
+            #[cfg(all(feature = "with-json", feature = "postgres-array"))]
             Value::JsonArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDate(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoTime(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoTimeArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTime(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeUtc(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeUtcArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeLocal(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeLocalArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeWithTimeZoneArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-time")]
             Value::TimeDate(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeDateArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-time")]
             Value::TimeTime(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeTimeArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-time")]
             Value::TimeDateTime(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeDateTimeArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeDateTimeWithTimeZoneArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "postgres-rust_decimal", feature = "with-array"))]
+            #[cfg(all(feature = "postgres-rust_decimal", feature = "postgres-array"))]
             Value::DecimalArray(v) => v.as_deref().to_sql(ty, out),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(v) => v.as_deref().to_sql(ty, out),
-            #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+            #[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
             Value::UuidArray(v) => v.as_deref().to_sql(ty, out),
             #[allow(unreachable_patterns)]
             _ => unimplemented!(),

--- a/sea-query-rusqlite/src/lib.rs
+++ b/sea-query-rusqlite/src/lib.rs
@@ -126,9 +126,44 @@ impl ToSql for RusqliteValue {
                 panic!("Rusqlite doesn't support MacAddress arguments");
             }
             #[cfg(feature = "postgres-array")]
-            Value::Array(_) => {
-                panic!("Rusqlite doesn't support Array arguments");
+            Value::BoolArray(_)
+            | Value::TinyIntArray(_)
+            | Value::SmallIntArray(_)
+            | Value::IntArray(_)
+            | Value::BigIntArray(_)
+            | Value::SmallUnsignedArray(_)
+            | Value::UnsignedArray(_)
+            | Value::BigUnsignedArray(_)
+            | Value::FloatArray(_)
+            | Value::DoubleArray(_)
+            | Value::StringArray(_)
+            | Value::CharArray(_) => panic!("Rusqlite doesn't support array arguments"),
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+            Value::ChronoDateArray(_)
+            | Value::ChronoTimeArray(_)
+            | Value::ChronoDateTimeArray(_)
+            | Value::ChronoDateTimeUtcArray(_)
+            | Value::ChronoDateTimeLocalArray(_)
+            | Value::ChronoDateTimeWithTimeZoneArray(_) => panic!("Rusqlite doesn't support array"),
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
+            Value::TimeDateArray(_)
+            | Value::TimeTimeArray(_)
+            | Value::TimeDateTimeArray(_)
+            | Value::TimeDateTimeWithTimeZoneArray(_) => {
+                panic!("Rusqlite doesn't support array")
             }
+            #[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
+            Value::UuidArray(_) => panic!("Rusqlite doesn't support array"),
+            #[cfg(all(feature = "with-rust_decimal", feature = "postgres-array"))]
+            Value::DecimalArray(_) => panic!("Rusqlite doesn't support array"),
+            #[cfg(all(feature = "with-bigdecimal", feature = "postgres-array"))]
+            Value::BigDecimalArray(_) => panic!("Rusqlite doesn't support array"),
+            #[cfg(all(feature = "with-json", feature = "postgres-array"))]
+            Value::JsonArray(_) => panic!("Rusqlite doesn't support array"),
+            #[cfg(all(feature = "with-ipnetwork", feature = "postgres-array"))]
+            Value::IpNetworkArray(_) => panic!("Rusqlite doesn't support array"),
+            #[cfg(all(feature = "with-mac_address", feature = "postgres-array"))]
+            Value::MacAddressArray(_) => panic!("Rusqlite doesn't support array"),
         }
     }
 }

--- a/sea-query-rusqlite/src/lib.rs
+++ b/sea-query-rusqlite/src/lib.rs
@@ -2,11 +2,10 @@ use rusqlite::{
     types::{Null, ToSqlOutput},
     Result, ToSql,
 };
-use sea_query::Value;
-use sea_query::{query::*, QueryBuilder};
+use sea_query::{query::*, QueryBuilder, Value};
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct RusqliteValue(pub sea_query::Value);
+pub struct RusqliteValue(pub Value);
 #[derive(Clone, Debug, PartialEq)]
 pub struct RusqliteValues(pub Vec<RusqliteValue>);
 

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -96,7 +96,11 @@ impl TableBuilder for PostgresQueryBuilder {
                 ColumnType::Json => "json".into(),
                 ColumnType::JsonBinary => "jsonb".into(),
                 ColumnType::Uuid => "uuid".into(),
-                ColumnType::Array(elem_type) => format!("{}[]", elem_type.as_ref().unwrap()),
+                ColumnType::Array(elem_type) => {
+                    let mut inner = SqlWriter::new();
+                    self.prepare_column_type(elem_type, &mut inner);
+                    format!("{}[]", inner.result()).into()
+                }
                 ColumnType::Custom(iden) => iden.to_string(),
                 ColumnType::Enum { name, .. } => name.to_string(),
                 ColumnType::Cidr => "cidr".into(),

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -97,9 +97,9 @@ impl TableBuilder for PostgresQueryBuilder {
                 ColumnType::JsonBinary => "jsonb".into(),
                 ColumnType::Uuid => "uuid".into(),
                 ColumnType::Array(elem_type) => {
-                    let mut inner = SqlWriter::new();
+                    let mut inner = String::new();
                     self.prepare_column_type(elem_type, &mut inner);
-                    format!("{}[]", inner.result())
+                    format!("{}[]", inner)
                 }
                 ColumnType::Custom(iden) => iden.to_string(),
                 ColumnType::Enum { name, .. } => name.to_string(),

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -99,7 +99,7 @@ impl TableBuilder for PostgresQueryBuilder {
                 ColumnType::Array(elem_type) => {
                     let mut inner = SqlWriter::new();
                     self.prepare_column_type(elem_type, &mut inner);
-                    format!("{}[]", inner.result()).into()
+                    format!("{}[]", inner.result())
                 }
                 ColumnType::Custom(iden) => iden.to_string(),
                 ColumnType::Enum { name, .. } => name.to_string(),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -948,6 +948,8 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             | Value::CharArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-json")]
             Value::Json(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-json", feature = "with-array"))]
+            Value::JsonArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDate(None) => write!(s, "NULL").unwrap(),
             #[cfg(all(feature = "with-chrono", feature = "with-array"))]
@@ -1058,7 +1060,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             #[cfg(feature = "with-json")]
             Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), &mut s),
             #[cfg(all(feature = "with-json", feature = "with-array"))]
-            Value::JsonArray(Some(v)) => todo!(),
+            Value::JsonArray(Some(_)) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDate(Some(v)) => write!(s, "'{}'", v.format("%Y-%m-%d")).unwrap(),
             #[cfg(all(feature = "with-chrono", feature = "with-array"))]
@@ -1121,11 +1123,11 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(Some(v)) => write!(s, "{}", v).unwrap(),
             #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
-            Value::DecimalArray(Some(v)) => todo!(),
+            Value::DecimalArray(Some(_)) => todo!(),
             #[cfg(feature = "with-bigdecimal")]
             Value::BigDecimal(Some(v)) => write!(s, "{}", v).unwrap(),
             #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
-            Value::BigDecimalArray(Some(v)) => todo!(),
+            Value::BigDecimalArray(Some(_)) => todo!(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(Some(v)) => write!(s, "'{}'", v).unwrap(),
             #[cfg(all(feature = "with-uuid", feature = "with-array"))]

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -933,6 +933,19 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             | Value::String(None)
             | Value::Char(None)
             | Value::Bytes(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-array")]
+            Value::BoolArray(None)
+            | Value::TinyIntArray(None)
+            | Value::SmallIntArray(None)
+            | Value::IntArray(None)
+            | Value::BigIntArray(None)
+            | Value::SmallUnsignedArray(None)
+            | Value::UnsignedArray(None)
+            | Value::BigUnsignedArray(None)
+            | Value::FloatArray(None)
+            | Value::DoubleArray(None)
+            | Value::StringArray(None)
+            | Value::CharArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-json")]
             Value::Json(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
@@ -965,8 +978,6 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             Value::IpNetwork(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "postgres-array")]
-            Value::Array(None) => write!(s, "NULL").unwrap(),
             Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
             Value::TinyInt(Some(v)) => write!(s, "{}", v).unwrap(),
             Value::SmallInt(Some(v)) => write!(s, "{}", v).unwrap(),
@@ -988,6 +999,31 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 v.iter().map(|b| format!("{:02X}", b)).collect::<String>()
             )
             .unwrap(),
+            #[cfg(feature = "with-array")]
+            Value::BoolArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::TinyIntArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::SmallIntArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::IntArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::BigIntArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::SmallUnsignedArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::UnsignedArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::BigUnsignedArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::FloatArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::DoubleArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::StringArray(Some(_)) => {}
+            #[cfg(feature = "with-array")]
+            Value::CharArray(Some(_)) => {}
+
             #[cfg(feature = "with-json")]
             Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), &mut s),
             #[cfg(feature = "with-chrono")]
@@ -1035,16 +1071,6 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             Value::BigDecimal(Some(v)) => write!(s, "{}", v).unwrap(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(Some(v)) => write!(s, "'{}'", v).unwrap(),
-            #[cfg(feature = "postgres-array")]
-            Value::Array(Some(v)) => write!(
-                s,
-                "'{{{}}}'",
-                v.iter()
-                    .map(|element| self.value_to_string(element))
-                    .collect::<Vec<String>>()
-                    .join(",")
-            )
-            .unwrap(),
             #[cfg(feature = "with-ipnetwork")]
             Value::IpNetwork(Some(v)) => write!(s, "'{}'", v).unwrap(),
             #[cfg(feature = "with-mac_address")]

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -933,7 +933,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             | Value::String(None)
             | Value::Char(None)
             | Value::Bytes(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::BoolArray(None)
             | Value::TinyIntArray(None)
             | Value::SmallIntArray(None)
@@ -948,67 +948,67 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             | Value::CharArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-json")]
             Value::Json(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-json", feature = "with-array"))]
+            #[cfg(all(feature = "with-json", feature = "postgres-array"))]
             Value::JsonArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDate(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoTimeArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeUtc(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeUtcArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeLocal(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeLocalArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeWithTimeZoneArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
             Value::TimeDate(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeDateArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
             Value::TimeTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeTimeArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
             Value::TimeDateTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeDateTimeArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeDateTimeWithTimeZoneArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+            #[cfg(all(feature = "with-rust_decimal", feature = "postgres-array"))]
             Value::DecimalArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-bigdecimal")]
             Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
+            #[cfg(all(feature = "with-bigdecimal", feature = "postgres-array"))]
             Value::BigDecimalArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+            #[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
             Value::UuidArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-ipnetwork")]
             Value::IpNetwork(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+            #[cfg(all(feature = "with-ipnetwork", feature = "postgres-array"))]
             Value::IpNetworkArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(None) => write!(s, "NULL").unwrap(),
-            #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
+            #[cfg(all(feature = "with-mac_address", feature = "postgres-array"))]
             Value::MacAddressArray(None) => write!(s, "NULL").unwrap(),
 
             Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
@@ -1032,84 +1032,84 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 v.iter().map(|b| format!("{:02X}", b)).collect::<String>()
             )
             .unwrap(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::BoolArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::TinyIntArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::SmallIntArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::IntArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::BigIntArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::SmallUnsignedArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::UnsignedArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::BigUnsignedArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::FloatArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::DoubleArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::StringArray(Some(_)) => todo!(),
-            #[cfg(feature = "with-array")]
+            #[cfg(feature = "postgres-array")]
             Value::CharArray(Some(_)) => todo!(),
 
             #[cfg(feature = "with-json")]
             Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), &mut s),
-            #[cfg(all(feature = "with-json", feature = "with-array"))]
+            #[cfg(all(feature = "with-json", feature = "postgres-array"))]
             Value::JsonArray(Some(_)) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDate(Some(v)) => write!(s, "'{}'", v.format("%Y-%m-%d")).unwrap(),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateArray(_) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoTime(Some(v)) => write!(s, "'{}'", v.format("%H:%M:%S")).unwrap(),
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoTimeArray(_) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTime(Some(v)) => {
                 write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S")).unwrap()
             }
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeArray(_) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeUtc(Some(v)) => {
                 write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeUtcArray(_) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeLocal(Some(v)) => {
                 write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeLocalArray(_) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(Some(v)) => {
                 write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
-            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
             Value::ChronoDateTimeWithTimeZoneArray(_) => todo!(),
             #[cfg(feature = "with-time")]
             Value::TimeDate(Some(v)) => {
                 write!(s, "'{}'", v.format(time_format::FORMAT_DATE).unwrap()).unwrap()
             }
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeDateArray(_) => todo!(),
             #[cfg(feature = "with-time")]
             Value::TimeTime(Some(v)) => {
                 write!(s, "'{}'", v.format(time_format::FORMAT_TIME).unwrap()).unwrap()
             }
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeTimeArray(_) => todo!(),
             #[cfg(feature = "with-time")]
             Value::TimeDateTime(Some(v)) => {
                 write!(s, "'{}'", v.format(time_format::FORMAT_DATETIME).unwrap()).unwrap()
             }
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeDateTimeArray(_) => todo!(),
             #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(Some(v)) => write!(
@@ -1118,27 +1118,27 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 v.format(time_format::FORMAT_DATETIME_TZ).unwrap()
             )
             .unwrap(),
-            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            #[cfg(all(feature = "with-time", feature = "postgres-array"))]
             Value::TimeDateTimeWithTimeZoneArray(_) => todo!(),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(Some(v)) => write!(s, "{}", v).unwrap(),
-            #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+            #[cfg(all(feature = "with-rust_decimal", feature = "postgres-array"))]
             Value::DecimalArray(Some(_)) => todo!(),
             #[cfg(feature = "with-bigdecimal")]
             Value::BigDecimal(Some(v)) => write!(s, "{}", v).unwrap(),
-            #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
+            #[cfg(all(feature = "with-bigdecimal", feature = "postgres-array"))]
             Value::BigDecimalArray(Some(_)) => todo!(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(Some(v)) => write!(s, "'{}'", v).unwrap(),
-            #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+            #[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
             Value::UuidArray(Some(_)) => todo!(),
             #[cfg(feature = "with-ipnetwork")]
             Value::IpNetwork(Some(v)) => write!(s, "'{}'", v).unwrap(),
-            #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+            #[cfg(all(feature = "with-ipnetwork", feature = "postgres-array"))]
             Value::IpNetworkArray(Some(_)) => todo!(),
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(Some(v)) => write!(s, "'{}'", v).unwrap(),
-            #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
+            #[cfg(all(feature = "with-mac_address", feature = "postgres-array"))]
             Value::MacAddressArray(Some(_)) => todo!(),
         };
         s

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -950,34 +950,64 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             Value::Json(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDate(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoTimeArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeUtc(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeUtcArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeLocal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeLocalArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeWithTimeZoneArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
             Value::TimeDate(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeDateArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
             Value::TimeTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeTimeArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
             Value::TimeDateTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeDateTimeArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeDateTimeWithTimeZoneArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+            Value::DecimalArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-bigdecimal")]
             Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
+            Value::BigDecimalArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+            Value::UuidArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-ipnetwork")]
             Value::IpNetwork(None) => write!(s, "NULL").unwrap(),
+            #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+            Value::IpNetworkArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-mac_address")]
+            Value::MacAddressArray(None) => write!(s, "NULL").unwrap(),
 
             Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
             Value::TinyInt(Some(v)) => write!(s, "{}", v).unwrap(),
@@ -1027,38 +1057,58 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
             #[cfg(feature = "with-json")]
             Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), &mut s),
+            #[cfg(all(feature = "with-json", feature = "with-array"))]
+            Value::JsonArray(Some(v)) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDate(Some(v)) => write!(s, "'{}'", v.format("%Y-%m-%d")).unwrap(),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateArray(_) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoTime(Some(v)) => write!(s, "'{}'", v.format("%H:%M:%S")).unwrap(),
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoTimeArray(_) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTime(Some(v)) => {
                 write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S")).unwrap()
             }
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeArray(_) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeUtc(Some(v)) => {
                 write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeUtcArray(_) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeLocal(Some(v)) => {
                 write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeLocalArray(_) => todo!(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(Some(v)) => {
                 write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
+            #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+            Value::ChronoDateTimeWithTimeZoneArray(_) => todo!(),
             #[cfg(feature = "with-time")]
             Value::TimeDate(Some(v)) => {
                 write!(s, "'{}'", v.format(time_format::FORMAT_DATE).unwrap()).unwrap()
             }
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeDateArray(_) => todo!(),
             #[cfg(feature = "with-time")]
             Value::TimeTime(Some(v)) => {
                 write!(s, "'{}'", v.format(time_format::FORMAT_TIME).unwrap()).unwrap()
             }
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeTimeArray(_) => todo!(),
             #[cfg(feature = "with-time")]
             Value::TimeDateTime(Some(v)) => {
                 write!(s, "'{}'", v.format(time_format::FORMAT_DATETIME).unwrap()).unwrap()
             }
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeDateTimeArray(_) => todo!(),
             #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(Some(v)) => write!(
                 s,
@@ -1066,16 +1116,28 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 v.format(time_format::FORMAT_DATETIME_TZ).unwrap()
             )
             .unwrap(),
+            #[cfg(all(feature = "with-time", feature = "with-array"))]
+            Value::TimeDateTimeWithTimeZoneArray(_) => todo!(),
             #[cfg(feature = "with-rust_decimal")]
             Value::Decimal(Some(v)) => write!(s, "{}", v).unwrap(),
+            #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+            Value::DecimalArray(Some(v)) => todo!(),
             #[cfg(feature = "with-bigdecimal")]
             Value::BigDecimal(Some(v)) => write!(s, "{}", v).unwrap(),
+            #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
+            Value::BigDecimalArray(Some(v)) => todo!(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(Some(v)) => write!(s, "'{}'", v).unwrap(),
+            #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+            Value::UuidArray(Some(_)) => todo!(),
             #[cfg(feature = "with-ipnetwork")]
             Value::IpNetwork(Some(v)) => write!(s, "'{}'", v).unwrap(),
+            #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+            Value::IpNetworkArray(Some(_)) => todo!(),
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(Some(v)) => write!(s, "'{}'", v).unwrap(),
+            #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
+            Value::MacAddressArray(Some(_)) => todo!(),
         };
         s
     }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1008,7 +1008,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             Value::IpNetworkArray(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-mac_address")]
+            #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
             Value::MacAddressArray(None) => write!(s, "NULL").unwrap(),
 
             Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -978,6 +978,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             Value::IpNetwork(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(None) => write!(s, "NULL").unwrap(),
+
             Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
             Value::TinyInt(Some(v)) => write!(s, "{}", v).unwrap(),
             Value::SmallInt(Some(v)) => write!(s, "{}", v).unwrap(),
@@ -1000,29 +1001,29 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             )
             .unwrap(),
             #[cfg(feature = "with-array")]
-            Value::BoolArray(Some(_)) => {}
+            Value::BoolArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::TinyIntArray(Some(_)) => {}
+            Value::TinyIntArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::SmallIntArray(Some(_)) => {}
+            Value::SmallIntArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::IntArray(Some(_)) => {}
+            Value::IntArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::BigIntArray(Some(_)) => {}
+            Value::BigIntArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::SmallUnsignedArray(Some(_)) => {}
+            Value::SmallUnsignedArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::UnsignedArray(Some(_)) => {}
+            Value::UnsignedArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::BigUnsignedArray(Some(_)) => {}
+            Value::BigUnsignedArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::FloatArray(Some(_)) => {}
+            Value::FloatArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::DoubleArray(Some(_)) => {}
+            Value::DoubleArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::StringArray(Some(_)) => {}
+            Value::StringArray(Some(_)) => todo!(),
             #[cfg(feature = "with-array")]
-            Value::CharArray(Some(_)) => {}
+            Value::CharArray(Some(_)) => todo!(),
 
             #[cfg(feature = "with-json")]
             Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), &mut s),

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -198,10 +198,7 @@ impl InsertStatement {
     where
         I: IntoIterator<Item = SimpleExpr>,
     {
-        let values = values
-            .into_iter()
-            .map(|v| v.into())
-            .collect::<Vec<SimpleExpr>>();
+        let values = values.into_iter().collect::<Vec<SimpleExpr>>();
         if self.columns.len() != values.len() {
             return Err(Error::ColValNumMismatch {
                 col_len: self.columns.len(),

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -45,7 +45,7 @@ pub enum ColumnType {
         name: DynIden,
         variants: Vec<DynIden>,
     },
-    Array(Option<String>),
+    Array(Box<ColumnType>),
     Cidr,
     Inet,
     MacAddr,
@@ -524,8 +524,8 @@ impl ColumnDef {
 
     /// Set column type as an array with a specified element type.
     /// This is only supported on Postgres.
-    pub fn array(&mut self, elem_type: String) -> &mut Self {
-        self.types = Some(ColumnType::Array(Some(elem_type)));
+    pub fn array(&mut self, elem_type: ColumnType) -> &mut Self {
+        self.types = Some(ColumnType::Array(Box::new(elem_type)));
         self
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -81,66 +81,126 @@ pub enum Value {
     #[cfg(feature = "with-json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-json")))]
     Json(Option<Box<Json>>),
+    #[cfg(all(feature = "with-json", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-json", feature = "with-array"))))]
+    JsonArray(Option<Vec<Json>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDate(Option<Box<NaiveDate>>),
+    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    ChronoDateArray(Option<Vec<NaiveDate>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoTime(Option<Box<NaiveTime>>),
+    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    ChronoTimeArray(Option<Vec<NaiveTime>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDateTime(Option<Box<NaiveDateTime>>),
+    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    ChronoDateTimeArray(Option<Vec<NaiveDateTime>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDateTimeUtc(Option<Box<DateTime<Utc>>>),
+    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    ChronoDateTimeUtcArray(Option<Vec<DateTime<Utc>>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDateTimeLocal(Option<Box<DateTime<Local>>>),
+    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    ChronoDateTimeLocalArray(Option<Vec<DateTime<Local>>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDateTimeWithTimeZone(Option<Box<DateTime<FixedOffset>>>),
+    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    ChronoDateTimeWithTimeZoneArray(Option<Vec<DateTime<FixedOffset>>>),
 
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeDate(Option<Box<time::Date>>),
+    #[cfg(all(feature = "with-time", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-time", feature = "with-array"))))]
+    TimeDateArray(Option<Vec<time::Date>>),
 
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeTime(Option<Box<time::Time>>),
+    #[cfg(all(feature = "with-time", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-time", feature = "with-array"))))]
+    TimeTimeArray(Option<Vec<time::Time>>),
 
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeDateTime(Option<Box<PrimitiveDateTime>>),
+    #[cfg(all(feature = "with-time", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-time", feature = "with-array"))))]
+    TimeDateTimeArray(Option<Vec<PrimitiveDateTime>>),
 
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeDateTimeWithTimeZone(Option<Box<OffsetDateTime>>),
+    #[cfg(all(feature = "with-time", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-time", feature = "with-array"))))]
+    TimeDateTimeWithTimeZoneArray(Option<Vec<OffsetDateTime>>),
 
     #[cfg(feature = "with-uuid")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
     Uuid(Option<Box<Uuid>>),
+    #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-uuid", feature = "with-array"))))]
+    UuidArray(Option<Vec<Uuid>>),
 
     #[cfg(feature = "with-rust_decimal")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-rust_decimal")))]
     Decimal(Option<Box<Decimal>>),
+    #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-rust_decimal", feature = "with-array")))
+    )]
+    DecimalArray(Option<Vec<Decimal>>),
 
     #[cfg(feature = "with-bigdecimal")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-bigdecimal")))]
     BigDecimal(Option<Box<BigDecimal>>),
+    #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-bigdecimal", feature = "with-array")))
+    )]
+    BigDecimalArray(Option<Vec<BigDecimal>>),
 
     #[cfg(feature = "with-ipnetwork")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-ipnetwork")))]
     IpNetwork(Option<Box<IpNetwork>>),
+    #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-ipnetwork", feature = "with-array")))
+    )]
+    IpNetworkArray(Option<Vec<IpNetwork>>),
 
     #[cfg(feature = "with-mac_address")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-mac_address")))]
     MacAddress(Option<Box<MacAddress>>),
+    #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-mac_address", feature = "with-array")))
+    )]
+    MacAddressArray(Option<Box<MacAddress>>),
 }
 
 impl std::fmt::Display for Value {
@@ -350,6 +410,9 @@ mod with_json {
     use super::*;
 
     type_to_box_value!(Json, Json, Json);
+
+    #[cfg(feature = "with-array")]
+    type_to_value!(Vec<Json>, JsonArray, Array(Box::new(Json)));
 }
 
 #[cfg(feature = "with-chrono")]
@@ -449,6 +512,35 @@ mod with_chrono {
             ColumnType::TimestampWithTimeZone(None)
         }
     }
+
+    #[cfg(feature = "with-array")]
+    type_to_value!(Vec<NaiveDate>, ChronoDateArray, Array(Box::new(Date)));
+    #[cfg(feature = "with-array")]
+    type_to_value!(Vec<NaiveTime>, ChronoTimeArray, Array(Box::new(Time(None))));
+    #[cfg(feature = "with-array")]
+    type_to_value!(
+        Vec<NaiveDateTime>,
+        ChronoDateTimeArray,
+        Array(Box::new(DateTime(None)))
+    );
+    #[cfg(feature = "with-array")]
+    type_to_value!(
+        Vec<DateTime<Local>>,
+        ChronoDateTimeLocalArray,
+        Array(Box::new(TimestampWithTimeZone(None)))
+    );
+    #[cfg(feature = "with-array")]
+    type_to_value!(
+        Vec<DateTime<Utc>>,
+        ChronoDateTimeUtcArray,
+        Array(Box::new(TimestampWithTimeZone(None)))
+    );
+    #[cfg(feature = "with-array")]
+    type_to_value!(
+        Vec<DateTime<FixedOffset>>,
+        ChronoDateTimeWithTimeZoneArray,
+        Array(Box::new(TimestampWithTimeZone(None)))
+    );
 }
 
 #[cfg(feature = "with-time")]
@@ -504,6 +596,23 @@ mod with_time {
             ColumnType::TimestampWithTimeZone(None)
         }
     }
+
+    #[cfg(feature = "with-array")]
+    type_to_value!(Vec<time::Date>, TimeDateArray, Array(Box::new(Date)));
+    #[cfg(feature = "with-array")]
+    type_to_value!(Vec<time::Time>, TimeTimeArray, Array(Box::new(Time(None))));
+    #[cfg(feature = "with-array")]
+    type_to_value!(
+        Vec<PrimitiveDateTime>,
+        TimeDateTimeArray,
+        Array(Box::new(DateTime(None)))
+    );
+    #[cfg(feature = "with-array")]
+    type_to_value!(
+        Vec<OffsetDateTime>,
+        TimeDateTimeWithTimeZoneArray,
+        Array(Box::new(TimestampWithTimeZone(None)))
+    );
 }
 
 #[cfg(feature = "with-rust_decimal")]
@@ -512,6 +621,9 @@ mod with_rust_decimal {
     use super::*;
 
     type_to_box_value!(Decimal, Decimal, Decimal(None));
+
+    #[cfg(feature = "with-array")]
+    type_to_value!(Vec<Decimal>, DecimalArray, Array(Box::new(Decimal(None))));
 }
 
 #[cfg(feature = "with-bigdecimal")]
@@ -520,6 +632,13 @@ mod with_bigdecimal {
     use super::*;
 
     type_to_box_value!(BigDecimal, BigDecimal, Decimal(None));
+
+    #[cfg(feature = "with-array")]
+    type_to_value!(
+        Vec<BigDecimal>,
+        BigDecimalArray,
+        Array(Box::new(Decimal(None)))
+    );
 }
 
 #[cfg(feature = "with-uuid")]
@@ -536,6 +655,9 @@ mod with_ipnetwork {
     use super::*;
 
     type_to_box_value!(IpNetwork, IpNetwork, Inet);
+
+    #[cfg(feature = "with-array")]
+    type_to_value!(Vec<IpNetwork>, IpNetwork, Array(Box::new(Inet)));
 }
 
 #[cfg(feature = "with-mac_address")]
@@ -544,6 +666,9 @@ mod with_mac_address {
     use super::*;
 
     type_to_box_value!(MacAddress, MacAddress, MacAddr);
+
+    #[cfg(feature = "with-array")]
+    type_to_value!(Vec<MacAddress>, MacAddressArray, Array(Box::new(MacAddr)));
 }
 
 #[cfg(feature = "with-array")]
@@ -551,61 +676,26 @@ mod with_mac_address {
 mod with_array {
     use super::*;
 
-    macro_rules! impl_array {
-        ( $type: ty, $name: ident) => {
-            impl From<Vec<$type>> for Value {
-                fn from(x: Vec<$type>) -> Value {
-                    Value::$name(Some(x))
-                }
-            }
-
-            impl Nullable for Vec<$type> {
-                fn null() -> Value {
-                    Value::$name(None)
-                }
-            }
-
-            impl ValueType for Vec<$type> {
-                fn try_from(v: Value) -> Result<Self, ValueTypeErr> {
-                    match v {
-                        Value::$name(Some(v)) => Ok(v.into_iter().collect()),
-                        _ => Err(ValueTypeErr),
-                    }
-                }
-
-                fn type_name() -> String {
-                    stringify!(Vec<$type>).to_owned()
-                }
-
-                fn column_type() -> ColumnType {
-                    ColumnType::Array(Box::new(<$type as ValueType>::column_type()))
-                }
-            }
-        };
-    }
-
-    impl_array!(bool, BoolArray);
-    impl_array!(i8, TinyIntArray);
-    impl_array!(i16, SmallIntArray);
-    impl_array!(i32, IntArray);
-    impl_array!(i64, BigIntArray);
-    impl_array!(u16, SmallUnsignedArray);
-    impl_array!(u32, UnsignedArray);
-    impl_array!(u64, BigUnsignedArray);
-    impl_array!(f32, FloatArray);
-    impl_array!(f64, DoubleArray);
-    impl_array!(String, StringArray);
-    impl_array!(char, CharArray);
-}
-
-#[allow(unused_macros)]
-macro_rules! box_to_opt_ref {
-    ( $v: expr ) => {
-        match $v {
-            Some(v) => Some(v.as_ref()),
-            None => None,
-        }
-    };
+    type_to_value!(Vec<bool>, BoolArray, Array(Box::new(Boolean)));
+    type_to_value!(Vec<i8>, TinyIntArray, Array(Box::new(TinyInteger(None))));
+    type_to_value!(Vec<i16>, SmallIntArray, Array(Box::new(SmallInteger(None))));
+    type_to_value!(Vec<i32>, IntArray, Array(Box::new(Integer(None))));
+    type_to_value!(Vec<i64>, BigIntArray, Array(Box::new(BigInteger(None))));
+    type_to_value!(
+        Vec<u16>,
+        SmallUnsignedArray,
+        Array(Box::new(SmallUnsigned(None)))
+    );
+    type_to_value!(Vec<u32>, UnsignedArray, Array(Box::new(Unsigned(None))));
+    type_to_value!(
+        Vec<u64>,
+        BigUnsignedArray,
+        Array(Box::new(BigUnsigned(None)))
+    );
+    type_to_value!(Vec<f32>, FloatArray, Array(Box::new(Float(None))));
+    type_to_value!(Vec<f64>, DoubleArray, Array(Box::new(Double(None))));
+    type_to_value!(Vec<String>, StringArray, Array(Box::new(String(None))));
+    type_to_value!(Vec<char>, CharArray, Array(Box::new(Char(None))));
 }
 
 #[cfg(feature = "with-json")]
@@ -616,7 +706,7 @@ impl Value {
 
     pub fn as_ref_json(&self) -> Option<&Json> {
         match self {
-            Self::Json(v) => box_to_opt_ref!(v),
+            Self::Json(v) => v.as_deref(),
             _ => panic!("not Value::Json"),
         }
     }
@@ -630,140 +720,66 @@ impl Value {
 
     pub fn as_ref_chrono_date(&self) -> Option<&NaiveDate> {
         match self {
-            Self::ChronoDate(v) => box_to_opt_ref!(v),
+            Self::ChronoDate(v) => v.as_deref(),
             _ => panic!("not Value::ChronoDate"),
         }
     }
-}
 
-#[cfg(feature = "with-time")]
-impl Value {
-    pub fn is_time_date(&self) -> bool {
-        matches!(self, Self::TimeDate(_))
-    }
-
-    pub fn as_ref_time_date(&self) -> Option<&time::Date> {
-        match self {
-            Self::TimeDate(v) => box_to_opt_ref!(v),
-            _ => panic!("not Value::TimeDate"),
-        }
-    }
-}
-
-#[cfg(feature = "with-chrono")]
-impl Value {
-    pub fn is_chrono_time(&self) -> bool {
-        matches!(self, Self::ChronoTime(_))
-    }
-
-    pub fn as_ref_chrono_time(&self) -> Option<&NaiveTime> {
-        match self {
-            Self::ChronoTime(v) => box_to_opt_ref!(v),
-            _ => panic!("not Value::ChronoTime"),
-        }
-    }
-}
-
-#[cfg(feature = "with-time")]
-impl Value {
-    pub fn is_time_time(&self) -> bool {
-        matches!(self, Self::TimeTime(_))
-    }
-
-    pub fn as_ref_time_time(&self) -> Option<&time::Time> {
-        match self {
-            Self::TimeTime(v) => box_to_opt_ref!(v),
-            _ => panic!("not Value::TimeTime"),
-        }
-    }
-}
-
-#[cfg(feature = "with-chrono")]
-impl Value {
     pub fn is_chrono_date_time(&self) -> bool {
         matches!(self, Self::ChronoDateTime(_))
     }
 
     pub fn as_ref_chrono_date_time(&self) -> Option<&NaiveDateTime> {
         match self {
-            Self::ChronoDateTime(v) => box_to_opt_ref!(v),
+            Self::ChronoDateTime(v) => v.as_deref(),
             _ => panic!("not Value::ChronoDateTime"),
         }
     }
-}
 
-#[cfg(feature = "with-time")]
-impl Value {
-    pub fn is_time_date_time(&self) -> bool {
-        matches!(self, Self::TimeDateTime(_))
+    pub fn is_chrono_time(&self) -> bool {
+        matches!(self, Self::ChronoTime(_))
     }
 
-    pub fn as_ref_time_date_time(&self) -> Option<&PrimitiveDateTime> {
+    pub fn as_ref_chrono_time(&self) -> Option<&NaiveTime> {
         match self {
-            Self::TimeDateTime(v) => box_to_opt_ref!(v),
-            _ => panic!("not Value::TimeDateTime"),
+            Self::ChronoTime(v) => v.as_deref(),
+            _ => panic!("not Value::ChronoTime"),
         }
     }
-}
 
-#[cfg(feature = "with-chrono")]
-impl Value {
     pub fn is_chrono_date_time_utc(&self) -> bool {
         matches!(self, Self::ChronoDateTimeUtc(_))
     }
 
     pub fn as_ref_chrono_date_time_utc(&self) -> Option<&DateTime<Utc>> {
         match self {
-            Self::ChronoDateTimeUtc(v) => box_to_opt_ref!(v),
+            Self::ChronoDateTimeUtc(v) => v.as_deref(),
             _ => panic!("not Value::ChronoDateTimeUtc"),
         }
     }
-}
 
-#[cfg(feature = "with-chrono")]
-impl Value {
     pub fn is_chrono_date_time_local(&self) -> bool {
         matches!(self, Self::ChronoDateTimeLocal(_))
     }
 
     pub fn as_ref_chrono_date_time_local(&self) -> Option<&DateTime<Local>> {
         match self {
-            Self::ChronoDateTimeLocal(v) => box_to_opt_ref!(v),
+            Self::ChronoDateTimeLocal(v) => v.as_deref(),
             _ => panic!("not Value::ChronoDateTimeLocal"),
         }
     }
-}
 
-#[cfg(feature = "with-chrono")]
-impl Value {
     pub fn is_chrono_date_time_with_time_zone(&self) -> bool {
         matches!(self, Self::ChronoDateTimeWithTimeZone(_))
     }
 
     pub fn as_ref_chrono_date_time_with_time_zone(&self) -> Option<&DateTime<FixedOffset>> {
         match self {
-            Self::ChronoDateTimeWithTimeZone(v) => box_to_opt_ref!(v),
+            Self::ChronoDateTimeWithTimeZone(v) => v.as_deref(),
             _ => panic!("not Value::ChronoDateTimeWithTimeZone"),
         }
     }
-}
 
-#[cfg(feature = "with-time")]
-impl Value {
-    pub fn is_time_date_time_with_time_zone(&self) -> bool {
-        matches!(self, Self::TimeDateTimeWithTimeZone(_))
-    }
-
-    pub fn as_ref_time_date_time_with_time_zone(&self) -> Option<&OffsetDateTime> {
-        match self {
-            Self::TimeDateTimeWithTimeZone(v) => box_to_opt_ref!(v),
-            _ => panic!("not Value::TimeDateTimeWithTimeZone"),
-        }
-    }
-}
-
-#[cfg(feature = "with-chrono")]
-impl Value {
     pub fn chrono_as_naive_utc_in_string(&self) -> Option<String> {
         match self {
             Self::ChronoDate(v) => v.as_ref().map(|v| v.to_string()),
@@ -779,6 +795,50 @@ impl Value {
 
 #[cfg(feature = "with-time")]
 impl Value {
+    pub fn is_time_date(&self) -> bool {
+        matches!(self, Self::TimeDate(_))
+    }
+
+    pub fn as_ref_time_date(&self) -> Option<&time::Date> {
+        match self {
+            Self::TimeDate(v) => v.as_deref(),
+            _ => panic!("not Value::TimeDate"),
+        }
+    }
+
+    pub fn is_time_time(&self) -> bool {
+        matches!(self, Self::TimeTime(_))
+    }
+
+    pub fn as_ref_time_time(&self) -> Option<&time::Time> {
+        match self {
+            Self::TimeTime(v) => v.as_deref(),
+            _ => panic!("not Value::TimeTime"),
+        }
+    }
+
+    pub fn is_time_date_time(&self) -> bool {
+        matches!(self, Self::TimeDateTime(_))
+    }
+
+    pub fn as_ref_time_date_time(&self) -> Option<&PrimitiveDateTime> {
+        match self {
+            Self::TimeDateTime(v) => v.as_deref(),
+            _ => panic!("not Value::TimeDateTime"),
+        }
+    }
+
+    pub fn is_time_date_time_with_time_zone(&self) -> bool {
+        matches!(self, Self::TimeDateTimeWithTimeZone(_))
+    }
+
+    pub fn as_ref_time_date_time_with_time_zone(&self) -> Option<&OffsetDateTime> {
+        match self {
+            Self::TimeDateTimeWithTimeZone(v) => v.as_deref(),
+            _ => panic!("not Value::TimeDateTimeWithTimeZone"),
+        }
+    }
+
     pub fn time_as_naive_utc_in_string(&self) -> Option<String> {
         match self {
             Self::TimeDate(v) => v
@@ -808,7 +868,7 @@ impl Value {
 
     pub fn as_ref_decimal(&self) -> Option<&Decimal> {
         match self {
-            Self::Decimal(v) => box_to_opt_ref!(v),
+            Self::Decimal(v) => v.as_deref(),
             _ => panic!("not Value::Decimal"),
         }
     }
@@ -828,7 +888,7 @@ impl Value {
 
     pub fn as_ref_big_decimal(&self) -> Option<&BigDecimal> {
         match self {
-            Self::BigDecimal(v) => box_to_opt_ref!(v),
+            Self::BigDecimal(v) => v.as_deref(),
             _ => panic!("not Value::BigDecimal"),
         }
     }
@@ -846,7 +906,7 @@ impl Value {
     }
     pub fn as_ref_uuid(&self) -> Option<&Uuid> {
         match self {
-            Self::Uuid(v) => box_to_opt_ref!(v),
+            Self::Uuid(v) => v.as_deref(),
             _ => panic!("not Value::Uuid"),
         }
     }
@@ -860,7 +920,7 @@ impl Value {
 
     pub fn as_ref_ipnetwork(&self) -> Option<&IpNetwork> {
         match self {
-            Self::IpNetwork(v) => box_to_opt_ref!(v),
+            Self::IpNetwork(v) => v.as_deref(),
             _ => panic!("not Value::IpNetwork"),
         }
     }
@@ -881,7 +941,7 @@ impl Value {
 
     pub fn as_ref_mac_address(&self) -> Option<&MacAddress> {
         match self {
-            Self::MacAddress(v) => box_to_opt_ref!(v),
+            Self::MacAddress(v) => v.as_deref(),
             _ => panic!("not Value::MacAddress"),
         }
     }
@@ -1138,18 +1198,34 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         | Value::FloatArray(None)
         | Value::DoubleArray(None)
         | Value::StringArray(None)
-        | Value::CharArray(None) => Json::Null,
+        | Value::CharArray(None)
+        | Value::JsonArray(None) => Json::Null,
 
         #[cfg(feature = "with-rust_decimal")]
         Value::Decimal(None) => Json::Null,
+        #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+        Value::DecimalArray(None) => Json::Null,
+
         #[cfg(feature = "with-bigdecimal")]
         Value::BigDecimal(None) => Json::Null,
+        #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
+        Value::BigDecimalArray(None) => Json::Null,
+
         #[cfg(feature = "with-uuid")]
         Value::Uuid(None) => Json::Null,
+        #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+        Value::UuidArray(None) => Json::Null,
+
         #[cfg(feature = "with-ipnetwork")]
         Value::IpNetwork(None) => Json::Null,
+        #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+        Value::IpNetworkArray(None) => Json::Null,
+
         #[cfg(feature = "with-mac_address")]
         Value::MacAddress(None) => Json::Null,
+        #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
+        Value::MacAddressArray(None) => Json::Null,
+
         Value::Bool(Some(b)) => Json::Bool(*b),
         Value::TinyInt(Some(v)) => (*v).into(),
         Value::SmallInt(Some(v)) => (*v).into(),
@@ -1165,6 +1241,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::Char(Some(v)) => Json::String(v.to_string()),
         Value::Bytes(Some(s)) => Json::String(from_utf8(s).unwrap().to_string()),
         Value::Json(Some(v)) => v.as_ref().clone(),
+        Value::JsonArray(Some(v)) => todo!(),
         #[cfg(feature = "with-array")]
         Value::BoolArray(Some(v)) => v.as_slice().into(),
         #[cfg(feature = "with-array")]
@@ -1195,40 +1272,75 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
             .into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDate(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        Value::ChronoDateArray(_) => todo!(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        Value::ChronoTimeArray(_) => todo!(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        Value::ChronoDateTimeArray(_) => todo!(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeWithTimeZone(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        Value::ChronoDateTimeWithTimeZoneArray(_) => todo!(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeUtc(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        Value::ChronoDateTimeUtcArray(_) => todo!(),
+        #[cfg(feature = "with-chrono")]
+        Value::ChronoDateTimeUtc(_) => todo!(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeLocal(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        Value::ChronoDateTimeLocalArray(_) => todo!(),
+
         #[cfg(feature = "with-time")]
         Value::TimeDate(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-time", feature = "with-array"))]
+        Value::TimeDateArray(_) => todo!(),
         #[cfg(feature = "with-time")]
         Value::TimeTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-time", feature = "with-array"))]
+        Value::TimeTimeArray(_) => todo!(),
         #[cfg(feature = "with-time")]
         Value::TimeDateTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-time", feature = "with-array"))]
+        Value::TimeDateTimeArray(_) => todo!(),
+
         #[cfg(feature = "with-time")]
         Value::TimeDateTimeWithTimeZone(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-time", feature = "with-array"))]
+        Value::TimeDateTimeWithTimeZoneArray(_) => todo!(),
+
         #[cfg(feature = "with-rust_decimal")]
         Value::Decimal(Some(v)) => {
             use rust_decimal::prelude::ToPrimitive;
             v.as_ref().to_f64().unwrap().into()
         }
+        #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+        Value::DecimalArray(Some(v)) => todo!(),
         #[cfg(feature = "with-bigdecimal")]
         Value::BigDecimal(Some(v)) => {
             use bigdecimal::ToPrimitive;
             v.as_ref().to_f64().unwrap().into()
         }
+        #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+        Value::BigDecimalArray(Some(v)) => todo!(),
         #[cfg(feature = "with-uuid")]
         Value::Uuid(Some(v)) => Json::String(v.to_string()),
+        #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+        Value::UuidArray(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-ipnetwork")]
         Value::IpNetwork(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+        Value::IpNetworkArray(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-mac_address")]
         Value::MacAddress(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
+        Value::MacAddressArray(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -50,29 +50,29 @@ pub enum Value {
     String(Option<Box<String>>),
     Char(Option<char>),
 
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     BoolArray(Option<Vec<bool>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     TinyIntArray(Option<Vec<i8>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     SmallIntArray(Option<Vec<i16>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     IntArray(Option<Vec<i32>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     BigIntArray(Option<Vec<i64>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     SmallUnsignedArray(Option<Vec<u16>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     UnsignedArray(Option<Vec<u32>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     BigUnsignedArray(Option<Vec<u64>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     FloatArray(Option<Vec<f32>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     DoubleArray(Option<Vec<f64>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     StringArray(Option<Vec<String>>),
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     CharArray(Option<Vec<char>>),
 
     #[allow(clippy::box_collection)]
@@ -81,124 +81,160 @@ pub enum Value {
     #[cfg(feature = "with-json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-json")))]
     Json(Option<Box<Json>>),
-    #[cfg(all(feature = "with-json", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-json", feature = "with-array"))))]
+    #[cfg(all(feature = "with-json", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-json", feature = "postgres-array")))
+    )]
     JsonArray(Option<Vec<Json>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDate(Option<Box<NaiveDate>>),
-    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-chrono", feature = "postgres-array")))
+    )]
     ChronoDateArray(Option<Vec<NaiveDate>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoTime(Option<Box<NaiveTime>>),
-    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-chrono", feature = "postgres-array")))
+    )]
     ChronoTimeArray(Option<Vec<NaiveTime>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDateTime(Option<Box<NaiveDateTime>>),
-    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-chrono", feature = "postgres-array")))
+    )]
     ChronoDateTimeArray(Option<Vec<NaiveDateTime>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDateTimeUtc(Option<Box<DateTime<Utc>>>),
-    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-chrono", feature = "postgres-array")))
+    )]
     ChronoDateTimeUtcArray(Option<Vec<DateTime<Utc>>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDateTimeLocal(Option<Box<DateTime<Local>>>),
-    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-chrono", feature = "postgres-array")))
+    )]
     ChronoDateTimeLocalArray(Option<Vec<DateTime<Local>>>),
 
     #[cfg(feature = "with-chrono")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDateTimeWithTimeZone(Option<Box<DateTime<FixedOffset>>>),
-    #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-chrono", feature = "with-array"))))]
+    #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-chrono", feature = "postgres-array")))
+    )]
     ChronoDateTimeWithTimeZoneArray(Option<Vec<DateTime<FixedOffset>>>),
 
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeDate(Option<Box<time::Date>>),
-    #[cfg(all(feature = "with-time", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-time", feature = "with-array"))))]
+    #[cfg(all(feature = "with-time", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-time", feature = "postgres-array")))
+    )]
     TimeDateArray(Option<Vec<time::Date>>),
 
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeTime(Option<Box<time::Time>>),
-    #[cfg(all(feature = "with-time", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-time", feature = "with-array"))))]
+    #[cfg(all(feature = "with-time", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-time", feature = "postgres-array")))
+    )]
     TimeTimeArray(Option<Vec<time::Time>>),
 
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeDateTime(Option<Box<PrimitiveDateTime>>),
-    #[cfg(all(feature = "with-time", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-time", feature = "with-array"))))]
+    #[cfg(all(feature = "with-time", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-time", feature = "postgres-array")))
+    )]
     TimeDateTimeArray(Option<Vec<PrimitiveDateTime>>),
 
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeDateTimeWithTimeZone(Option<Box<OffsetDateTime>>),
-    #[cfg(all(feature = "with-time", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-time", feature = "with-array"))))]
+    #[cfg(all(feature = "with-time", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-time", feature = "postgres-array")))
+    )]
     TimeDateTimeWithTimeZoneArray(Option<Vec<OffsetDateTime>>),
 
     #[cfg(feature = "with-uuid")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
     Uuid(Option<Box<Uuid>>),
-    #[cfg(all(feature = "with-uuid", feature = "with-array"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "with-uuid", feature = "with-array"))))]
+    #[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "with-uuid", feature = "postgres-array")))
+    )]
     UuidArray(Option<Vec<Uuid>>),
 
     #[cfg(feature = "with-rust_decimal")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-rust_decimal")))]
     Decimal(Option<Box<Decimal>>),
-    #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+    #[cfg(all(feature = "with-rust_decimal", feature = "postgres-array"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(feature = "with-rust_decimal", feature = "with-array")))
+        doc(cfg(all(feature = "with-rust_decimal", feature = "postgres-array")))
     )]
     DecimalArray(Option<Vec<Decimal>>),
 
     #[cfg(feature = "with-bigdecimal")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-bigdecimal")))]
     BigDecimal(Option<Box<BigDecimal>>),
-    #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
+    #[cfg(all(feature = "with-bigdecimal", feature = "postgres-array"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(feature = "with-bigdecimal", feature = "with-array")))
+        doc(cfg(all(feature = "with-bigdecimal", feature = "postgres-array")))
     )]
     BigDecimalArray(Option<Vec<BigDecimal>>),
 
     #[cfg(feature = "with-ipnetwork")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-ipnetwork")))]
     IpNetwork(Option<Box<IpNetwork>>),
-    #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+    #[cfg(all(feature = "with-ipnetwork", feature = "postgres-array"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(feature = "with-ipnetwork", feature = "with-array")))
+        doc(cfg(all(feature = "with-ipnetwork", feature = "postgres-array")))
     )]
     IpNetworkArray(Option<Vec<IpNetwork>>),
 
     #[cfg(feature = "with-mac_address")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-mac_address")))]
     MacAddress(Option<Box<MacAddress>>),
-    #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
+    #[cfg(all(feature = "with-mac_address", feature = "postgres-array"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(feature = "with-mac_address", feature = "with-array")))
+        doc(cfg(all(feature = "with-mac_address", feature = "postgres-array")))
     )]
     MacAddressArray(Option<Vec<MacAddress>>),
 }
@@ -404,8 +440,8 @@ where
 type_to_box_value!(Vec<u8>, Bytes, Binary(BlobSize::Blob(None)));
 type_to_box_value!(String, String, String(None));
 
-#[cfg(feature = "with-array")]
-#[cfg_attr(docsrs, doc(cfg(feature = "with-array")))]
+#[cfg(feature = "postgres-array")]
+#[cfg_attr(docsrs, doc(cfg(feature = "postgres-array")))]
 mod with_array {
     use super::*;
 
@@ -438,7 +474,7 @@ mod with_json {
 
     type_to_box_value!(Json, Json, Json);
 
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(Vec<Json>, JsonArray, Array(Box::new(Json)));
 }
 
@@ -540,29 +576,29 @@ mod with_chrono {
         }
     }
 
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(Vec<NaiveDate>, ChronoDateArray, Array(Box::new(Date)));
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(Vec<NaiveTime>, ChronoTimeArray, Array(Box::new(Time(None))));
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(
         Vec<NaiveDateTime>,
         ChronoDateTimeArray,
         Array(Box::new(DateTime(None)))
     );
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(
         Vec<DateTime<Local>>,
         ChronoDateTimeLocalArray,
         Array(Box::new(TimestampWithTimeZone(None)))
     );
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(
         Vec<DateTime<Utc>>,
         ChronoDateTimeUtcArray,
         Array(Box::new(TimestampWithTimeZone(None)))
     );
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(
         Vec<DateTime<FixedOffset>>,
         ChronoDateTimeWithTimeZoneArray,
@@ -624,17 +660,17 @@ mod with_time {
         }
     }
 
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(Vec<time::Date>, TimeDateArray, Array(Box::new(Date)));
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(Vec<time::Time>, TimeTimeArray, Array(Box::new(Time(None))));
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(
         Vec<PrimitiveDateTime>,
         TimeDateTimeArray,
         Array(Box::new(DateTime(None)))
     );
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(
         Vec<OffsetDateTime>,
         TimeDateTimeWithTimeZoneArray,
@@ -649,7 +685,7 @@ mod with_rust_decimal {
 
     type_to_box_value!(Decimal, Decimal, Decimal(None));
 
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(Vec<Decimal>, DecimalArray, Array(Box::new(Decimal(None))));
 }
 
@@ -660,7 +696,7 @@ mod with_bigdecimal {
 
     type_to_box_value!(BigDecimal, BigDecimal, Decimal(None));
 
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(
         Vec<BigDecimal>,
         BigDecimalArray,
@@ -674,12 +710,8 @@ mod with_uuid {
     use super::*;
 
     type_to_box_value!(Uuid, Uuid, Uuid);
-    #[cfg(feature = "with-array")]
-    type_to_value!(
-        Vec<Uuid>,
-        UuidArray,
-        Array(Box::new(Uuid))
-    );
+    #[cfg(feature = "postgres-array")]
+    type_to_value!(Vec<Uuid>, UuidArray, Array(Box::new(Uuid)));
 }
 
 #[cfg(feature = "with-ipnetwork")]
@@ -689,7 +721,7 @@ mod with_ipnetwork {
 
     type_to_box_value!(IpNetwork, IpNetwork, Inet);
 
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(Vec<IpNetwork>, IpNetworkArray, Array(Box::new(Inet)));
 }
 
@@ -700,7 +732,7 @@ mod with_mac_address {
 
     type_to_box_value!(MacAddress, MacAddress, MacAddr);
 
-    #[cfg(feature = "with-array")]
+    #[cfg(feature = "postgres-array")]
     type_to_value!(Vec<MacAddress>, MacAddressArray, Array(Box::new(MacAddr)));
 }
 
@@ -722,21 +754,41 @@ macro_rules! impl_value_methods {
 
 #[cfg(feature = "with-json")]
 impl_value_methods!(Json, is_json, as_ref_json, Json);
-#[cfg(all(feature = "with-json", feature = "with-array"))]
+#[cfg(all(feature = "with-json", feature = "postgres-array"))]
 impl_value_methods!(JsonArray, is_json_array, as_ref_json_array, [Json]);
 
 #[cfg(feature = "with-time")]
 impl_value_methods!(ChronoDate, is_chrono_date, as_ref_chrono_date, NaiveDate);
 #[cfg(feature = "with-time")]
-impl_value_methods!(ChronoDateTime, is_chrono_date_time, as_ref_chrono_date_time, NaiveDateTime);
+impl_value_methods!(
+    ChronoDateTime,
+    is_chrono_date_time,
+    as_ref_chrono_date_time,
+    NaiveDateTime
+);
 #[cfg(feature = "with-time")]
 impl_value_methods!(ChronoTime, is_chrono_time, as_ref_chrono_time, NaiveTime);
 #[cfg(feature = "with-time")]
-impl_value_methods!(ChronoDateTimeUtc, is_chrono_date_time_utc, as_ref_chrono_date_time_utc, DateTime<Utc>);
+impl_value_methods!(
+    ChronoDateTimeUtc,
+    is_chrono_date_time_utc,
+    as_ref_chrono_date_time_utc,
+    DateTime<Utc>
+);
 #[cfg(feature = "with-time")]
-impl_value_methods!(ChronoDateTimeLocal, is_chrono_date_time_local, as_ref_chrono_date_time_local, DateTime<Local>);
+impl_value_methods!(
+    ChronoDateTimeLocal,
+    is_chrono_date_time_local,
+    as_ref_chrono_date_time_local,
+    DateTime<Local>
+);
 #[cfg(feature = "with-time")]
-impl_value_methods!(ChronoDateTimeWithTimeZone, is_chrono_date_time_with_time_zone, as_ref_chrono_date_time_with_time_zone, DateTime<FixedOffset>);
+impl_value_methods!(
+    ChronoDateTimeWithTimeZone,
+    is_chrono_date_time_with_time_zone,
+    as_ref_chrono_date_time_with_time_zone,
+    DateTime<FixedOffset>
+);
 #[cfg(feature = "with-chrono")]
 impl Value {
     pub fn chrono_as_naive_utc_in_string(&self) -> Option<String> {
@@ -751,27 +803,67 @@ impl Value {
         }
     }
 }
-#[cfg(all(feature = "with-chrono", feature = "with-array"))]
-impl_value_methods!(ChronoDateArray, is_chrono_date_array, as_ref_chrono_date_array, [NaiveDate]);
-#[cfg(all(feature = "with-chrono", feature = "with-array"))]
-impl_value_methods!(ChronoDateTimeArray, is_chrono_date_time_array, as_ref_chrono_date_time_array, [NaiveDateTime]);
-#[cfg(all(feature = "with-chrono", feature = "with-array"))]
-impl_value_methods!(ChronoTimeArray, is_chrono_time_array, as_ref_chrono_time_array, [NaiveTime]);
-#[cfg(all(feature = "with-chrono", feature = "with-array"))]
-impl_value_methods!(ChronoDateTimeUtcArray, is_chrono_date_time_utc_array, as_ref_chrono_date_time_utc_array, [DateTime<Utc>]);
-#[cfg(all(feature = "with-chrono", feature = "with-array"))]
-impl_value_methods!(ChronoDateTimeLocalArray, is_chrono_date_time_local_array, as_ref_chrono_date_time_local_array, [DateTime<Local>]);
-#[cfg(all(feature = "with-chrono", feature = "with-array"))]
-impl_value_methods!(ChronoDateTimeWithTimeZoneArray, is_chrono_date_time_with_time_zone_array, as_ref_chrono_date_time_with_time_zone_array, [DateTime<FixedOffset>]);
+#[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+impl_value_methods!(
+    ChronoDateArray,
+    is_chrono_date_array,
+    as_ref_chrono_date_array,
+    [NaiveDate]
+);
+#[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+impl_value_methods!(
+    ChronoDateTimeArray,
+    is_chrono_date_time_array,
+    as_ref_chrono_date_time_array,
+    [NaiveDateTime]
+);
+#[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+impl_value_methods!(
+    ChronoTimeArray,
+    is_chrono_time_array,
+    as_ref_chrono_time_array,
+    [NaiveTime]
+);
+#[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+impl_value_methods!(
+    ChronoDateTimeUtcArray,
+    is_chrono_date_time_utc_array,
+    as_ref_chrono_date_time_utc_array,
+    [DateTime<Utc>]
+);
+#[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+impl_value_methods!(
+    ChronoDateTimeLocalArray,
+    is_chrono_date_time_local_array,
+    as_ref_chrono_date_time_local_array,
+    [DateTime<Local>]
+);
+#[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
+impl_value_methods!(
+    ChronoDateTimeWithTimeZoneArray,
+    is_chrono_date_time_with_time_zone_array,
+    as_ref_chrono_date_time_with_time_zone_array,
+    [DateTime<FixedOffset>]
+);
 
 #[cfg(feature = "with-time")]
 impl_value_methods!(TimeDate, is_time_date, as_ref_time_date, time::Date);
 #[cfg(feature = "with-time")]
 impl_value_methods!(TimeTime, is_time_time, as_ref_time_time, time::Time);
 #[cfg(feature = "with-time")]
-impl_value_methods!(TimeDateTime, is_time_date_time, as_ref_time_date_time, PrimitiveDateTime);
+impl_value_methods!(
+    TimeDateTime,
+    is_time_date_time,
+    as_ref_time_date_time,
+    PrimitiveDateTime
+);
 #[cfg(feature = "with-time")]
-impl_value_methods!(TimeDateTimeWithTimeZone, is_time_date_time_with_time_zone, as_ref_time_date_time_with_time_zone, OffsetDateTime);
+impl_value_methods!(
+    TimeDateTimeWithTimeZone,
+    is_time_date_time_with_time_zone,
+    as_ref_time_date_time_with_time_zone,
+    OffsetDateTime
+);
 #[cfg(feature = "with-time")]
 impl Value {
     pub fn time_as_naive_utc_in_string(&self) -> Option<String> {
@@ -794,14 +886,34 @@ impl Value {
         }
     }
 }
-#[cfg(all(feature = "with-time", feature = "with-array"))]
-impl_value_methods!(TimeDateArray, is_time_date_array, as_ref_time_date_array, [time::Date]);
-#[cfg(all(feature = "with-time", feature = "with-array"))]
-impl_value_methods!(TimeTimeArray, is_time_time_array, as_ref_time_time_array, [time::Time]);
-#[cfg(all(feature = "with-time", feature = "with-array"))]
-impl_value_methods!(TimeDateTimeArray, is_time_date_time_array, as_ref_time_date_time_array, [PrimitiveDateTime]);
-#[cfg(all(feature = "with-time", feature = "with-array"))]
-impl_value_methods!(TimeDateTimeWithTimeZoneArray, is_time_date_time_with_time_zone_array, as_ref_time_date_time_with_time_zone_array, [OffsetDateTime]);
+#[cfg(all(feature = "with-time", feature = "postgres-array"))]
+impl_value_methods!(
+    TimeDateArray,
+    is_time_date_array,
+    as_ref_time_date_array,
+    [time::Date]
+);
+#[cfg(all(feature = "with-time", feature = "postgres-array"))]
+impl_value_methods!(
+    TimeTimeArray,
+    is_time_time_array,
+    as_ref_time_time_array,
+    [time::Time]
+);
+#[cfg(all(feature = "with-time", feature = "postgres-array"))]
+impl_value_methods!(
+    TimeDateTimeArray,
+    is_time_date_time_array,
+    as_ref_time_date_time_array,
+    [PrimitiveDateTime]
+);
+#[cfg(all(feature = "with-time", feature = "postgres-array"))]
+impl_value_methods!(
+    TimeDateTimeWithTimeZoneArray,
+    is_time_date_time_with_time_zone_array,
+    as_ref_time_date_time_with_time_zone_array,
+    [OffsetDateTime]
+);
 
 #[cfg(feature = "with-rust_decimal")]
 impl_value_methods!(Decimal, is_decimal, as_ref_decimal, Decimal);
@@ -813,8 +925,13 @@ impl Value {
         self.as_ref_decimal().and_then(|d| d.to_f64())
     }
 }
-#[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
-impl_value_methods!(DecimalArray, is_decimal_array, as_ref_decimal_array, [Decimal]);
+#[cfg(all(feature = "with-rust_decimal", feature = "postgres-array"))]
+impl_value_methods!(
+    DecimalArray,
+    is_decimal_array,
+    as_ref_decimal_array,
+    [Decimal]
+);
 
 #[cfg(feature = "with-bigdecimal")]
 impl_value_methods!(BigDecimal, is_big_decimal, as_ref_big_decimal, BigDecimal);
@@ -825,12 +942,17 @@ impl Value {
         self.as_ref_big_decimal().map(|d| d.to_f64().unwrap())
     }
 }
-#[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
-impl_value_methods!(BigDecimalArray, is_big_decimal_array, as_ref_big_decimal_array, [BigDecimal]);
+#[cfg(all(feature = "with-bigdecimal", feature = "postgres-array"))]
+impl_value_methods!(
+    BigDecimalArray,
+    is_big_decimal_array,
+    as_ref_big_decimal_array,
+    [BigDecimal]
+);
 
 #[cfg(feature = "with-uuid")]
 impl_value_methods!(Uuid, is_uuid, as_ref_uuid, Uuid);
-#[cfg(all(feature = "with-uuid", feature = "with-array"))]
+#[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
 impl_value_methods!(UuidArray, is_uuid_array, as_ref_uuid_array, [Uuid]);
 
 #[cfg(feature = "with-ipnetwork")]
@@ -838,17 +960,26 @@ impl_value_methods!(IpNetwork, is_ipnetwork, as_ref_ipnetwork, IpNetwork);
 #[cfg(feature = "with-ipnetwork")]
 impl Value {
     pub fn as_ipaddr(&self) -> Option<IpAddr> {
-        self.as_ref_ipnetwork().map(|v|v.network())
+        self.as_ref_ipnetwork().map(|v| v.network())
     }
 }
-#[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
-impl_value_methods!(IpNetworkArray, is_ipnetwork_array, as_ref_ipnetwork_array, [IpNetwork]);
+#[cfg(all(feature = "with-ipnetwork", feature = "postgres-array"))]
+impl_value_methods!(
+    IpNetworkArray,
+    is_ipnetwork_array,
+    as_ref_ipnetwork_array,
+    [IpNetwork]
+);
 
 #[cfg(feature = "with-mac_address")]
 impl_value_methods!(MacAddress, is_mac_address, as_ref_mac_address, MacAddress);
-#[cfg(all(feature = "with-mac_address", feature = "with-array"))]
-impl_value_methods!(MacAddressArray, is_mac_address_array, as_ref_mac_address_array, [MacAddress]);
-
+#[cfg(all(feature = "with-mac_address", feature = "postgres-array"))]
+impl_value_methods!(
+    MacAddressArray,
+    is_mac_address_array,
+    as_ref_mac_address_array,
+    [MacAddress]
+);
 
 impl IntoIterator for ValueTuple {
     type Item = Value;
@@ -1089,7 +1220,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         | Value::Char(None)
         | Value::Bytes(None)
         | Value::Json(None) => Json::Null,
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::BoolArray(None)
         | Value::TinyIntArray(None)
         | Value::SmallIntArray(None)
@@ -1113,7 +1244,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::IpNetwork(None) => Json::Null,
         #[cfg(feature = "with-mac_address")]
         Value::MacAddress(None) => Json::Null,
-        #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+        #[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
         Value::UuidArray(None) => Json::Null,
 
         Value::Bool(Some(b)) => Json::Bool(*b),
@@ -1131,31 +1262,31 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::Char(Some(v)) => Json::String(v.to_string()),
         Value::Bytes(Some(s)) => Json::String(from_utf8(s).unwrap().to_string()),
         Value::Json(Some(v)) => v.as_ref().clone(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::JsonArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::BoolArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::TinyIntArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::SmallIntArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::IntArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::BigIntArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::SmallUnsignedArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::UnsignedArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::BigUnsignedArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::FloatArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::DoubleArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::StringArray(Some(v)) => v.as_slice().into(),
-        #[cfg(feature = "with-array")]
+        #[cfg(feature = "postgres-array")]
         Value::CharArray(Some(v)) => v
             .iter()
             .map(|c| c.to_string())
@@ -1163,46 +1294,46 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
             .into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDate(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
         Value::ChronoDateArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
         Value::ChronoTimeArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
         Value::ChronoDateTimeArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeWithTimeZone(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
         Value::ChronoDateTimeWithTimeZoneArray(_) => {
             CommonSqlQueryBuilder.value_to_string(value).into()
         }
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeUtc(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
         Value::ChronoDateTimeUtcArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeLocal(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-chrono", feature = "with-array"))]
+        #[cfg(all(feature = "with-chrono", feature = "postgres-array"))]
         Value::ChronoDateTimeLocalArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
 
         #[cfg(feature = "with-time")]
         Value::TimeDate(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-time", feature = "with-array"))]
+        #[cfg(all(feature = "with-time", feature = "postgres-array"))]
         Value::TimeDateArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-time")]
         Value::TimeTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-time", feature = "with-array"))]
+        #[cfg(all(feature = "with-time", feature = "postgres-array"))]
         Value::TimeTimeArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-time")]
         Value::TimeDateTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-time", feature = "with-array"))]
+        #[cfg(all(feature = "with-time", feature = "postgres-array"))]
         Value::TimeDateTimeArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-time")]
         Value::TimeDateTimeWithTimeZone(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-time", feature = "with-array"))]
+        #[cfg(all(feature = "with-time", feature = "postgres-array"))]
         Value::TimeDateTimeWithTimeZoneArray(_) => {
             CommonSqlQueryBuilder.value_to_string(value).into()
         }
@@ -1212,18 +1343,18 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
             use rust_decimal::prelude::ToPrimitive;
             v.as_ref().to_f64().unwrap().into()
         }
-        #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+        #[cfg(all(feature = "with-rust_decimal", feature = "postgres-array"))]
         Value::DecimalArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-bigdecimal")]
         Value::BigDecimal(Some(v)) => {
             use bigdecimal::ToPrimitive;
             v.as_ref().to_f64().unwrap().into()
         }
-        #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
+        #[cfg(all(feature = "with-bigdecimal", feature = "postgres-array"))]
         Value::BigDecimalArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-uuid")]
         Value::Uuid(Some(v)) => Json::String(v.to_string()),
-        #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+        #[cfg(all(feature = "with-uuid", feature = "postgres-array"))]
         Value::UuidArray(Some(v)) => v
             .iter()
             .map(|v| v.to_string())
@@ -1231,11 +1362,11 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
             .into(),
         #[cfg(feature = "with-ipnetwork")]
         Value::IpNetwork(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
+        #[cfg(all(feature = "with-ipnetwork", feature = "postgres-array"))]
         Value::IpNetworkArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-mac_address")]
         Value::MacAddress(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
+        #[cfg(all(feature = "with-mac_address", feature = "postgres-array"))]
         Value::MacAddressArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -757,32 +757,32 @@ impl_value_methods!(Json, is_json, as_ref_json, Json);
 #[cfg(all(feature = "with-json", feature = "postgres-array"))]
 impl_value_methods!(JsonArray, is_json_array, as_ref_json_array, [Json]);
 
-#[cfg(feature = "with-time")]
+#[cfg(feature = "with-chrono")]
 impl_value_methods!(ChronoDate, is_chrono_date, as_ref_chrono_date, NaiveDate);
-#[cfg(feature = "with-time")]
+#[cfg(feature = "with-chrono")]
 impl_value_methods!(
     ChronoDateTime,
     is_chrono_date_time,
     as_ref_chrono_date_time,
     NaiveDateTime
 );
-#[cfg(feature = "with-time")]
+#[cfg(feature = "with-chrono")]
 impl_value_methods!(ChronoTime, is_chrono_time, as_ref_chrono_time, NaiveTime);
-#[cfg(feature = "with-time")]
+#[cfg(feature = "with-chrono")]
 impl_value_methods!(
     ChronoDateTimeUtc,
     is_chrono_date_time_utc,
     as_ref_chrono_date_time_utc,
     DateTime<Utc>
 );
-#[cfg(feature = "with-time")]
+#[cfg(feature = "with-chrono")]
 impl_value_methods!(
     ChronoDateTimeLocal,
     is_chrono_date_time_local,
     as_ref_chrono_date_time_local,
     DateTime<Local>
 );
-#[cfg(feature = "with-time")]
+#[cfg(feature = "with-chrono")]
 impl_value_methods!(
     ChronoDateTimeWithTimeZone,
     is_chrono_date_time_with_time_zone,

--- a/src/value.rs
+++ b/src/value.rs
@@ -200,7 +200,7 @@ pub enum Value {
         docsrs,
         doc(cfg(all(feature = "with-mac_address", feature = "with-array")))
     )]
-    MacAddressArray(Option<Box<MacAddress>>),
+    MacAddressArray(Option<Vec<MacAddress>>),
 }
 
 impl std::fmt::Display for Value {
@@ -657,7 +657,7 @@ mod with_ipnetwork {
     type_to_box_value!(IpNetwork, IpNetwork, Inet);
 
     #[cfg(feature = "with-array")]
-    type_to_value!(Vec<IpNetwork>, IpNetwork, Array(Box::new(Inet)));
+    type_to_value!(Vec<IpNetwork>, IpNetworkArray, Array(Box::new(Inet)));
 }
 
 #[cfg(feature = "with-mac_address")]
@@ -1200,31 +1200,18 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         | Value::StringArray(None)
         | Value::CharArray(None)
         | Value::JsonArray(None) => Json::Null,
-
         #[cfg(feature = "with-rust_decimal")]
         Value::Decimal(None) => Json::Null,
-        #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
-        Value::DecimalArray(None) => Json::Null,
-
         #[cfg(feature = "with-bigdecimal")]
         Value::BigDecimal(None) => Json::Null,
-        #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
-        Value::BigDecimalArray(None) => Json::Null,
-
         #[cfg(feature = "with-uuid")]
         Value::Uuid(None) => Json::Null,
-        #[cfg(all(feature = "with-uuid", feature = "with-array"))]
-        Value::UuidArray(None) => Json::Null,
-
         #[cfg(feature = "with-ipnetwork")]
         Value::IpNetwork(None) => Json::Null,
-        #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
-        Value::IpNetworkArray(None) => Json::Null,
-
         #[cfg(feature = "with-mac_address")]
         Value::MacAddress(None) => Json::Null,
-        #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
-        Value::MacAddressArray(None) => Json::Null,
+        #[cfg(all(feature = "with-uuid", feature = "with-array"))]
+        Value::UuidArray(None) => Json::Null,
 
         Value::Bool(Some(b)) => Json::Bool(*b),
         Value::TinyInt(Some(v)) => (*v).into(),
@@ -1241,7 +1228,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::Char(Some(v)) => Json::String(v.to_string()),
         Value::Bytes(Some(s)) => Json::String(from_utf8(s).unwrap().to_string()),
         Value::Json(Some(v)) => v.as_ref().clone(),
-        Value::JsonArray(Some(v)) => todo!(),
+        Value::JsonArray(Some(v)) => v.as_slice().into(),
         #[cfg(feature = "with-array")]
         Value::BoolArray(Some(v)) => v.as_slice().into(),
         #[cfg(feature = "with-array")]
@@ -1273,46 +1260,48 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         #[cfg(feature = "with-chrono")]
         Value::ChronoDate(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-        Value::ChronoDateArray(_) => todo!(),
+        Value::ChronoDateArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-        Value::ChronoTimeArray(_) => todo!(),
+        Value::ChronoTimeArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-        Value::ChronoDateTimeArray(_) => todo!(),
+        Value::ChronoDateTimeArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeWithTimeZone(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-        Value::ChronoDateTimeWithTimeZoneArray(_) => todo!(),
+        Value::ChronoDateTimeWithTimeZoneArray(_) => {
+            CommonSqlQueryBuilder.value_to_string(value).into()
+        }
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeUtc(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-        Value::ChronoDateTimeUtcArray(_) => todo!(),
-        #[cfg(feature = "with-chrono")]
-        Value::ChronoDateTimeUtc(_) => todo!(),
+        Value::ChronoDateTimeUtcArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeLocal(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-chrono", feature = "with-array"))]
-        Value::ChronoDateTimeLocalArray(_) => todo!(),
+        Value::ChronoDateTimeLocalArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
 
         #[cfg(feature = "with-time")]
         Value::TimeDate(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-time", feature = "with-array"))]
-        Value::TimeDateArray(_) => todo!(),
+        Value::TimeDateArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-time")]
         Value::TimeTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-time", feature = "with-array"))]
-        Value::TimeTimeArray(_) => todo!(),
+        Value::TimeTimeArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-time")]
         Value::TimeDateTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-time", feature = "with-array"))]
-        Value::TimeDateTimeArray(_) => todo!(),
+        Value::TimeDateTimeArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-time")]
         Value::TimeDateTimeWithTimeZone(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-time", feature = "with-array"))]
-        Value::TimeDateTimeWithTimeZoneArray(_) => todo!(),
+        Value::TimeDateTimeWithTimeZoneArray(_) => {
+            CommonSqlQueryBuilder.value_to_string(value).into()
+        }
 
         #[cfg(feature = "with-rust_decimal")]
         Value::Decimal(Some(v)) => {
@@ -1320,26 +1309,30 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
             v.as_ref().to_f64().unwrap().into()
         }
         #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
-        Value::DecimalArray(Some(v)) => todo!(),
+        Value::DecimalArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-bigdecimal")]
         Value::BigDecimal(Some(v)) => {
             use bigdecimal::ToPrimitive;
             v.as_ref().to_f64().unwrap().into()
         }
         #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
-        Value::BigDecimalArray(Some(v)) => todo!(),
+        Value::BigDecimalArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-uuid")]
         Value::Uuid(Some(v)) => Json::String(v.to_string()),
         #[cfg(all(feature = "with-uuid", feature = "with-array"))]
-        Value::UuidArray(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        Value::UuidArray(Some(v)) => v
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<String>>()
+            .into(),
         #[cfg(feature = "with-ipnetwork")]
         Value::IpNetwork(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-ipnetwork", feature = "with-array"))]
-        Value::IpNetworkArray(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        Value::IpNetworkArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-mac_address")]
-        Value::MacAddress(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        Value::MacAddress(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-mac_address", feature = "with-array"))]
-        Value::MacAddressArray(Some(_)) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        Value::MacAddressArray(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1309,7 +1309,6 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::TimeDateTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-time", feature = "with-array"))]
         Value::TimeDateTimeArray(_) => todo!(),
-
         #[cfg(feature = "with-time")]
         Value::TimeDateTimeWithTimeZone(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(all(feature = "with-time", feature = "with-array"))]
@@ -1327,7 +1326,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
             use bigdecimal::ToPrimitive;
             v.as_ref().to_f64().unwrap().into()
         }
-        #[cfg(all(feature = "with-rust_decimal", feature = "with-array"))]
+        #[cfg(all(feature = "with-bigdecimal", feature = "with-array"))]
         Value::BigDecimalArray(Some(v)) => todo!(),
         #[cfg(feature = "with-uuid")]
         Value::Uuid(Some(v)) => Json::String(v.to_string()),

--- a/src/value.rs
+++ b/src/value.rs
@@ -1228,6 +1228,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::Char(Some(v)) => Json::String(v.to_string()),
         Value::Bytes(Some(s)) => Json::String(from_utf8(s).unwrap().to_string()),
         Value::Json(Some(v)) => v.as_ref().clone(),
+        #[cfg(feature = "with-array")]
         Value::JsonArray(Some(v)) => v.as_slice().into(),
         #[cfg(feature = "with-array")]
         Value::BoolArray(Some(v)) => v.as_slice().into(),


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-query/issues/336

Depends:
- https://github.com/SeaQL/sea-query/pull/387

## Adds

- [x] Support Array

## Todo:

- [x] Implement for all other types
- [x] Fix examples
- [x] Fix tests
- [ ] Add documentation
- [x] Fix `postgres` driver
- [x] Fix `sea-query-driver`
- [x] Fix `sea-query-binder`
- [ ] Remove todo from `CommonQueryBuilder`
- [x] Add methods for work with new `Value` items