### PR TITLE
Implements the `MOD` function

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -732,6 +732,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder {
                     Function::Upper => "UPPER",
                     Function::Custom(_) => "",
                     Function::CurrentTimestamp => "CURRENT_TIMESTAMP",
+                    Function::Mod => "MOD",
                     #[cfg(feature = "backend-postgres")]
                     Function::PgFunction(_) => unimplemented!(),
                 }

--- a/src/func.rs
+++ b/src/func.rs
@@ -22,6 +22,7 @@ pub enum Function {
     Lower,
     Upper,
     CurrentTimestamp,
+    Mod,
     #[cfg(feature = "backend-postgres")]
     PgFunction(PgFunction),
 }
@@ -400,6 +401,40 @@ impl Func {
         I: IntoIterator<Item = T>,
     {
         Expr::func(Function::Coalesce).args(args)
+    }
+
+    /// Call `MOD` function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::tests_cfg::Character::Character;
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Func::modulo(Expr::col(Char::FontSize), Expr::value(2)))
+    ///     .from(Char::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT MOD(`font_size`, 2) FROM `character`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT MOD("font_size", 2) FROM "character""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT MOD("font_size", 2) FROM "character""#
+    /// );
+    /// ```
+    pub fn modulo<A, B>(a: A, b: B) -> SimpleExpr
+    where
+        A: Into<SimpleExpr>,
+        B: Into<SimpleExpr>,
+    {
+        Expr::func(Function::Mod).args(vec![a.into(), b.into()])
     }
 
     /// Call `LOWER` function.


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

[PostgreSQL](https://www.postgresqltutorial.com/postgresql-math-functions/postgresql-mod/), [MySQL](https://dev.mysql.com/doc/refman/8.0/en/arithmetic-functions.html#operator_mod) and [SQLite](https://www.sqlite.org/lang_mathfunc.html#mod) provide the `MOD` function to return the remainder after one number is divided by the other.

This small PR intends to bind this operation in sea-query


## Adds

- Add the `MOD` function

