### PR TITLE
Update SQLite backend Boolean type from int to bool

### DIFF
--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -102,7 +102,7 @@ impl TableBuilder for SqliteQueryBuilder {
                     _ => "blob".into(),
                 },
                 ColumnType::VarBinary(length) => format!("binary({})", length),
-                ColumnType::Boolean => "bool".into(),
+                ColumnType::Boolean => "boolean".into(),
                 ColumnType::Money(precision) => match precision {
                     Some((precision, scale)) => format!("integer({}, {})", precision, scale),
                     None => "integer".into(),

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -102,7 +102,7 @@ impl TableBuilder for SqliteQueryBuilder {
                     _ => "blob".into(),
                 },
                 ColumnType::VarBinary(length) => format!("binary({})", length),
-                ColumnType::Boolean => "integer".into(),
+                ColumnType::Boolean => "bool".into(),
                 ColumnType::Money(precision) => match precision {
                     Some((precision, scale)) => format!("integer({}, {})", precision, scale),
                     None => "integer".into(),

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -108,3 +108,30 @@ impl Iden for Glyph {
         .unwrap();
     }
 }
+
+/// Representation of a database table named `Task`.
+///
+/// A `Enum` implemented [`Iden`] used in rustdoc and test to demonstrate the library usage.
+///
+/// [`Iden`]: crate::types::Iden
+#[derive(Debug)]
+pub enum Task {
+    Table,
+    Id,
+    IsDone,
+}
+
+impl Iden for Task {
+    fn unquoted(&self, s: &mut dyn FmtWrite) {
+        write!(
+            s,
+            "{}",
+            match self {
+                Self::Table => "task",
+                Self::Id => "id",
+                Self::IsDone => "is_done",
+            }
+        )
+        .unwrap();
+    }
+}

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1085,6 +1085,36 @@ fn insert_8() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
+fn insert_9() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Task::Table)
+            .columns([Task::IsDone])
+            .values_panic(vec![
+                true.into(),
+            ])
+            .to_string(SqliteQueryBuilder),
+        r#"INSERT INTO "task" ("is_done") VALUES (TRUE)"#
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
+fn insert_10() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Task::Table)
+            .columns([Task::IsDone])
+            .values_panic(vec![
+                false.into(),
+            ])
+            .to_string(SqliteQueryBuilder),
+        r#"INSERT INTO "task" ("is_done") VALUES (FALSE)"#
+    );
+}
+
+#[test]
 fn insert_from_select() {
     assert_eq!(
         Query::insert()

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -148,6 +148,30 @@ fn create_5() {
 }
 
 #[test]
+fn create_6() {
+    assert_eq!(
+        Table::create()
+            .table(Task::Table)
+            .col(
+                ColumnDef::new(Task::Id)
+                    .integer()
+                    .not_null()
+                    .auto_increment()
+                    .primary_key()
+            )
+            .col(ColumnDef::new(Task::IsDone).boolean().not_null())
+            .to_string(SqliteQueryBuilder),
+        vec![
+            r#"CREATE TABLE "task" ("#,
+            r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
+            r#""is_done" bool NOT NULL"#,
+            r#")"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn create_with_unique_index() {
     assert_eq!(
         Table::create()

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -164,7 +164,7 @@ fn create_6() {
         vec![
             r#"CREATE TABLE "task" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
-            r#""is_done" bool NOT NULL"#,
+            r#""is_done" boolean NOT NULL"#,
             r#")"#,
         ]
         .join(" ")


### PR DESCRIPTION
As mentioned in #375 the SQLite engine already supports boolean type implicitly. More details are provided in the issue's comments about this.
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #375 

## Adds

- [ ] Explicit support for booleans in SQLite backend

## Breaking Changes

- [ ] I don't think this is backwards compatible, because after this update the Entity will look for a `boolean`, until now we were using `int` there. So in case, someone makes an update, and they provide and int where we expect a bool, it might break some code. This still needs to be checked.
- [ ] Immediate change the this PR should bring is the difference in generated Entity's field type should change from `i32` to `boolean`.

## Changes

- [x] I have added a few unit test cases related to this PR, for SQLite's bool support
