### PR TITLE
fix: Clippy warnings

### DIFF
--- a/sea-query-derive/src/iden_attr.rs
+++ b/sea-query-derive/src/iden_attr.rs
@@ -4,7 +4,7 @@ use syn::{Attribute, Error, Ident, Lit, Meta, MetaNameValue, NestedMeta};
 
 use crate::{error::ErrorMsg, iden_path::IdenPath};
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum IdenAttr {
     Rename(String),
     Method(Ident),

--- a/src/backend/foreign_key_builder.rs
+++ b/src/backend/foreign_key_builder.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Mode {
     Creation,
     Alter,

--- a/src/token.rs
+++ b/src/token.rs
@@ -9,7 +9,7 @@ pub struct Tokenizer {
     pub p: usize,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Token {
     Quoted(String),
     Unquoted(String),


### PR DESCRIPTION
## PR Info

Fix clippy warnings after rust 1.63 release