### PR TITLE
exclude chrono default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ sea-query-derive = { version = "^0.2.0", path = "sea-query-derive", optional = t
 sea-query-driver = { version = "^0.2.0", path = "sea-query-driver", optional = true }
 serde_json = { version = "^1", optional = true }
 bytes = { version = "^1", optional = true }
-chrono = { version = "^0", optional = true }
+chrono = { version = "^0", default-features = false, features = ["clock"], optional = true }
 postgres-types = { version = "^0", optional = true }
 rust_decimal = { version = "^1", optional = true }
 bigdecimal = { version = "^0.3", optional = true }

--- a/examples/postgres_json/Cargo.toml
+++ b/examples/postgres_json/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = "^0"
+chrono = { version = "^0", default-features = false, features = ["clock"] }
 time = { version = "^0.3", features = ["macros"] }
 uuid = { version = "^1", features = ["serde", "v4"] }
 serde_json = "^1"

--- a/examples/rusqlite/Cargo.toml
+++ b/examples/rusqlite/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "^0" }
+chrono = { version = "^0", default-features = false, features = ["clock"] }
 time = { version = "^0.2" }
 serde_json = { version = "^1" }
 # rusqlite only supports uuid 0

--- a/examples/sqlx_any/Cargo.toml
+++ b/examples/sqlx_any/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = "^0"
+chrono = { version = "^0", default-features = false, features = ["clock"] }
 time = "^0.3"
 uuid = { version = "^1", features = ["serde", "v4"] }
 serde_json = "^1"

--- a/examples/sqlx_mysql/Cargo.toml
+++ b/examples/sqlx_mysql/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = "^0"
+chrono = { version = "^0", default-features = false, features = ["clock"] }
 time = { version = "^0.3", features = ["macros"] }
 uuid = { version = "^1", features = ["serde", "v4"] }
 serde_json = "^1"

--- a/examples/sqlx_postgres/Cargo.toml
+++ b/examples/sqlx_postgres/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = "^0"
+chrono = { version = "^0", default-features = false, features = ["clock"] }
 time = { version = "^0.3", features = ["macros"] }
 uuid = { version = "^1", features = ["serde", "v4"] }
 serde_json = "^1"

--- a/examples/sqlx_sqlite/Cargo.toml
+++ b/examples/sqlx_sqlite/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = "^0"
+chrono = { version = "^0", default-features = false, features = ["clock"] }
 time = { version = "^0.3", features = ["macros"] }
 uuid = { version = "^1", features = ["serde", "v4"] }
 serde_json = "^1"


### PR DESCRIPTION
in an effort to remove time v0.1 from the dep graph