### PR TITLE
fix #420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ assert_eq!(
         .cond_where(any![Expr::col(Glyph::Id).eq(1), Expr::col(Glyph::Id).eq(2)])
         .cond_where(Expr::col(Glyph::Id).eq(3))
         .to_owned()
-        .to_string(PostgresQueryBuilder),
+        .to_string(&PostgresQueryBuilder),
     r#"SELECT WHERE "id" = 1 OR "id" = 2 OR "id" = 3"#
 );
 // Before: confusing, since it depends on the order of invocation:
@@ -36,7 +36,7 @@ assert_eq!(
         .cond_where(Expr::col(Glyph::Id).eq(3))
         .cond_where(any![Expr::col(Glyph::Id).eq(1), Expr::col(Glyph::Id).eq(2)])
         .to_owned()
-        .to_string(PostgresQueryBuilder),
+        .to_string(&PostgresQueryBuilder),
     r#"SELECT WHERE "id" = 3 AND ("id" = 1 OR "id" = 2)"#
 );
 // Now: will always conjoin with `AND`
@@ -45,7 +45,7 @@ assert_eq!(
         .cond_where(Expr::col(Glyph::Id).eq(1))
         .cond_where(any![Expr::col(Glyph::Id).eq(2), Expr::col(Glyph::Id).eq(3)])
         .to_owned()
-        .to_string(PostgresQueryBuilder),
+        .to_string(&PostgresQueryBuilder),
     r#"SELECT WHERE "id" = 1 AND ("id" = 2 OR "id" = 3)"#
 );
 // Now: so they are now equivalent
@@ -54,7 +54,7 @@ assert_eq!(
         .cond_where(any![Expr::col(Glyph::Id).eq(2), Expr::col(Glyph::Id).eq(3)])
         .cond_where(Expr::col(Glyph::Id).eq(1))
         .to_owned()
-        .to_string(PostgresQueryBuilder),
+        .to_string(&PostgresQueryBuilder),
     r#"SELECT WHERE ("id" = 2 OR "id" = 3) AND "id" = 1"#
 );
 ```
@@ -179,7 +179,7 @@ let query = Query::select()
     .to_owned();
 
 assert_eq!(
-    query.to_string(PostgresQueryBuilder),
+    query.to_string(&PostgresQueryBuilder),
     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "id" = 1 AND 6 = 2 * 3"#
 );
 ```
@@ -195,7 +195,7 @@ let query = Query::select()
     .to_owned();
 
 assert_eq!(
-    query.to_string(PostgresQueryBuilder),
+    query.to_string(&PostgresQueryBuilder),
     r#"SELECT data @? ('hello'::JSONPATH)"#
 );
 ```
@@ -548,7 +548,7 @@ In addition, if you constructed `Value` manually before (instead of using `into(
 Before:
 
 ```rust
-let (sql, values) = query.build(PostgresQueryBuilder);
+let (sql, values) = query.build(&PostgresQueryBuilder);
 assert_eq!(
 	values,
 	Values(vec![Value::String(Box::new("A".to_owned())), Value::Int(1), Value::Int(2), Value::Int(3)]))
@@ -558,7 +558,7 @@ assert_eq!(
 After:
 
 ```rust
-let (sql, values) = query.build(PostgresQueryBuilder);
+let (sql, values) = query.build(&PostgresQueryBuilder);
 assert_eq!(
 	values,
 	Values(vec![Value::String(Some(Box::new("A".to_owned()))), Value::Int(Some(1)), Value::Int(Some(2)), Value::Int(Some(3))]))

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ assert_eq!(
         .from(Glyph::Table)
         .and_where(Expr::col(Glyph::Image).like("A"))
         .and_where(Expr::col(Glyph::Id).is_in(vec![1, 2, 3]))
-        .build(PostgresQueryBuilder),
+        .build(&PostgresQueryBuilder),
     (
         r#"SELECT "image" FROM "glyph" WHERE "image" LIKE $1 AND "id" IN ($2, $3, $4)"#
             .to_owned(),
@@ -246,7 +246,7 @@ assert_eq!(
                 .like("D")
                 .and(Expr::col(Char::Character).like("E"))
         )
-        .to_string(PostgresQueryBuilder),
+        .to_string(&PostgresQueryBuilder),
     [
         r#"SELECT "character" FROM "character""#,
         r#"WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#,
@@ -280,7 +280,7 @@ assert_eq!(
                         .add(Expr::col(Glyph::Image).like("A%"))
                 )
         )
-        .to_string(PostgresQueryBuilder),
+        .to_string(&PostgresQueryBuilder),
     [
         r#"SELECT "id" FROM "glyph""#,
         r#"WHERE"#,
@@ -342,15 +342,15 @@ let query = Query::select()
     .to_owned();
 
 assert_eq!(
-    query.to_string(MysqlQueryBuilder),
+    query.to_string(&MysqlQueryBuilder),
     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` WHERE `size_w` IN (3, 4) AND `character` LIKE 'A%'"#
 );
 assert_eq!(
-    query.to_string(PostgresQueryBuilder),
+    query.to_string(&PostgresQueryBuilder),
     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" WHERE "size_w" IN (3, 4) AND "character" LIKE 'A%'"#
 );
 assert_eq!(
-    query.to_string(SqliteQueryBuilder),
+    query.to_string(&SqliteQueryBuilder),
     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" WHERE "size_w" IN (3, 4) AND "character" LIKE 'A%'"#
 );
 ```
@@ -366,15 +366,15 @@ let query = Query::insert()
     .to_owned();
 
 assert_eq!(
-    query.to_string(MysqlQueryBuilder),
+    query.to_string(&MysqlQueryBuilder),
     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (5.15, '12A'), (4.21, '123')"#
 );
 assert_eq!(
-    query.to_string(PostgresQueryBuilder),
+    query.to_string(&PostgresQueryBuilder),
     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (5.15, '12A'), (4.21, '123')"#
 );
 assert_eq!(
-    query.to_string(SqliteQueryBuilder),
+    query.to_string(&SqliteQueryBuilder),
     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (5.15, '12A'), (4.21, '123')"#
 );
 ```
@@ -392,15 +392,15 @@ let query = Query::update()
     .to_owned();
 
 assert_eq!(
-    query.to_string(MysqlQueryBuilder),
+    query.to_string(&MysqlQueryBuilder),
     r#"UPDATE `glyph` SET `aspect` = 1.23, `image` = '123' WHERE `id` = 1"#
 );
 assert_eq!(
-    query.to_string(PostgresQueryBuilder),
+    query.to_string(&PostgresQueryBuilder),
     r#"UPDATE "glyph" SET "aspect" = 1.23, "image" = '123' WHERE "id" = 1"#
 );
 assert_eq!(
-    query.to_string(SqliteQueryBuilder),
+    query.to_string(&SqliteQueryBuilder),
     r#"UPDATE "glyph" SET "aspect" = 1.23, "image" = '123' WHERE "id" = 1"#
 );
 ```
@@ -418,15 +418,15 @@ let query = Query::delete()
     .to_owned();
 
 assert_eq!(
-    query.to_string(MysqlQueryBuilder),
+    query.to_string(&MysqlQueryBuilder),
     r#"DELETE FROM `glyph` WHERE `id` < 1 OR `id` > 10"#
 );
 assert_eq!(
-    query.to_string(PostgresQueryBuilder),
+    query.to_string(&PostgresQueryBuilder),
     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 );
 assert_eq!(
-    query.to_string(SqliteQueryBuilder),
+    query.to_string(&SqliteQueryBuilder),
     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 );
 ```
@@ -454,7 +454,7 @@ let table = Table::create()
     .to_owned();
 
 assert_eq!(
-    table.to_string(MysqlQueryBuilder),
+    table.to_string(&MysqlQueryBuilder),
     vec![
         r#"CREATE TABLE IF NOT EXISTS `character` ("#,
             r#"`id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,"#,
@@ -470,7 +470,7 @@ assert_eq!(
     ].join(" ")
 );
 assert_eq!(
-    table.to_string(PostgresQueryBuilder),
+    table.to_string(&PostgresQueryBuilder),
     vec![
         r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -486,7 +486,7 @@ assert_eq!(
     ].join(" ")
 );
 assert_eq!(
-    table.to_string(SqliteQueryBuilder),
+    table.to_string(&SqliteQueryBuilder),
     vec![
        r#"CREATE TABLE IF NOT EXISTS "character" ("#,
            r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
@@ -515,15 +515,15 @@ let table = Table::alter()
     .to_owned();
 
 assert_eq!(
-    table.to_string(MysqlQueryBuilder),
+    table.to_string(&MysqlQueryBuilder),
     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
 );
 assert_eq!(
-    table.to_string(PostgresQueryBuilder),
+    table.to_string(&PostgresQueryBuilder),
     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
 );
 assert_eq!(
-    table.to_string(SqliteQueryBuilder),
+    table.to_string(&SqliteQueryBuilder),
     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#,
 );
 ```
@@ -537,15 +537,15 @@ let table = Table::drop()
     .to_owned();
 
 assert_eq!(
-    table.to_string(MysqlQueryBuilder),
+    table.to_string(&MysqlQueryBuilder),
     r#"DROP TABLE `glyph`, `character`"#
 );
 assert_eq!(
-    table.to_string(PostgresQueryBuilder),
+    table.to_string(&PostgresQueryBuilder),
     r#"DROP TABLE "glyph", "character""#
 );
 assert_eq!(
-    table.to_string(SqliteQueryBuilder),
+    table.to_string(&SqliteQueryBuilder),
     r#"DROP TABLE "glyph", "character""#
 );
 ```
@@ -558,15 +558,15 @@ let table = Table::rename()
     .to_owned();
 
 assert_eq!(
-    table.to_string(MysqlQueryBuilder),
+    table.to_string(&MysqlQueryBuilder),
     r#"RENAME TABLE `font` TO `font_new`"#
 );
 assert_eq!(
-    table.to_string(PostgresQueryBuilder),
+    table.to_string(&PostgresQueryBuilder),
     r#"ALTER TABLE "font" RENAME TO "font_new""#
 );
 assert_eq!(
-    table.to_string(SqliteQueryBuilder),
+    table.to_string(&SqliteQueryBuilder),
     r#"ALTER TABLE "font" RENAME TO "font_new""#
 );
 ```
@@ -577,15 +577,15 @@ assert_eq!(
 let table = Table::truncate().table(Font::Table).to_owned();
 
 assert_eq!(
-    table.to_string(MysqlQueryBuilder),
+    table.to_string(&MysqlQueryBuilder),
     r#"TRUNCATE TABLE `font`"#
 );
 assert_eq!(
-    table.to_string(PostgresQueryBuilder),
+    table.to_string(&PostgresQueryBuilder),
     r#"TRUNCATE TABLE "font""#
 );
 assert_eq!(
-    table.to_string(SqliteQueryBuilder),
+    table.to_string(&SqliteQueryBuilder),
     r#"TRUNCATE TABLE "font""#
 );
 ```
@@ -602,7 +602,7 @@ let foreign_key = ForeignKey::create()
     .to_owned();
 
 assert_eq!(
-    foreign_key.to_string(MysqlQueryBuilder),
+    foreign_key.to_string(&MysqlQueryBuilder),
     vec![
         r#"ALTER TABLE `character`"#,
         r#"ADD CONSTRAINT `FK_character_font`"#,
@@ -612,7 +612,7 @@ assert_eq!(
     .join(" ")
 );
 assert_eq!(
-    foreign_key.to_string(PostgresQueryBuilder),
+    foreign_key.to_string(&PostgresQueryBuilder),
     vec![
         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_font""#,
         r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
@@ -632,11 +632,11 @@ let foreign_key = ForeignKey::drop()
     .to_owned();
 
 assert_eq!(
-    foreign_key.to_string(MysqlQueryBuilder),
+    foreign_key.to_string(&MysqlQueryBuilder),
     r#"ALTER TABLE `character` DROP FOREIGN KEY `FK_character_font`"#
 );
 assert_eq!(
-    foreign_key.to_string(PostgresQueryBuilder),
+    foreign_key.to_string(&PostgresQueryBuilder),
     r#"ALTER TABLE "character" DROP CONSTRAINT "FK_character_font""#
 );
 // Sqlite does not support modification of foreign key constraints to existing tables
@@ -652,15 +652,15 @@ let index = Index::create()
     .to_owned();
 
 assert_eq!(
-    index.to_string(MysqlQueryBuilder),
+    index.to_string(&MysqlQueryBuilder),
     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"#
 );
 assert_eq!(
-    index.to_string(PostgresQueryBuilder),
+    index.to_string(&PostgresQueryBuilder),
     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
 );
 assert_eq!(
-    index.to_string(SqliteQueryBuilder),
+    index.to_string(&SqliteQueryBuilder),
     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
 );
 ```
@@ -674,15 +674,15 @@ let index = Index::drop()
     .to_owned();
 
 assert_eq!(
-    index.to_string(MysqlQueryBuilder),
+    index.to_string(&MysqlQueryBuilder),
     r#"DROP INDEX `idx-glyph-aspect` ON `glyph`"#
 );
 assert_eq!(
-    index.to_string(PostgresQueryBuilder),
+    index.to_string(&PostgresQueryBuilder),
     r#"DROP INDEX "idx-glyph-aspect""#
 );
 assert_eq!(
-    index.to_string(SqliteQueryBuilder),
+    index.to_string(&SqliteQueryBuilder),
     r#"DROP INDEX "idx-glyph-aspect" ON "glyph""#
 );
 ```

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -19,11 +19,11 @@ fn select() -> SelectStatement {
 }
 
 fn select_and_build() {
-    select().build(MysqlQueryBuilder);
+    select().build(&MysqlQueryBuilder);
 }
 
 fn select_and_to_string() {
-    select().to_string(MysqlQueryBuilder);
+    select().to_string(&MysqlQueryBuilder);
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
         Table::drop()
             .table(Character::Table)
             .if_exists()
-            .build(PostgresQueryBuilder),
+            .build(&PostgresQueryBuilder),
         Table::create()
             .table(Character::Table)
             .if_not_exists()
@@ -25,7 +25,7 @@ fn main() {
             )
             .col(ColumnDef::new(Character::FontSize).integer())
             .col(ColumnDef::new(Character::Character).string())
-            .build(PostgresQueryBuilder),
+            .build(&PostgresQueryBuilder),
     ]
     .join("; ");
 
@@ -39,7 +39,7 @@ fn main() {
         .columns([Character::Character, Character::FontSize])
         .values_panic(vec!["A".into(), 12.into()])
         .returning_col(Character::Id)
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let row = client.query_one(sql.as_str(), &values.as_params()).unwrap();
     let id: i32 = row.try_get(0).unwrap();
@@ -52,7 +52,7 @@ fn main() {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let rows = client.query(sql.as_str(), &values.as_params()).unwrap();
     println!("Select one from character:");
@@ -68,7 +68,7 @@ fn main() {
         .table(Character::Table)
         .values(vec![(Character::FontSize, 24.into())])
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let result = client.execute(sql.as_str(), &values.as_params());
     println!("Update character: {:?}\n", result);
@@ -80,7 +80,7 @@ fn main() {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let rows = client.query(sql.as_str(), &values.as_params()).unwrap();
     println!("Select one from character:");
@@ -95,7 +95,7 @@ fn main() {
     let (sql, values) = Query::select()
         .from(Character::Table)
         .expr(Func::count(Expr::col(Character::Id)))
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let row = client.query_one(sql.as_str(), &values.as_params()).unwrap();
     print!("Count character: ");
@@ -108,7 +108,7 @@ fn main() {
     let (sql, values) = Query::delete()
         .from_table(Character::Table)
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let result = client.execute(sql.as_str(), &values.as_params());
     println!("Delete character: {:?}", result);

--- a/examples/postgres_json/src/main.rs
+++ b/examples/postgres_json/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
         Table::drop()
             .table(Document::Table)
             .if_exists()
-            .build(PostgresQueryBuilder),
+            .build(&PostgresQueryBuilder),
         Table::create()
             .table(Document::Table)
             .if_not_exists()
@@ -34,7 +34,7 @@ fn main() {
             .col(ColumnDef::new(Document::TimestampWithTimeZone).timestamp_with_time_zone())
             .col(ColumnDef::new(Document::Decimal).decimal())
             .col(ColumnDef::new(Document::Array).array("integer".into()))
-            .build(PostgresQueryBuilder),
+            .build(&PostgresQueryBuilder),
     ]
     .join("; ");
 
@@ -110,7 +110,7 @@ fn main() {
             document_time.decimal.into(),
             document_time.array.into(),
         ])
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let result = client.execute(sql.as_str(), &values.as_params());
     println!("Insert into document: {:?}\n", result);
@@ -130,7 +130,7 @@ fn main() {
         .from(Document::Table)
         .order_by(Document::Id, Order::Desc)
         .limit(1)
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let rows = client.query(sql.as_str(), &values.as_params()).unwrap();
     println!("Select one from document:");

--- a/examples/rusqlite/Cargo.toml
+++ b/examples/rusqlite/Cargo.toml
@@ -10,7 +10,7 @@ serde_json = { version = "^1" }
 # rusqlite only supports uuid 0
 uuid = { version = "^0", features = ["serde", "v4"] }
 # that's why we can only use an older version of sea-query
-sea-query = { version = "^0.25", features = [
+sea-query = {  path = "../../", features = [
     "rusqlite",
     "with-chrono",
     "with-json",

--- a/examples/rusqlite/Cargo.toml
+++ b/examples/rusqlite/Cargo.toml
@@ -10,7 +10,7 @@ serde_json = { version = "^1" }
 # rusqlite only supports uuid 0
 uuid = { version = "^0", features = ["serde", "v4"] }
 # that's why we can only use an older version of sea-query
-sea-query = {  path = "../../", features = [
+sea-query = { version = "^0.25", features = [
     "rusqlite",
     "with-chrono",
     "with-json",

--- a/examples/rusqlite/src/main.rs
+++ b/examples/rusqlite/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
         Table::drop()
             .table(Character::Table)
             .if_exists()
-            .build(&SqliteQueryBuilder),
+            .build(SqliteQueryBuilder),
         Table::create()
             .table(Character::Table)
             .if_not_exists()
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
             .col(ColumnDef::new(Character::Character).string())
             .col(ColumnDef::new(Character::Meta).json())
             .col(ColumnDef::new(Character::Created).date_time())
-            .build(&SqliteQueryBuilder),
+            .build(SqliteQueryBuilder),
     ]
     .join("; ");
 
@@ -92,7 +92,7 @@ fn main() -> Result<()> {
             .into(),
             Some(date!(2020 - 1 - 1).with_time(time!(2:2:2))).into(),
         ])
-        .build(&SqliteQueryBuilder);
+        .build(SqliteQueryBuilder);
 
     let result = conn.execute(
         sql.as_str(),
@@ -115,7 +115,7 @@ fn main() -> Result<()> {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(&SqliteQueryBuilder);
+        .build(SqliteQueryBuilder);
 
     println!("Select one from character:");
     let mut stmt = conn.prepare(sql.as_str())?;
@@ -135,7 +135,7 @@ fn main() -> Result<()> {
         .table(Character::Table)
         .values(vec![(Character::FontSize, 24.into())])
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(&SqliteQueryBuilder);
+        .build(SqliteQueryBuilder);
 
     let result = conn.execute(
         sql.as_str(),
@@ -157,7 +157,7 @@ fn main() -> Result<()> {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(&SqliteQueryBuilder);
+        .build(SqliteQueryBuilder);
 
     println!("Select one from character:");
     let mut stmt = conn.prepare(sql.as_str())?;
@@ -176,7 +176,7 @@ fn main() -> Result<()> {
     let (sql, values) = Query::select()
         .from(Character::Table)
         .expr(Func::count(Expr::col(Character::Id)))
-        .build(&SqliteQueryBuilder);
+        .build(SqliteQueryBuilder);
 
     print!("Count character: ");
     let mut stmt = conn.prepare(sql.as_str())?;
@@ -194,7 +194,7 @@ fn main() -> Result<()> {
     let (sql, values) = Query::delete()
         .from_table(Character::Table)
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(&SqliteQueryBuilder);
+        .build(SqliteQueryBuilder);
 
     let result = conn.execute(
         sql.as_str(),

--- a/examples/rusqlite/src/main.rs
+++ b/examples/rusqlite/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
         Table::drop()
             .table(Character::Table)
             .if_exists()
-            .build(SqliteQueryBuilder),
+            .build(&SqliteQueryBuilder),
         Table::create()
             .table(Character::Table)
             .if_not_exists()
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
             .col(ColumnDef::new(Character::Character).string())
             .col(ColumnDef::new(Character::Meta).json())
             .col(ColumnDef::new(Character::Created).date_time())
-            .build(SqliteQueryBuilder),
+            .build(&SqliteQueryBuilder),
     ]
     .join("; ");
 
@@ -92,7 +92,7 @@ fn main() -> Result<()> {
             .into(),
             Some(date!(2020 - 1 - 1).with_time(time!(2:2:2))).into(),
         ])
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let result = conn.execute(
         sql.as_str(),
@@ -115,7 +115,7 @@ fn main() -> Result<()> {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     println!("Select one from character:");
     let mut stmt = conn.prepare(sql.as_str())?;
@@ -135,7 +135,7 @@ fn main() -> Result<()> {
         .table(Character::Table)
         .values(vec![(Character::FontSize, 24.into())])
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let result = conn.execute(
         sql.as_str(),
@@ -157,7 +157,7 @@ fn main() -> Result<()> {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     println!("Select one from character:");
     let mut stmt = conn.prepare(sql.as_str())?;
@@ -176,7 +176,7 @@ fn main() -> Result<()> {
     let (sql, values) = Query::select()
         .from(Character::Table)
         .expr(Func::count(Expr::col(Character::Id)))
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     print!("Count character: ");
     let mut stmt = conn.prepare(sql.as_str())?;
@@ -194,7 +194,7 @@ fn main() -> Result<()> {
     let (sql, values) = Query::delete()
         .from_table(Character::Table)
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let result = conn.execute(
         sql.as_str(),

--- a/examples/sqlx_mysql/src/main.rs
+++ b/examples/sqlx_mysql/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
         .col(ColumnDef::new(Character::Decimal).decimal())
         .col(ColumnDef::new(Character::BigDecimal).decimal())
         .col(ColumnDef::new(Character::Created).date_time())
-        .build(MysqlQueryBuilder);
+        .build(&MysqlQueryBuilder);
 
     let result = sqlx::query(&sql).execute(&mut pool).await;
     println!("Create table character: {:?}\n", result);
@@ -87,7 +87,7 @@ async fn main() {
                 .into(),
             date!(2020 - 8 - 20).with_time(time!(0:0:0)).into(),
         ])
-        .build(MysqlQueryBuilder);
+        .build(&MysqlQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values)
         .execute(&mut pool)
@@ -111,7 +111,7 @@ async fn main() {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(MysqlQueryBuilder);
+        .build(&MysqlQueryBuilder);
 
     let rows = bind_query_as(sqlx::query_as::<_, CharacterStructChrono>(&sql), &values)
         .fetch_all(&mut pool)
@@ -139,7 +139,7 @@ async fn main() {
         .table(Character::Table)
         .values(vec![(Character::FontSize, 24.into())])
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(MysqlQueryBuilder);
+        .build(&MysqlQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values)
         .execute(&mut pool)
@@ -162,7 +162,7 @@ async fn main() {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(MysqlQueryBuilder);
+        .build(&MysqlQueryBuilder);
 
     let rows = bind_query_as(sqlx::query_as::<_, CharacterStructChrono>(&sql), &values)
         .fetch_all(&mut pool)
@@ -196,7 +196,7 @@ async fn main() {
                 .update_columns([Character::FontSize, Character::Character])
                 .to_owned(),
         )
-        .build(MysqlQueryBuilder);
+        .build(&MysqlQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values)
         .execute(&mut pool)
@@ -219,7 +219,7 @@ async fn main() {
         ])
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
-        .build(MysqlQueryBuilder);
+        .build(&MysqlQueryBuilder);
 
     let rows = bind_query_as(sqlx::query_as::<_, CharacterStructChrono>(&sql), &values)
         .fetch_all(&mut pool)
@@ -246,7 +246,7 @@ async fn main() {
     let (sql, values) = Query::select()
         .from(Character::Table)
         .expr(Func::count(Expr::col(Character::Id)))
-        .build(MysqlQueryBuilder);
+        .build(&MysqlQueryBuilder);
 
     let row = bind_query(sqlx::query(&sql), &values)
         .fetch_one(&mut pool)
@@ -262,7 +262,7 @@ async fn main() {
     let (sql, values) = Query::delete()
         .from_table(Character::Table)
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(MysqlQueryBuilder);
+        .build(&MysqlQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values)
         .execute(&mut pool)

--- a/examples/sqlx_postgres/src/main.rs
+++ b/examples/sqlx_postgres/src/main.rs
@@ -46,7 +46,7 @@ async fn main() {
         .col(ColumnDef::new(Character::Created).date_time())
         .col(ColumnDef::new(Character::Inet).inet())
         .col(ColumnDef::new(Character::MacAddress).mac_address())
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let result = sqlx::query(&sql).execute(&mut pool).await;
     println!("Create table character: {:?}\n", result);
@@ -105,7 +105,7 @@ async fn main() {
             get_mac_address().unwrap().unwrap().into(),
         ])
         .returning_col(Character::Id)
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let row = bind_query(sqlx::query(&sql), &values)
         .fetch_one(&mut pool)
@@ -132,7 +132,7 @@ async fn main() {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let rows = bind_query_as(sqlx::query_as::<_, CharacterStructChrono>(&sql), &values)
         .fetch_all(&mut pool)
@@ -160,7 +160,7 @@ async fn main() {
         .table(Character::Table)
         .values(vec![(Character::FontSize, 24.into())])
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values)
         .execute(&mut pool)
@@ -185,7 +185,7 @@ async fn main() {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let rows = bind_query_as(sqlx::query_as::<_, CharacterStructChrono>(&sql), &values)
         .fetch_all(&mut pool)
@@ -212,7 +212,7 @@ async fn main() {
     let (sql, values) = Query::select()
         .from(Character::Table)
         .expr(Func::count(Expr::col(Character::Id)))
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let row = bind_query(sqlx::query(&sql), &values)
         .fetch_one(&mut pool)
@@ -235,7 +235,7 @@ async fn main() {
                 .update_columns([Character::FontSize, Character::Character])
                 .to_owned(),
         )
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values)
         .execute(&mut pool)
@@ -259,7 +259,7 @@ async fn main() {
         ])
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let rows = bind_query_as(sqlx::query_as::<_, CharacterStructChrono>(&sql), &values)
         .fetch_all(&mut pool)
@@ -286,7 +286,7 @@ async fn main() {
     let (sql, values) = Query::delete()
         .from_table(Character::Table)
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values)
         .execute(&mut pool)

--- a/examples/sqlx_sqlite/src/main.rs
+++ b/examples/sqlx_sqlite/src/main.rs
@@ -33,7 +33,7 @@ async fn main() {
         .col(ColumnDef::new(Character::Character).string())
         .col(ColumnDef::new(Character::Meta).json())
         .col(ColumnDef::new(Character::Created).date_time())
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let result = sqlx::query(&sql).execute(&pool).await;
     println!("Create table character: {:?}\n", result);
@@ -68,7 +68,7 @@ async fn main() {
             .into(),
             date!(2020 - 8 - 20).with_time(time!(0:0:0)).into(),
         ])
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     //TODO: Implement RETURNING (returning_col) for the Sqlite driver.
     let row = bind_query(sqlx::query(&sql), &values)
@@ -92,7 +92,7 @@ async fn main() {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let rows = bind_query_as(sqlx::query_as::<_, CharacterStructChrono>(&sql), &values)
         .fetch_all(&pool)
@@ -120,7 +120,7 @@ async fn main() {
         .table(Character::Table)
         .values(vec![(Character::FontSize, 24.into())])
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values).execute(&pool).await;
     println!("Update character: {:?}\n", result);
@@ -138,7 +138,7 @@ async fn main() {
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
         .limit(1)
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let rows = bind_query_as(sqlx::query_as::<_, CharacterStructChrono>(&sql), &values)
         .fetch_all(&pool)
@@ -164,7 +164,7 @@ async fn main() {
     let (sql, values) = Query::select()
         .from(Character::Table)
         .expr(Func::count(Expr::col(Character::Id)))
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let row = bind_query(sqlx::query(&sql), &values)
         .fetch_one(&pool)
@@ -185,7 +185,7 @@ async fn main() {
                 .update_columns([Character::FontSize, Character::Character])
                 .to_owned(),
         )
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values).execute(&pool).await;
     println!("Insert into character (with upsert): {:?}\n", result);
@@ -202,7 +202,7 @@ async fn main() {
         ])
         .from(Character::Table)
         .order_by(Character::Id, Order::Desc)
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let rows = bind_query_as(sqlx::query_as::<_, CharacterStructChrono>(&sql), &values)
         .fetch_all(&pool)
@@ -228,7 +228,7 @@ async fn main() {
     let (sql, values) = Query::delete()
         .from_table(Character::Table)
         .and_where(Expr::col(Character::Id).eq(id))
-        .build(SqliteQueryBuilder);
+        .build(&SqliteQueryBuilder);
 
     let result = bind_query(sqlx::query(&sql), &values).execute(&pool).await;
 

--- a/sea-query-binder/src/sqlx.rs
+++ b/sea-query-binder/src/sqlx.rs
@@ -3,7 +3,7 @@ use sea_query::{query::*, QueryBuilder};
 
 pub trait SqlxBinder {
     fn build_sqlx<T: QueryBuilder>(&self, query_builder: &T) -> (String, SqlxValues);
-    fn build_any_sqlx<T: QueryBuilder>(&self, query_builder: &T) -> (String, SqlxValues);
+    fn build_any_sqlx<T: QueryBuilder + ?Sized>(&self, query_builder: &T) -> (String, SqlxValues);
 }
 
 macro_rules! impl_sqlx_binder {
@@ -13,7 +13,10 @@ macro_rules! impl_sqlx_binder {
                 let (query, values) = self.build(query_builder);
                 (query, SqlxValues(values))
             }
-            fn build_any_sqlx<T: QueryBuilder>(&self, query_builder: &T) -> (String, SqlxValues) {
+            fn build_any_sqlx<T: QueryBuilder + ?Sized>(
+                &self,
+                query_builder: &T,
+            ) -> (String, SqlxValues) {
                 let (query, values) = self.build_any(query_builder);
                 (query, SqlxValues(values))
             }

--- a/sea-query-binder/src/sqlx.rs
+++ b/sea-query-binder/src/sqlx.rs
@@ -2,8 +2,8 @@ use crate::SqlxValues;
 use sea_query::{query::*, QueryBuilder};
 
 pub trait SqlxBinder {
-    fn build_sqlx<T: QueryBuilder>(&self, query_builder: T) -> (String, SqlxValues);
-    fn build_any_sqlx(&self, query_builder: &dyn QueryBuilder) -> (String, SqlxValues);
+    fn build_sqlx<T: QueryBuilder + ?Sized>(&self, query_builder: &T) -> (String, SqlxValues);
+    fn build_any_sqlx<T: QueryBuilder + ?Sized>(&self, query_builder: &T) -> (String, SqlxValues);
 }
 
 macro_rules! impl_sqlx_binder {
@@ -16,7 +16,10 @@ macro_rules! impl_sqlx_binder {
                 let (query, values) = self.build(query_builder);
                 (query, SqlxValues(values))
             }
-            fn build_any_sqlx(&self, query_builder: &dyn QueryBuilder) -> (String, SqlxValues) {
+            fn build_any_sqlx<T: QueryBuilder + ?Sized>(
+                &self,
+                query_builder: &T,
+            ) -> (String, SqlxValues) {
                 let (query, values) = self.build_any(query_builder);
                 (query, SqlxValues(values))
             }

--- a/sea-query-binder/src/sqlx.rs
+++ b/sea-query-binder/src/sqlx.rs
@@ -2,24 +2,18 @@ use crate::SqlxValues;
 use sea_query::{query::*, QueryBuilder};
 
 pub trait SqlxBinder {
-    fn build_sqlx<T: QueryBuilder + ?Sized>(&self, query_builder: &T) -> (String, SqlxValues);
-    fn build_any_sqlx<T: QueryBuilder + ?Sized>(&self, query_builder: &T) -> (String, SqlxValues);
+    fn build_sqlx<T: QueryBuilder>(&self, query_builder: &T) -> (String, SqlxValues);
+    fn build_any_sqlx<T: QueryBuilder>(&self, query_builder: &T) -> (String, SqlxValues);
 }
 
 macro_rules! impl_sqlx_binder {
     ($l:ident) => {
         impl SqlxBinder for $l {
-            fn build_sqlx<T: QueryBuilder + ?Sized>(
-                &self,
-                query_builder: &T,
-            ) -> (String, SqlxValues) {
+            fn build_sqlx<T: QueryBuilder>(&self, query_builder: &T) -> (String, SqlxValues) {
                 let (query, values) = self.build(query_builder);
                 (query, SqlxValues(values))
             }
-            fn build_any_sqlx<T: QueryBuilder + ?Sized>(
-                &self,
-                query_builder: &T,
-            ) -> (String, SqlxValues) {
+            fn build_any_sqlx<T: QueryBuilder>(&self, query_builder: &T) -> (String, SqlxValues) {
                 let (query, values) = self.build_any(query_builder);
                 (query, SqlxValues(values))
             }

--- a/sea-query-binder/src/sqlx.rs
+++ b/sea-query-binder/src/sqlx.rs
@@ -9,7 +9,10 @@ pub trait SqlxBinder {
 macro_rules! impl_sqlx_binder {
     ($l:ident) => {
         impl SqlxBinder for $l {
-            fn build_sqlx<T: QueryBuilder>(&self, query_builder: T) -> (String, SqlxValues) {
+            fn build_sqlx<T: QueryBuilder + ?Sized>(
+                &self,
+                query_builder: &T,
+            ) -> (String, SqlxValues) {
                 let (query, values) = self.build(query_builder);
                 (query, SqlxValues(values))
             }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -68,15 +68,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT * FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT * FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT * FROM "character""#
     /// );
     /// ```
@@ -91,15 +91,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" = 1"#
     /// );
     /// ```
@@ -121,15 +121,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 1"#
     /// );
     /// ```
@@ -144,15 +144,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" = 1"#
     /// );
     /// ```
@@ -179,15 +179,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE (`size_w`, 100) < (500, 100)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w", 100) < (500, 100)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w", 100) < (500, 100)"#
     /// );
     /// ```
@@ -213,15 +213,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT * FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT * FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT * FROM "character""#
     /// );
     /// ```
@@ -237,15 +237,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`.*, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character".*, "font"."name" FROM "character" INNER JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character".*, "font"."name" FROM "character" INNER JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     /// ```
@@ -270,15 +270,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" = 1"#
     /// );
     /// ```
@@ -306,15 +306,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 AND 2.5 AND '3'"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 AND 2.5 AND '3'"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 AND 2.5 AND '3'"#
     /// );
     /// ```
@@ -339,15 +339,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE IFNULL(`size_w`, 0) > 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE COALESCE("size_w", 0) > 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE IFNULL("size_w", 0) > 2"#
     /// );
     /// ```
@@ -372,15 +372,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 AND 2.5 AND '3'"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 AND 2.5 AND '3'"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 AND 2.5 AND '3'"#
     /// );
     /// ```
@@ -405,15 +405,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 = 1"#
     /// );
     /// ```
@@ -436,11 +436,11 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `id` = 1 AND 6 = 2 * 3"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "id" = 1 AND 6 = 2 * 3"#
     /// );
     /// ```
@@ -455,7 +455,7 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "id" = 1 AND 6 = 2 * 3"#
     /// );
     /// ```
@@ -466,8 +466,8 @@ impl Expr {
     ///     .expr(Expr::cust_with_values("6 = ? * ?", vec![2, 3]))
     ///     .to_owned();
     ///
-    /// assert_eq!(query.to_string(MysqlQueryBuilder), r#"SELECT 6 = 2 * 3"#);
-    /// assert_eq!(query.to_string(SqliteQueryBuilder), r#"SELECT 6 = 2 * 3"#);
+    /// assert_eq!(query.to_string(&MysqlQueryBuilder), r#"SELECT 6 = 2 * 3"#);
+    /// assert_eq!(query.to_string(&SqliteQueryBuilder), r#"SELECT 6 = 2 * 3"#);
     /// ```
     /// Postgres only: use `$$` to escape `$`
     /// ```
@@ -477,7 +477,7 @@ impl Expr {
     ///     .expr(Expr::cust_with_values("$1 $$ $2", vec!["a", "b"]))
     ///     .to_owned();
     ///
-    /// assert_eq!(query.to_string(PostgresQueryBuilder), r#"SELECT 'a' $ 'b'"#);
+    /// assert_eq!(query.to_string(&PostgresQueryBuilder), r#"SELECT 'a' $ 'b'"#);
     /// ```
     /// ```
     /// use sea_query::{tests_cfg::*, *};
@@ -490,7 +490,7 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT data @? ('hello'::JSONPATH)"#
     /// );
     /// ```
@@ -517,15 +517,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 'What!' = 'Nothing' AND `id` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'What!' = 'Nothing' AND "id" = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'What!' = 'Nothing' AND "id" = 1"#
     /// );
     /// ```
@@ -551,15 +551,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 'Morning' <> 'Good' AND `id` <> 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'Morning' <> 'Good' AND "id" <> 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'Morning' <> 'Good' AND "id" <> 1"#
     /// );
     /// ```
@@ -585,15 +585,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."font_id" = "font"."id""#
     /// );
     /// ```
@@ -622,15 +622,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` > 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" > 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" > 2"#
     /// );
     /// ```
@@ -658,15 +658,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` > `character`.`size_h`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" > "character"."size_h""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" > "character"."size_h""#
     /// );
     /// ```
@@ -690,15 +690,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` >= 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" >= 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" >= 2"#
     /// );
     /// ```
@@ -726,15 +726,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` >= `character`.`size_h`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" >= "character"."size_h""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" >= "character"."size_h""#
     /// );
     /// ```
@@ -759,15 +759,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` < 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" < 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" < 2"#
     /// );
     /// ```
@@ -795,15 +795,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` < `character`.`size_h`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" < "character"."size_h""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" < "character"."size_h""#
     /// );
     /// ```
@@ -828,15 +828,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` <= 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" <= 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" <= 2"#
     /// );
     /// ```
@@ -864,15 +864,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` <= `character`.`size_h`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" <= "character"."size_h""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" <= "character"."size_h""#
     /// );
     /// ```
@@ -897,15 +897,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 + 1 = 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 + 1 = 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 + 1 = 2"#
     /// );
     /// ```
@@ -931,15 +931,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 - 1 = 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 - 1 = 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 - 1 = 2"#
     /// );
     /// ```
@@ -965,15 +965,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 * 1 = 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 * 1 = 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 * 1 = 2"#
     /// );
     /// ```
@@ -999,15 +999,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 / 1 = 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 / 1 = 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 / 1 = 2"#
     /// );
     /// ```
@@ -1033,15 +1033,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` BETWEEN 1 AND 10"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" BETWEEN 1 AND 10"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" BETWEEN 1 AND 10"#
     /// );
     /// ```
@@ -1066,15 +1066,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` NOT BETWEEN 1 AND 10"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" NOT BETWEEN 1 AND 10"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" NOT BETWEEN 1 AND 10"#
     /// );
     /// ```
@@ -1113,15 +1113,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`character` LIKE 'Ours\'%'"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE E'Ours\'%'"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE 'Ours''%'"#
     /// );
     /// ```
@@ -1138,15 +1138,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`character` LIKE '|_Our|_' ESCAPE '|'"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE '|_Our|_' ESCAPE '|'"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE '|_Our|_' ESCAPE '|'"#
     /// );
     /// ```
@@ -1187,15 +1187,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` IS NULL"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" IS NULL"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" IS NULL"#
     /// );
     /// ```
@@ -1218,15 +1218,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`ascii` IS TRUE"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."ascii" IS TRUE"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."ascii" IS TRUE"#
     /// );
     /// ```
@@ -1251,15 +1251,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` IS NOT NULL"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" IS NOT NULL"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" IS NOT NULL"#
     /// );
     /// ```
@@ -1282,15 +1282,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`ascii` IS NOT TRUE"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."ascii" IS NOT TRUE"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."ascii" IS NOT TRUE"#
     /// );
     /// ```
@@ -1316,15 +1316,15 @@ impl Expr {
     ///     ])
     ///     .to_owned();
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` < 10 AND `size_w` > `size_h`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" < 10 AND "size_w" > "size_h""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" < 10 AND "size_w" > "size_h""#
     /// );
     /// ```
@@ -1349,15 +1349,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE NOT `character`.`size_w` IS NULL"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE NOT "character"."size_w" IS NULL"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE NOT "character"."size_w" IS NULL"#
     /// );
     /// ```
@@ -1379,15 +1379,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT MAX(`character`.`size_w`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT MAX("character"."size_w") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT MAX("character"."size_w") FROM "character""#
     /// );
     /// ```
@@ -1409,15 +1409,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT MIN(`character`.`size_w`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT MIN("character"."size_w") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT MIN("character"."size_w") FROM "character""#
     /// );
     /// ```
@@ -1439,15 +1439,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT SUM(`character`.`size_w`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT SUM("character"."size_w") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT SUM("character"."size_w") FROM "character""#
     /// );
     /// ```
@@ -1469,15 +1469,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT COUNT(`character`.`size_w`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT COUNT("character"."size_w") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT COUNT("character"."size_w") FROM "character""#
     /// );
     /// ```
@@ -1499,15 +1499,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT IFNULL(`character`.`size_w`, 0) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT COALESCE("character"."size_w", 0) FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT IFNULL("character"."size_w", 0) FROM "character""#
     /// );
     /// ```
@@ -1536,15 +1536,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `id` FROM `character` WHERE `character`.`size_w` IN (1, 2, 3)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "id" FROM "character" WHERE "character"."size_w" IN (1, 2, 3)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "id" FROM "character" WHERE "character"."size_w" IN (1, 2, 3)"#
     /// );
     /// ```
@@ -1559,15 +1559,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `id` FROM `character` WHERE 1 = 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "id" FROM "character" WHERE 1 = 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "id" FROM "character" WHERE 1 = 2"#
     /// );
     /// ```
@@ -1604,17 +1604,17 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font_id` FROM `character` WHERE (`character`, `font_id`) IN ((1, '1'), (2, '2'))"#
     /// );
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font_id" FROM "character" WHERE ("character", "font_id") IN ((1, '1'), (2, '2'))"#
     /// );
     ///
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font_id" FROM "character" WHERE ("character", "font_id") IN ((1, '1'), (2, '2'))"#
     /// );
     /// ```
@@ -1647,15 +1647,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `id` FROM `character` WHERE `character`.`size_w` NOT IN (1, 2, 3)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "id" FROM "character" WHERE "character"."size_w" NOT IN (1, 2, 3)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "id" FROM "character" WHERE "character"."size_w" NOT IN (1, 2, 3)"#
     /// );
     /// ```
@@ -1670,15 +1670,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `id` FROM `character` WHERE 1 = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "id" FROM "character" WHERE 1 = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "id" FROM "character" WHERE 1 = 1"#
     /// );
     /// ```
@@ -1713,15 +1713,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` IN (SELECT 3 + 2 * 2)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" IN (SELECT 3 + 2 * 2)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" IN (SELECT 3 + 2 * 2)"#
     /// );
     /// ```
@@ -1752,15 +1752,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` NOT IN (SELECT 3 + 2 * 2)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" NOT IN (SELECT 3 + 2 * 2)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" NOT IN (SELECT 3 + 2 * 2)"#
     /// );
     /// ```
@@ -1788,7 +1788,7 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' @@ 'a b' AND "name" @@ 'a b'"#
     /// );
     /// ```
@@ -1815,7 +1815,7 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' @> 'a b' AND "name" @> 'a b'"#
     /// );
     /// ```
@@ -1842,7 +1842,7 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' <@ 'a b' AND "name" <@ 'a b'"#
     /// );
     /// ```
@@ -1869,7 +1869,7 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a' || 'b' AND 'c' || 'd'"#
     /// );
     /// ```
@@ -1926,15 +1926,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `font_size` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT CAST("font_size" AS text) FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "font_size" FROM "character""#
     /// );
     ///
@@ -1945,15 +1945,15 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `character` (`font_size`) VALUES ('large')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "character" ("font_size") VALUES (CAST('large' AS FontSizeEnum))"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "character" ("font_size") VALUES ('large')"#
     /// );
     /// ```
@@ -2007,7 +2007,7 @@ impl Expr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT (CASE WHEN ("glyph"."aspect" IN (2, 4)) THEN TRUE ELSE FALSE END) AS "is_even" FROM "glyph""#
     /// );
     /// ```
@@ -2063,15 +2063,15 @@ impl SimpleExpr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE ((`size_w` = 1) AND (`size_h` = 2)) OR ((`size_w` = 3) AND (`size_h` = 4))"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE (("size_w" = 1) AND ("size_h" = 2)) OR (("size_w" = 3) AND ("size_h" = 4))"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE (("size_w" = 1) AND ("size_h" = 2)) OR (("size_w" = 3) AND ("size_h" = 4))"#
     /// );
     /// ```
@@ -2094,15 +2094,15 @@ impl SimpleExpr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE ((`size_w` = 1) OR (`size_h` = 2)) AND ((`size_w` = 3) OR (`size_h` = 4))"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE (("size_w" = 1) OR ("size_h" = 2)) AND (("size_w" = 3) OR ("size_h" = 4))"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE (("size_w" = 1) OR ("size_h" = 2)) AND (("size_w" = 3) OR ("size_h" = 4))"#
     /// );
     /// ```
@@ -2128,15 +2128,15 @@ impl SimpleExpr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `size_w` * 2 = `size_h` * 3"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "size_w" * 2 = "size_h" * 3"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "size_w" * 2 = "size_h" * 3"#
     /// );
     /// ```
@@ -2165,15 +2165,15 @@ impl SimpleExpr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `size_w` * 2 <> `size_h`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "size_w" * 2 <> "size_h""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "size_w" * 2 <> "size_h""#
     /// );
     /// ```
@@ -2201,15 +2201,15 @@ impl SimpleExpr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT MAX(`size_w`) + MAX(`size_h`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT MAX("size_w") + MAX("size_h") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT MAX("size_w") + MAX("size_h") FROM "character""#
     /// );
     /// ```
@@ -2238,15 +2238,15 @@ impl SimpleExpr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT MAX(`size_w`) - MIN(`size_w`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT MAX("size_w") - MIN("size_w") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT MAX("size_w") - MIN("size_w") FROM "character""#
     /// );
     /// ```
@@ -2343,7 +2343,7 @@ impl SimpleExpr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a' || 'b' || 'c' || 'd'"#
     /// );
     /// ```
@@ -2376,15 +2376,15 @@ impl SimpleExpr {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT CAST('1' AS integer)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT CAST('1' AS integer)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT CAST('1' AS integer)"#
     /// );
     /// ```

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -40,7 +40,7 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT TO_TSQUERY('a & b')"#
     /// );
     /// ```
@@ -73,7 +73,7 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT TO_TSVECTOR('a b')"#
     /// );
     /// ```
@@ -106,7 +106,7 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT PHRASETO_TSQUERY('a b')"#
     /// );
     /// ```
@@ -139,7 +139,7 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT PLAINTO_TSQUERY('a b')"#
     /// );
     /// ```
@@ -172,7 +172,7 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT WEBSEARCH_TO_TSQUERY('a b')"#
     /// );
     /// ```
@@ -202,7 +202,7 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT TS_RANK('a b', 'a&b')"#
     /// );
     /// ```
@@ -225,7 +225,7 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT TS_RANK_CD('a b', 'a&b')"#
     /// );
     /// ```
@@ -248,7 +248,7 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT ANY('{0,1}')"#
     /// );
     /// ```
@@ -272,7 +272,7 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT SOME('{0,1}')"#
     /// );
     /// ```
@@ -296,7 +296,7 @@ impl PgFunc {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT ALL('{0,1}')"#
     /// );
     /// ```

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -260,10 +260,7 @@ impl TypeCreateStatement {
     }
 
     /// Build corresponding SQL statement and return SQL string
-    pub fn to_string<T>(&self, type_builder: &T) -> String
-    where
-        T: TypeBuilder + QueryBuilder,
-    {
+    pub fn to_string<T: TypeBuilder>(&self, type_builder: &T) -> String {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
     }
@@ -365,10 +362,7 @@ impl TypeDropStatement {
     }
 
     /// Build corresponding SQL statement and return SQL string
-    pub fn to_string<T>(&self, type_builder: &T) -> String
-    where
-        T: TypeBuilder + QueryBuilder,
-    {
+    pub fn to_string<T: TypeBuilder>(&self, type_builder: &T) -> String {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
     }

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -204,7 +204,7 @@ impl TypeCreateStatement {
     ///             FontFamily::Sans,
     ///             FontFamily::Monospace
     ///         ])
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"CREATE TYPE "font_family" AS ENUM ('serif', 'sans', 'monospace')"#
     /// );
     /// ```
@@ -260,12 +260,12 @@ impl TypeCreateStatement {
     }
 
     /// Build corresponding SQL statement and return SQL string
-    pub fn to_string<T>(&self, type_builder: T) -> String
+    pub fn to_string<T>(&self, type_builder: &T) -> String
     where
         T: TypeBuilder + QueryBuilder,
     {
-        let (sql, values) = self.build_ref(&type_builder);
-        inject_parameters(&sql, values, &type_builder)
+        let (sql, values) = self.build_ref(type_builder);
+        inject_parameters(&sql, values, type_builder)
     }
 }
 
@@ -292,7 +292,7 @@ impl TypeDropStatement {
     ///         .if_exists()
     ///         .name(FontFamily)
     ///         .restrict()
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"DROP TYPE IF EXISTS "font_family" RESTRICT"#
     /// );
     /// ```
@@ -365,12 +365,12 @@ impl TypeDropStatement {
     }
 
     /// Build corresponding SQL statement and return SQL string
-    pub fn to_string<T>(&self, type_builder: T) -> String
+    pub fn to_string<T>(&self, type_builder: &T) -> String
     where
         T: TypeBuilder + QueryBuilder,
     {
-        let (sql, values) = self.build_ref(&type_builder);
-        inject_parameters(&sql, values, &type_builder)
+        let (sql, values) = self.build_ref(type_builder);
+        inject_parameters(&sql, values, type_builder)
     }
 }
 
@@ -411,7 +411,7 @@ impl TypeAlterStatement {
     ///     Type::alter()
     ///         .name(FontFamily::Type)
     ///         .add_value(Alias::new("cursive"))
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"ALTER TYPE "font_family" ADD VALUE 'cursive'"#
     /// );
     /// ```
@@ -440,7 +440,7 @@ impl TypeAlterStatement {
     ///         .name(Font::Table)
     ///         .add_value(Alias::new("weight"))
     ///         .before(Font::Variant)
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"ALTER TYPE "font" ADD VALUE 'weight' BEFORE 'variant'"#
     /// )
     /// ```
@@ -480,7 +480,7 @@ impl TypeAlterStatement {
     ///     Type::alter()
     ///         .name(Font::Table)
     ///         .rename_value(Alias::new("variant"), Alias::new("language"))
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"ALTER TYPE "font" RENAME VALUE 'variant' TO 'language'"#
     /// )
     /// ```
@@ -532,12 +532,12 @@ impl TypeAlterStatement {
     }
 
     /// Build corresponding SQL statement and return SQL string
-    pub fn to_string<T>(&self, type_builder: T) -> String
+    pub fn to_string<T>(&self, type_builder: &T) -> String
     where
         T: TypeBuilder + QueryBuilder,
     {
-        let (sql, values) = self.build_ref(&type_builder);
-        inject_parameters(&sql, values, &type_builder)
+        let (sql, values) = self.build_ref(type_builder);
+        inject_parameters(&sql, values, type_builder)
     }
 }
 

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -22,8 +22,8 @@ impl IntoTypeRef for TypeRef {
 }
 
 impl<I> IntoTypeRef for I
-where
-    I: IntoIden,
+    where
+        I: IntoIden,
 {
     fn into_type_ref(self) -> TypeRef {
         TypeRef::Type(self.into_iden())
@@ -31,9 +31,9 @@ where
 }
 
 impl<A, B> IntoTypeRef for (A, B)
-where
-    A: IntoIden,
-    B: IntoIden,
+    where
+        A: IntoIden,
+        B: IntoIden,
 {
     fn into_type_ref(self) -> TypeRef {
         TypeRef::SchemaType(self.0.into_iden(), self.1.into_iden())
@@ -41,10 +41,10 @@ where
 }
 
 impl<A, B, C> IntoTypeRef for (A, B, C)
-where
-    A: IntoIden,
-    B: IntoIden,
-    C: IntoIden,
+    where
+        A: IntoIden,
+        B: IntoIden,
+        C: IntoIden,
 {
     fn into_type_ref(self) -> TypeRef {
         TypeRef::DatabaseSchemaType(self.0.into_iden(), self.1.into_iden(), self.2.into_iden())
@@ -99,7 +99,7 @@ pub enum TypeAlterAddOpt {
     After(DynIden),
 }
 
-pub trait TypeBuilder: QuotedBuilder {
+pub trait TypeBuilder: QuotedBuilder + QueryBuilder {
     /// Translate [`TypeCreateStatement`] into database specific SQL statement.
     fn prepare_type_create_statement(
         &self,
@@ -209,8 +209,8 @@ impl TypeCreateStatement {
     /// );
     /// ```
     pub fn as_enum<T: 'static>(&mut self, name: T) -> &mut Self
-    where
-        T: IntoTypeRef,
+        where
+            T: IntoTypeRef,
     {
         self.name = Some(name.into_type_ref());
         self.as_type = Some(TypeAs::Enum);
@@ -218,9 +218,9 @@ impl TypeCreateStatement {
     }
 
     pub fn values<T, I>(&mut self, values: I) -> &mut Self
-    where
-        T: IntoIden,
-        I: IntoIterator<Item = T>,
+        where
+            T: IntoIden,
+            I: IntoIterator<Item=T>,
     {
         for v in values.into_iter() {
             self.values.push(v.into_iden());
@@ -261,8 +261,8 @@ impl TypeCreateStatement {
 
     /// Build corresponding SQL statement and return SQL string
     pub fn to_string<T>(&self, type_builder: &T) -> String
-    where
-        T: TypeBuilder + QueryBuilder,
+        where
+            T: TypeBuilder + QueryBuilder,
     {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
@@ -297,17 +297,17 @@ impl TypeDropStatement {
     /// );
     /// ```
     pub fn name<T>(&mut self, name: T) -> &mut Self
-    where
-        T: IntoTypeRef,
+        where
+            T: IntoTypeRef,
     {
         self.names.push(name.into_type_ref());
         self
     }
 
     pub fn names<T, I>(&mut self, names: I) -> &mut Self
-    where
-        T: IntoTypeRef,
-        I: IntoIterator<Item = T>,
+        where
+            T: IntoTypeRef,
+            I: IntoIterator<Item=T>,
     {
         for n in names.into_iter() {
             self.names.push(n.into_type_ref());
@@ -366,8 +366,8 @@ impl TypeDropStatement {
 
     /// Build corresponding SQL statement and return SQL string
     pub fn to_string<T>(&self, type_builder: &T) -> String
-    where
-        T: TypeBuilder + QueryBuilder,
+        where
+            T: TypeBuilder + QueryBuilder,
     {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
@@ -416,16 +416,16 @@ impl TypeAlterStatement {
     /// );
     /// ```
     pub fn name<T>(mut self, name: T) -> Self
-    where
-        T: IntoTypeRef,
+        where
+            T: IntoTypeRef,
     {
         self.name = Some(name.into_type_ref());
         self
     }
 
     pub fn add_value<T>(self, value: T) -> Self
-    where
-        T: IntoIden,
+        where
+            T: IntoIden,
     {
         self.alter_option(TypeAlterOpt::Add(value.into_iden(), None))
     }
@@ -445,8 +445,8 @@ impl TypeAlterStatement {
     /// )
     /// ```
     pub fn before<T>(mut self, value: T) -> Self
-    where
-        T: IntoIden,
+        where
+            T: IntoIden,
     {
         if let Some(option) = self.option {
             self.option = Some(option.before(value));
@@ -455,8 +455,8 @@ impl TypeAlterStatement {
     }
 
     pub fn after<T>(mut self, value: T) -> Self
-    where
-        T: IntoIden,
+        where
+            T: IntoIden,
     {
         if let Some(option) = self.option {
             self.option = Some(option.after(value));
@@ -465,8 +465,8 @@ impl TypeAlterStatement {
     }
 
     pub fn rename_to<T>(self, name: T) -> Self
-    where
-        T: IntoIden,
+        where
+            T: IntoIden,
     {
         self.alter_option(TypeAlterOpt::Rename(name.into_iden()))
     }
@@ -485,9 +485,9 @@ impl TypeAlterStatement {
     /// )
     /// ```
     pub fn rename_value<T, V>(self, existing: T, new_name: V) -> Self
-    where
-        T: IntoIden,
-        V: IntoIden,
+        where
+            T: IntoIden,
+            V: IntoIden,
     {
         self.alter_option(TypeAlterOpt::RenameValue(
             existing.into_iden(),
@@ -533,8 +533,8 @@ impl TypeAlterStatement {
 
     /// Build corresponding SQL statement and return SQL string
     pub fn to_string<T>(&self, type_builder: &T) -> String
-    where
-        T: TypeBuilder + QueryBuilder,
+        where
+            T: TypeBuilder + QueryBuilder,
     {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
@@ -544,8 +544,8 @@ impl TypeAlterStatement {
 impl TypeAlterOpt {
     /// Changes only `ADD VALUE x` options into `ADD VALUE x BEFORE` options, does nothing otherwise
     pub fn before<T>(self, value: T) -> Self
-    where
-        T: IntoIden,
+        where
+            T: IntoIden,
     {
         match self {
             TypeAlterOpt::Add(iden, _) => {
@@ -557,8 +557,8 @@ impl TypeAlterOpt {
 
     /// Changes only `ADD VALUE x` options into `ADD VALUE x AFTER` options, does nothing otherwise
     pub fn after<T>(self, value: T) -> Self
-    where
-        T: IntoIden,
+        where
+            T: IntoIden,
     {
         match self {
             TypeAlterOpt::Add(iden, _) => {

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -22,8 +22,8 @@ impl IntoTypeRef for TypeRef {
 }
 
 impl<I> IntoTypeRef for I
-    where
-        I: IntoIden,
+where
+    I: IntoIden,
 {
     fn into_type_ref(self) -> TypeRef {
         TypeRef::Type(self.into_iden())
@@ -31,9 +31,9 @@ impl<I> IntoTypeRef for I
 }
 
 impl<A, B> IntoTypeRef for (A, B)
-    where
-        A: IntoIden,
-        B: IntoIden,
+where
+    A: IntoIden,
+    B: IntoIden,
 {
     fn into_type_ref(self) -> TypeRef {
         TypeRef::SchemaType(self.0.into_iden(), self.1.into_iden())
@@ -41,10 +41,10 @@ impl<A, B> IntoTypeRef for (A, B)
 }
 
 impl<A, B, C> IntoTypeRef for (A, B, C)
-    where
-        A: IntoIden,
-        B: IntoIden,
-        C: IntoIden,
+where
+    A: IntoIden,
+    B: IntoIden,
+    C: IntoIden,
 {
     fn into_type_ref(self) -> TypeRef {
         TypeRef::DatabaseSchemaType(self.0.into_iden(), self.1.into_iden(), self.2.into_iden())
@@ -209,8 +209,8 @@ impl TypeCreateStatement {
     /// );
     /// ```
     pub fn as_enum<T: 'static>(&mut self, name: T) -> &mut Self
-        where
-            T: IntoTypeRef,
+    where
+        T: IntoTypeRef,
     {
         self.name = Some(name.into_type_ref());
         self.as_type = Some(TypeAs::Enum);
@@ -218,9 +218,9 @@ impl TypeCreateStatement {
     }
 
     pub fn values<T, I>(&mut self, values: I) -> &mut Self
-        where
-            T: IntoIden,
-            I: IntoIterator<Item=T>,
+    where
+        T: IntoIden,
+        I: IntoIterator<Item = T>,
     {
         for v in values.into_iter() {
             self.values.push(v.into_iden());
@@ -261,8 +261,8 @@ impl TypeCreateStatement {
 
     /// Build corresponding SQL statement and return SQL string
     pub fn to_string<T>(&self, type_builder: &T) -> String
-        where
-            T: TypeBuilder + QueryBuilder,
+    where
+        T: TypeBuilder + QueryBuilder,
     {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
@@ -297,17 +297,17 @@ impl TypeDropStatement {
     /// );
     /// ```
     pub fn name<T>(&mut self, name: T) -> &mut Self
-        where
-            T: IntoTypeRef,
+    where
+        T: IntoTypeRef,
     {
         self.names.push(name.into_type_ref());
         self
     }
 
     pub fn names<T, I>(&mut self, names: I) -> &mut Self
-        where
-            T: IntoTypeRef,
-            I: IntoIterator<Item=T>,
+    where
+        T: IntoTypeRef,
+        I: IntoIterator<Item = T>,
     {
         for n in names.into_iter() {
             self.names.push(n.into_type_ref());
@@ -366,8 +366,8 @@ impl TypeDropStatement {
 
     /// Build corresponding SQL statement and return SQL string
     pub fn to_string<T>(&self, type_builder: &T) -> String
-        where
-            T: TypeBuilder + QueryBuilder,
+    where
+        T: TypeBuilder + QueryBuilder,
     {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
@@ -416,16 +416,16 @@ impl TypeAlterStatement {
     /// );
     /// ```
     pub fn name<T>(mut self, name: T) -> Self
-        where
-            T: IntoTypeRef,
+    where
+        T: IntoTypeRef,
     {
         self.name = Some(name.into_type_ref());
         self
     }
 
     pub fn add_value<T>(self, value: T) -> Self
-        where
-            T: IntoIden,
+    where
+        T: IntoIden,
     {
         self.alter_option(TypeAlterOpt::Add(value.into_iden(), None))
     }
@@ -445,8 +445,8 @@ impl TypeAlterStatement {
     /// )
     /// ```
     pub fn before<T>(mut self, value: T) -> Self
-        where
-            T: IntoIden,
+    where
+        T: IntoIden,
     {
         if let Some(option) = self.option {
             self.option = Some(option.before(value));
@@ -455,8 +455,8 @@ impl TypeAlterStatement {
     }
 
     pub fn after<T>(mut self, value: T) -> Self
-        where
-            T: IntoIden,
+    where
+        T: IntoIden,
     {
         if let Some(option) = self.option {
             self.option = Some(option.after(value));
@@ -465,8 +465,8 @@ impl TypeAlterStatement {
     }
 
     pub fn rename_to<T>(self, name: T) -> Self
-        where
-            T: IntoIden,
+    where
+        T: IntoIden,
     {
         self.alter_option(TypeAlterOpt::Rename(name.into_iden()))
     }
@@ -485,9 +485,9 @@ impl TypeAlterStatement {
     /// )
     /// ```
     pub fn rename_value<T, V>(self, existing: T, new_name: V) -> Self
-        where
-            T: IntoIden,
-            V: IntoIden,
+    where
+        T: IntoIden,
+        V: IntoIden,
     {
         self.alter_option(TypeAlterOpt::RenameValue(
             existing.into_iden(),
@@ -533,8 +533,8 @@ impl TypeAlterStatement {
 
     /// Build corresponding SQL statement and return SQL string
     pub fn to_string<T>(&self, type_builder: &T) -> String
-        where
-            T: TypeBuilder + QueryBuilder,
+    where
+        T: TypeBuilder + QueryBuilder,
     {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
@@ -544,8 +544,8 @@ impl TypeAlterStatement {
 impl TypeAlterOpt {
     /// Changes only `ADD VALUE x` options into `ADD VALUE x BEFORE` options, does nothing otherwise
     pub fn before<T>(self, value: T) -> Self
-        where
-            T: IntoIden,
+    where
+        T: IntoIden,
     {
         match self {
             TypeAlterOpt::Add(iden, _) => {
@@ -557,8 +557,8 @@ impl TypeAlterOpt {
 
     /// Changes only `ADD VALUE x` options into `ADD VALUE x AFTER` options, does nothing otherwise
     pub fn after<T>(self, value: T) -> Self
-        where
-            T: IntoIden,
+    where
+        T: IntoIden,
     {
         match self {
             TypeAlterOpt::Add(iden, _) => {

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -230,26 +230,26 @@ impl TypeCreateStatement {
 
     // below are boiler plates
 
-    pub fn build<T: TypeBuilder>(&self, type_builder: T) -> (String, Vec<Value>) {
-        self.build_ref(&type_builder)
+    pub fn build<T: TypeBuilder + ?Sized>(&self, type_builder: &T) -> (String, Vec<Value>) {
+        self.build_ref(type_builder)
     }
 
-    pub fn build_ref<T: TypeBuilder>(&self, type_builder: &T) -> (String, Vec<Value>) {
+    pub fn build_ref<T: TypeBuilder + ?Sized>(&self, type_builder: &T) -> (String, Vec<Value>) {
         let mut params = Vec::new();
         let mut collector = |v| params.push(v);
         let sql = self.build_collect_ref(type_builder, &mut collector);
         (sql, params)
     }
 
-    pub fn build_collect<T: TypeBuilder>(
+    pub fn build_collect<T: TypeBuilder + ?Sized>(
         &self,
-        type_builder: T,
+        type_builder: &T,
         collector: &mut dyn FnMut(Value),
     ) -> String {
-        self.build_collect_ref(&type_builder, collector)
+        self.build_collect_ref(type_builder, collector)
     }
 
-    pub fn build_collect_ref<T: TypeBuilder>(
+    pub fn build_collect_ref<T: TypeBuilder + ?Sized>(
         &self,
         type_builder: &T,
         collector: &mut dyn FnMut(Value),
@@ -260,7 +260,7 @@ impl TypeCreateStatement {
     }
 
     /// Build corresponding SQL statement and return SQL string
-    pub fn to_string<T: TypeBuilder>(&self, type_builder: &T) -> String {
+    pub fn to_string<T: TypeBuilder + ?Sized>(&self, type_builder: &T) -> String {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
     }
@@ -332,26 +332,26 @@ impl TypeDropStatement {
 
     // below are boiler plates
 
-    pub fn build<T: TypeBuilder>(&self, type_builder: T) -> (String, Vec<Value>) {
-        self.build_ref(&type_builder)
+    pub fn build<T: TypeBuilder + ?Sized>(&self, type_builder: &T) -> (String, Vec<Value>) {
+        self.build_ref(type_builder)
     }
 
-    pub fn build_ref<T: TypeBuilder>(&self, type_builder: &T) -> (String, Vec<Value>) {
+    pub fn build_ref<T: TypeBuilder + ?Sized>(&self, type_builder: &T) -> (String, Vec<Value>) {
         let mut params = Vec::new();
         let mut collector = |v| params.push(v);
         let sql = self.build_collect_ref(type_builder, &mut collector);
         (sql, params)
     }
 
-    pub fn build_collect<T: TypeBuilder>(
+    pub fn build_collect<T: TypeBuilder + ?Sized>(
         &self,
-        type_builder: T,
+        type_builder: &T,
         collector: &mut dyn FnMut(Value),
     ) -> String {
-        self.build_collect_ref(&type_builder, collector)
+        self.build_collect_ref(type_builder, collector)
     }
 
-    pub fn build_collect_ref<T: TypeBuilder>(
+    pub fn build_collect_ref<T: TypeBuilder + ?Sized>(
         &self,
         type_builder: &T,
         collector: &mut dyn FnMut(Value),
@@ -362,7 +362,7 @@ impl TypeDropStatement {
     }
 
     /// Build corresponding SQL statement and return SQL string
-    pub fn to_string<T: TypeBuilder>(&self, type_builder: &T) -> String {
+    pub fn to_string<T: TypeBuilder + ?Sized>(&self, type_builder: &T) -> String {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
     }
@@ -496,26 +496,26 @@ impl TypeAlterStatement {
 
     // below are boilerplate
 
-    pub fn build<T: TypeBuilder>(&self, type_builder: T) -> (String, Vec<Value>) {
-        self.build_ref(&type_builder)
+    pub fn build<T: TypeBuilder + ?Sized>(&self, type_builder: &T) -> (String, Vec<Value>) {
+        self.build_ref(type_builder)
     }
 
-    pub fn build_ref<T: TypeBuilder>(&self, type_builder: &T) -> (String, Vec<Value>) {
+    pub fn build_ref<T: TypeBuilder + ?Sized>(&self, type_builder: &T) -> (String, Vec<Value>) {
         let mut params = Vec::new();
         let mut collector = |v| params.push(v);
         let sql = self.build_collect_ref(type_builder, &mut collector);
         (sql, params)
     }
 
-    pub fn build_collect<T: TypeBuilder>(
+    pub fn build_collect<T: TypeBuilder + ?Sized>(
         &self,
-        type_builder: T,
+        type_builder: &T,
         collector: &mut dyn FnMut(Value),
     ) -> String {
-        self.build_collect_ref(&type_builder, collector)
+        self.build_collect_ref(type_builder, collector)
     }
 
-    pub fn build_collect_ref<T: TypeBuilder>(
+    pub fn build_collect_ref<T: TypeBuilder + ?Sized>(
         &self,
         type_builder: &T,
         collector: &mut dyn FnMut(Value),
@@ -526,7 +526,7 @@ impl TypeAlterStatement {
     }
 
     /// Build corresponding SQL statement and return SQL string
-    pub fn to_string<T: TypeBuilder>(&self, type_builder: &T) -> String {
+    pub fn to_string<T: TypeBuilder + ?Sized>(&self, type_builder: &T) -> String {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
     }

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -532,10 +532,7 @@ impl TypeAlterStatement {
     }
 
     /// Build corresponding SQL statement and return SQL string
-    pub fn to_string<T>(&self, type_builder: &T) -> String
-    where
-        T: TypeBuilder + QueryBuilder,
-    {
+    pub fn to_string<T: TypeBuilder>(&self, type_builder: &T) -> String {
         let (sql, values) = self.build_ref(type_builder);
         inject_parameters(&sql, values, type_builder)
     }

--- a/src/foreign_key/create.rs
+++ b/src/foreign_key/create.rs
@@ -19,7 +19,7 @@ use crate::{
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     foreign_key.to_string(MysqlQueryBuilder),
+///     foreign_key.to_string(&MysqlQueryBuilder),
 ///     vec![
 ///         r#"ALTER TABLE `character`"#,
 ///         r#"ADD CONSTRAINT `FK_character_font`"#,
@@ -29,7 +29,7 @@ use crate::{
 ///     .join(" ")
 /// );
 /// assert_eq!(
-///     foreign_key.to_string(PostgresQueryBuilder),
+///     foreign_key.to_string(&PostgresQueryBuilder),
 ///     vec![
 ///         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_font""#,
 ///         r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
@@ -52,7 +52,7 @@ use crate::{
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     foreign_key.to_string(MysqlQueryBuilder),
+///     foreign_key.to_string(&MysqlQueryBuilder),
 ///     vec![
 ///         r#"ALTER TABLE `character`"#,
 ///         r#"ADD CONSTRAINT `FK_character_glyph`"#,
@@ -62,7 +62,7 @@ use crate::{
 ///     .join(" ")
 /// );
 /// assert_eq!(
-///     foreign_key.to_string(PostgresQueryBuilder),
+///     foreign_key.to_string(&PostgresQueryBuilder),
 ///     vec![
 ///         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_glyph""#,
 ///         r#"FOREIGN KEY ("font_id", "id") REFERENCES "glyph" ("font_id", "id")"#,
@@ -212,7 +212,7 @@ impl ForeignKeyCreateStatement {
 }
 
 impl SchemaStatementBuilder for ForeignKeyCreateStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn build(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
         schema_builder.prepare_foreign_key_create_statement(self, &mut sql);
         sql.result()

--- a/src/foreign_key/drop.rs
+++ b/src/foreign_key/drop.rs
@@ -15,11 +15,11 @@ use crate::{
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     foreign_key.to_string(MysqlQueryBuilder),
+///     foreign_key.to_string(&MysqlQueryBuilder),
 ///     r#"ALTER TABLE `character` DROP FOREIGN KEY `FK_character_font`"#
 /// );
 /// assert_eq!(
-///     foreign_key.to_string(PostgresQueryBuilder),
+///     foreign_key.to_string(&PostgresQueryBuilder),
 ///     r#"ALTER TABLE "character" DROP CONSTRAINT "FK_character_font""#
 /// );
 /// // Sqlite does not support modification of foreign key constraints to existing tables
@@ -62,7 +62,7 @@ impl ForeignKeyDropStatement {
 }
 
 impl SchemaStatementBuilder for ForeignKeyDropStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn build(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
         schema_builder.prepare_foreign_key_drop_statement(self, &mut sql);
         sql.result()

--- a/src/func.rs
+++ b/src/func.rs
@@ -51,15 +51,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT MY_FUNCTION('hello')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT MY_FUNCTION('hello')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT MY_FUNCTION('hello')"#
     /// );
     /// ```
@@ -83,15 +83,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT MAX(`character`.`size_w`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT MAX("character"."size_w") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT MAX("character"."size_w") FROM "character""#
     /// );
     /// ```
@@ -115,15 +115,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT MIN(`character`.`size_h`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT MIN("character"."size_h") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT MIN("character"."size_h") FROM "character""#
     /// );
     /// ```
@@ -147,15 +147,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT SUM(`character`.`size_h`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT SUM("character"."size_h") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT SUM("character"."size_h") FROM "character""#
     /// );
     /// ```
@@ -179,15 +179,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT AVG(`character`.`size_h`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT AVG("character"."size_h") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT AVG("character"."size_h") FROM "character""#
     /// );
     /// ```
@@ -211,15 +211,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT ABS(`character`.`size_h`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT ABS("character"."size_h") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT ABS("character"."size_h") FROM "character""#
     /// );
     /// ```
@@ -243,15 +243,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT COUNT(`character`.`id`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT COUNT("character"."id") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT COUNT("character"."id") FROM "character""#
     /// );
     /// ```
@@ -275,15 +275,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT CHAR_LENGTH(`character`.`character`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT CHAR_LENGTH("character"."character") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT LENGTH("character"."character") FROM "character""#
     /// );
     /// ```
@@ -310,15 +310,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT IFNULL(`size_w`, `size_h`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT COALESCE("size_w", "size_h") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT IFNULL("size_w", "size_h") FROM "character""#
     /// );
     /// ```
@@ -342,15 +342,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT CAST('hello' AS MyType)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT CAST('hello' AS MyType)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT CAST('hello' AS MyType)"#
     /// );
     /// ```
@@ -382,15 +382,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT COALESCE(`size_w`, `size_h`, 12) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT COALESCE("size_w", "size_h", 12) FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT COALESCE("size_w", "size_h", 12) FROM "character""#
     /// );
     /// ```
@@ -416,15 +416,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT LOWER(`character`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT LOWER("character") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT LOWER("character") FROM "character""#
     /// );
     /// ```
@@ -449,15 +449,15 @@ impl Func {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT UPPER(`character`) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT UPPER("character") FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT UPPER("character") FROM "character""#
     /// );
     /// ```
@@ -479,15 +479,15 @@ impl Func {
     /// let query = Query::select().expr(Func::current_timestamp()).to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT CURRENT_TIMESTAMP"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT CURRENT_TIMESTAMP"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT CURRENT_TIMESTAMP"#
     /// );
     /// ```

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -15,15 +15,15 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     index.to_string(MysqlQueryBuilder),
+///     index.to_string(&MysqlQueryBuilder),
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(&PostgresQueryBuilder),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
 /// );
 /// assert_eq!(
-///     index.to_string(SqliteQueryBuilder),
+///     index.to_string(&SqliteQueryBuilder),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
 /// );
 /// ```
@@ -39,15 +39,15 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     index.to_string(MysqlQueryBuilder),
+///     index.to_string(&MysqlQueryBuilder),
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(&PostgresQueryBuilder),
 ///     r#"CREATE INDEX IF NOT EXISTS "idx-glyph-aspect" ON "glyph" ("aspect")"#
 /// );
 /// assert_eq!(
-///     index.to_string(SqliteQueryBuilder),
+///     index.to_string(&SqliteQueryBuilder),
 ///     r#"CREATE INDEX IF NOT EXISTS "idx-glyph-aspect" ON "glyph" ("aspect")"#
 /// );
 /// ```
@@ -62,15 +62,15 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     index.to_string(MysqlQueryBuilder),
+///     index.to_string(&MysqlQueryBuilder),
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect` (128))"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(&PostgresQueryBuilder),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect" (128))"#
 /// );
 /// assert_eq!(
-///     index.to_string(SqliteQueryBuilder),
+///     index.to_string(&SqliteQueryBuilder),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
 /// );
 /// ```
@@ -85,15 +85,15 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     index.to_string(MysqlQueryBuilder),
+///     index.to_string(&MysqlQueryBuilder),
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect` DESC)"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(&PostgresQueryBuilder),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect" DESC)"#
 /// );
 /// assert_eq!(
-///     index.to_string(SqliteQueryBuilder),
+///     index.to_string(&SqliteQueryBuilder),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect" DESC)"#
 /// );
 /// ```
@@ -108,15 +108,15 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     index.to_string(MysqlQueryBuilder),
+///     index.to_string(&MysqlQueryBuilder),
 ///     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect` (64) ASC)"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(&PostgresQueryBuilder),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect" (64) ASC)"#
 /// );
 /// assert_eq!(
-///     index.to_string(SqliteQueryBuilder),
+///     index.to_string(&SqliteQueryBuilder),
 ///     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect" ASC)"#
 /// );
 /// ```
@@ -238,7 +238,7 @@ impl IndexCreateStatement {
 }
 
 impl SchemaStatementBuilder for IndexCreateStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn build(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
         schema_builder.prepare_index_create_statement(self, &mut sql);
         sql.result()

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -13,15 +13,15 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     index.to_string(MysqlQueryBuilder),
+///     index.to_string(&MysqlQueryBuilder),
 ///     r#"DROP INDEX `idx-glyph-aspect` ON `glyph`"#
 /// );
 /// assert_eq!(
-///     index.to_string(PostgresQueryBuilder),
+///     index.to_string(&PostgresQueryBuilder),
 ///     r#"DROP INDEX "idx-glyph-aspect""#
 /// );
 /// assert_eq!(
-///     index.to_string(SqliteQueryBuilder),
+///     index.to_string(&SqliteQueryBuilder),
 ///     r#"DROP INDEX "idx-glyph-aspect" ON "glyph""#
 /// );
 /// ```
@@ -63,7 +63,7 @@ impl IndexDropStatement {
 }
 
 impl SchemaStatementBuilder for IndexDropStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn build(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
         schema_builder.prepare_index_drop_statement(self, &mut sql);
         sql.result()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //!         .from(Glyph::Table)
 //!         .and_where(Expr::col(Glyph::Image).like("A"))
 //!         .and_where(Expr::col(Glyph::Id).is_in(vec![1, 2, 3]))
-//!         .build(PostgresQueryBuilder),
+//!         .build(&PostgresQueryBuilder),
 //!     (
 //!         r#"SELECT "image" FROM "glyph" WHERE "image" LIKE $1 AND "id" IN ($2, $3, $4)"#
 //!             .to_owned(),
@@ -258,7 +258,7 @@
 //!                 .like("D")
 //!                 .and(Expr::col(Char::Character).like("E"))
 //!         )
-//!         .to_string(PostgresQueryBuilder),
+//!         .to_string(&PostgresQueryBuilder),
 //!     [
 //!         r#"SELECT "character" FROM "character""#,
 //!         r#"WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#,
@@ -293,7 +293,7 @@
 //!                         .add(Expr::col(Glyph::Image).like("A%"))
 //!                 )
 //!         )
-//!         .to_string(PostgresQueryBuilder),
+//!         .to_string(&PostgresQueryBuilder),
 //!     [
 //!         r#"SELECT "id" FROM "glyph""#,
 //!         r#"WHERE"#,
@@ -363,15 +363,15 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     query.to_string(MysqlQueryBuilder),
+//!     query.to_string(&MysqlQueryBuilder),
 //!     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` WHERE `size_w` IN (3, 4) AND `character` LIKE 'A%'"#
 //! );
 //! assert_eq!(
-//!     query.to_string(PostgresQueryBuilder),
+//!     query.to_string(&PostgresQueryBuilder),
 //!     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" WHERE "size_w" IN (3, 4) AND "character" LIKE 'A%'"#
 //! );
 //! assert_eq!(
-//!     query.to_string(SqliteQueryBuilder),
+//!     query.to_string(&SqliteQueryBuilder),
 //!     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" WHERE "size_w" IN (3, 4) AND "character" LIKE 'A%'"#
 //! );
 //! ```
@@ -388,15 +388,15 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     query.to_string(MysqlQueryBuilder),
+//!     query.to_string(&MysqlQueryBuilder),
 //!     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (5.15, '12A'), (4.21, '123')"#
 //! );
 //! assert_eq!(
-//!     query.to_string(PostgresQueryBuilder),
+//!     query.to_string(&PostgresQueryBuilder),
 //!     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (5.15, '12A'), (4.21, '123')"#
 //! );
 //! assert_eq!(
-//!     query.to_string(SqliteQueryBuilder),
+//!     query.to_string(&SqliteQueryBuilder),
 //!     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (5.15, '12A'), (4.21, '123')"#
 //! );
 //! ```
@@ -415,15 +415,15 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     query.to_string(MysqlQueryBuilder),
+//!     query.to_string(&MysqlQueryBuilder),
 //!     r#"UPDATE `glyph` SET `aspect` = 1.23, `image` = '123' WHERE `id` = 1"#
 //! );
 //! assert_eq!(
-//!     query.to_string(PostgresQueryBuilder),
+//!     query.to_string(&PostgresQueryBuilder),
 //!     r#"UPDATE "glyph" SET "aspect" = 1.23, "image" = '123' WHERE "id" = 1"#
 //! );
 //! assert_eq!(
-//!     query.to_string(SqliteQueryBuilder),
+//!     query.to_string(&SqliteQueryBuilder),
 //!     r#"UPDATE "glyph" SET "aspect" = 1.23, "image" = '123' WHERE "id" = 1"#
 //! );
 //! ```
@@ -442,15 +442,15 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     query.to_string(MysqlQueryBuilder),
+//!     query.to_string(&MysqlQueryBuilder),
 //!     r#"DELETE FROM `glyph` WHERE `id` < 1 OR `id` > 10"#
 //! );
 //! assert_eq!(
-//!     query.to_string(PostgresQueryBuilder),
+//!     query.to_string(&PostgresQueryBuilder),
 //!     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 //! );
 //! assert_eq!(
-//!     query.to_string(SqliteQueryBuilder),
+//!     query.to_string(&SqliteQueryBuilder),
 //!     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 //! );
 //! ```
@@ -479,7 +479,7 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     table.to_string(MysqlQueryBuilder),
+//!     table.to_string(&MysqlQueryBuilder),
 //!     vec![
 //!         r#"CREATE TABLE IF NOT EXISTS `character` ("#,
 //!             r#"`id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,"#,
@@ -495,7 +495,7 @@
 //!     ].join(" ")
 //! );
 //! assert_eq!(
-//!     table.to_string(PostgresQueryBuilder),
+//!     table.to_string(&PostgresQueryBuilder),
 //!     vec![
 //!         r#"CREATE TABLE IF NOT EXISTS "character" ("#,
 //!             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -511,7 +511,7 @@
 //!     ].join(" ")
 //! );
 //! assert_eq!(
-//!     table.to_string(SqliteQueryBuilder),
+//!     table.to_string(&SqliteQueryBuilder),
 //!     vec![
 //!        r#"CREATE TABLE IF NOT EXISTS "character" ("#,
 //!            r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
@@ -541,15 +541,15 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     table.to_string(MysqlQueryBuilder),
+//!     table.to_string(&MysqlQueryBuilder),
 //!     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
 //! );
 //! assert_eq!(
-//!     table.to_string(PostgresQueryBuilder),
+//!     table.to_string(&PostgresQueryBuilder),
 //!     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
 //! );
 //! assert_eq!(
-//!     table.to_string(SqliteQueryBuilder),
+//!     table.to_string(&SqliteQueryBuilder),
 //!     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#,
 //! );
 //! ```
@@ -564,15 +564,15 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     table.to_string(MysqlQueryBuilder),
+//!     table.to_string(&MysqlQueryBuilder),
 //!     r#"DROP TABLE `glyph`, `character`"#
 //! );
 //! assert_eq!(
-//!     table.to_string(PostgresQueryBuilder),
+//!     table.to_string(&PostgresQueryBuilder),
 //!     r#"DROP TABLE "glyph", "character""#
 //! );
 //! assert_eq!(
-//!     table.to_string(SqliteQueryBuilder),
+//!     table.to_string(&SqliteQueryBuilder),
 //!     r#"DROP TABLE "glyph", "character""#
 //! );
 //! ```
@@ -586,15 +586,15 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     table.to_string(MysqlQueryBuilder),
+//!     table.to_string(&MysqlQueryBuilder),
 //!     r#"RENAME TABLE `font` TO `font_new`"#
 //! );
 //! assert_eq!(
-//!     table.to_string(PostgresQueryBuilder),
+//!     table.to_string(&PostgresQueryBuilder),
 //!     r#"ALTER TABLE "font" RENAME TO "font_new""#
 //! );
 //! assert_eq!(
-//!     table.to_string(SqliteQueryBuilder),
+//!     table.to_string(&SqliteQueryBuilder),
 //!     r#"ALTER TABLE "font" RENAME TO "font_new""#
 //! );
 //! ```
@@ -606,15 +606,15 @@
 //! let table = Table::truncate().table(Font::Table).to_owned();
 //!
 //! assert_eq!(
-//!     table.to_string(MysqlQueryBuilder),
+//!     table.to_string(&MysqlQueryBuilder),
 //!     r#"TRUNCATE TABLE `font`"#
 //! );
 //! assert_eq!(
-//!     table.to_string(PostgresQueryBuilder),
+//!     table.to_string(&PostgresQueryBuilder),
 //!     r#"TRUNCATE TABLE "font""#
 //! );
 //! assert_eq!(
-//!     table.to_string(SqliteQueryBuilder),
+//!     table.to_string(&SqliteQueryBuilder),
 //!     r#"TRUNCATE TABLE "font""#
 //! );
 //! ```
@@ -632,7 +632,7 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     foreign_key.to_string(MysqlQueryBuilder),
+//!     foreign_key.to_string(&MysqlQueryBuilder),
 //!     vec![
 //!         r#"ALTER TABLE `character`"#,
 //!         r#"ADD CONSTRAINT `FK_character_font`"#,
@@ -642,7 +642,7 @@
 //!     .join(" ")
 //! );
 //! assert_eq!(
-//!     foreign_key.to_string(PostgresQueryBuilder),
+//!     foreign_key.to_string(&PostgresQueryBuilder),
 //!     vec![
 //!         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_font""#,
 //!         r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
@@ -663,11 +663,11 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     foreign_key.to_string(MysqlQueryBuilder),
+//!     foreign_key.to_string(&MysqlQueryBuilder),
 //!     r#"ALTER TABLE `character` DROP FOREIGN KEY `FK_character_font`"#
 //! );
 //! assert_eq!(
-//!     foreign_key.to_string(PostgresQueryBuilder),
+//!     foreign_key.to_string(&PostgresQueryBuilder),
 //!     r#"ALTER TABLE "character" DROP CONSTRAINT "FK_character_font""#
 //! );
 //! // Sqlite does not support modification of foreign key constraints to existing tables
@@ -684,15 +684,15 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     index.to_string(MysqlQueryBuilder),
+//!     index.to_string(&MysqlQueryBuilder),
 //!     r#"CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"#
 //! );
 //! assert_eq!(
-//!     index.to_string(PostgresQueryBuilder),
+//!     index.to_string(&PostgresQueryBuilder),
 //!     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
 //! );
 //! assert_eq!(
-//!     index.to_string(SqliteQueryBuilder),
+//!     index.to_string(&SqliteQueryBuilder),
 //!     r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
 //! );
 //! ```
@@ -707,15 +707,15 @@
 //!     .to_owned();
 //!
 //! assert_eq!(
-//!     index.to_string(MysqlQueryBuilder),
+//!     index.to_string(&MysqlQueryBuilder),
 //!     r#"DROP INDEX `idx-glyph-aspect` ON `glyph`"#
 //! );
 //! assert_eq!(
-//!     index.to_string(PostgresQueryBuilder),
+//!     index.to_string(&PostgresQueryBuilder),
 //!     r#"DROP INDEX "idx-glyph-aspect""#
 //! );
 //! assert_eq!(
-//!     index.to_string(SqliteQueryBuilder),
+//!     index.to_string(&SqliteQueryBuilder),
 //!     r#"DROP INDEX "idx-glyph-aspect" ON "glyph""#
 //! );
 //! ```

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -9,7 +9,11 @@ pub struct SqlWriter {
     pub(crate) string: String,
 }
 
-pub fn inject_parameters<I>(sql: &str, params: I, query_builder: &dyn QueryBuilder) -> String
+pub fn inject_parameters<I, T: QueryBuilder + ?Sized>(
+    sql: &str,
+    params: I,
+    query_builder: &T,
+) -> String
 where
     I: IntoIterator<Item = Value>,
 {

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -31,7 +31,7 @@ impl CaseStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT (CASE WHEN ("glyph"."aspect" IN (2, 4)) THEN TRUE ELSE FALSE END) AS "is_even" FROM "glyph""#
     /// );    
     /// ```
@@ -63,7 +63,7 @@ impl CaseStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT (CASE WHEN ("glyph"."aspect" > 0) THEN 'positive' WHEN ("glyph"."aspect" < 0) THEN 'negative' ELSE 'zero' END) AS "polarity" FROM "glyph""#
     /// );    
     /// ```
@@ -106,7 +106,7 @@ impl CaseStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     [
     ///         r#"SELECT"#,
     ///         r#"(CASE WHEN ("character"."font_size" > 48 OR "character"."size_w" > 500) THEN 'large'"#,

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -58,7 +58,7 @@ impl Condition {
     ///             .add(Expr::col(Glyph::Aspect).eq(0).into_condition().not())
     ///             .add(Expr::col(Glyph::Id).eq(0).into_condition().not()),
     ///     )
-    ///     .to_string(PostgresQueryBuilder);
+    ///     .to_string(&PostgresQueryBuilder);
     /// assert_eq!(
     ///     statement,
     ///     r#"SELECT "id" FROM "glyph" WHERE (NOT ("aspect" = 0)) AND (NOT ("id" = 0))"#
@@ -104,7 +104,7 @@ impl Condition {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `image` FROM `glyph` WHERE `glyph`.`image` LIKE 'A%'"#
     /// );
     /// ```
@@ -138,7 +138,7 @@ impl Condition {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4) OR `glyph`.`image` LIKE 'A%'"#
     /// );
     /// ```
@@ -168,7 +168,7 @@ impl Condition {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4) AND `glyph`.`image` LIKE 'A%'"#
     /// );
     /// ```
@@ -199,7 +199,7 @@ impl Condition {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `image` FROM `glyph` WHERE NOT (`glyph`.`aspect` IN (3, 4) AND `glyph`.`image` LIKE 'A%')"#
     /// );
     /// ```
@@ -224,7 +224,7 @@ impl Condition {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `id` WHERE (NOT (1 = 1 AND 2 = 2)) AND (3 = 3 OR 4 = 4)"#
     /// );
     /// ```
@@ -296,7 +296,7 @@ impl std::convert::From<SimpleExpr> for ConditionExpression {
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     query.to_string(MysqlQueryBuilder),
+///     query.to_string(&MysqlQueryBuilder),
 ///     r#"SELECT `image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4) OR `glyph`.`image` LIKE 'A%'"#
 /// );
 /// ```
@@ -332,7 +332,7 @@ macro_rules! any {
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     query.to_string(MysqlQueryBuilder),
+///     query.to_string(&MysqlQueryBuilder),
 ///     r#"SELECT `image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4) AND `glyph`.`image` LIKE 'A%'"#
 /// );
 #[macro_export]
@@ -365,7 +365,7 @@ pub trait ConditionalStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4) AND `glyph`.`image` LIKE 'A%'"#
     /// );
     /// ```
@@ -387,7 +387,7 @@ pub trait ConditionalStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `image` FROM `glyph` WHERE `aspect` IN (3, 4) AND `image` LIKE 'A%'"#
     /// );
     /// ```
@@ -435,7 +435,7 @@ pub trait ConditionalStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "image" FROM "glyph" WHERE "glyph"."aspect" IN (3, 4) AND ("glyph"."image" LIKE 'A%' OR "glyph"."image" LIKE 'B%')"#
     /// );
     /// ```
@@ -459,7 +459,7 @@ pub trait ConditionalStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "image" FROM "glyph" WHERE "glyph"."aspect" IN (3, 4) AND ("glyph"."image" LIKE 'A%' OR "glyph"."image" LIKE 'B%')"#
     /// );
     /// ```
@@ -474,7 +474,7 @@ pub trait ConditionalStatement {
     ///         .cond_where(Expr::col(Glyph::Id).eq(1))
     ///         .cond_where(any![Expr::col(Glyph::Id).eq(2), Expr::col(Glyph::Id).eq(3)])
     ///         .to_owned()
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"SELECT WHERE "id" = 1 AND ("id" = 2 OR "id" = 3)"#
     /// );
     ///
@@ -483,7 +483,7 @@ pub trait ConditionalStatement {
     ///         .cond_where(any![Expr::col(Glyph::Id).eq(2), Expr::col(Glyph::Id).eq(3)])
     ///         .cond_where(Expr::col(Glyph::Id).eq(1))
     ///         .to_owned()
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"SELECT WHERE ("id" = 2 OR "id" = 3) AND "id" = 1"#
     /// );
     /// ```
@@ -498,7 +498,7 @@ pub trait ConditionalStatement {
     ///         .cond_where(any![Expr::col(Glyph::Id).eq(1), Expr::col(Glyph::Id).eq(2)])
     ///         .cond_where(any![Expr::col(Glyph::Id).eq(3), Expr::col(Glyph::Id).eq(4)])
     ///         .to_owned()
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"SELECT WHERE ("id" = 1 OR "id" = 2) AND ("id" = 3 OR "id" = 4)"#
     /// );
     ///
@@ -507,7 +507,7 @@ pub trait ConditionalStatement {
     ///         .cond_where(all![Expr::col(Glyph::Id).eq(1), Expr::col(Glyph::Id).eq(2)])
     ///         .cond_where(all![Expr::col(Glyph::Id).eq(3), Expr::col(Glyph::Id).eq(4)])
     ///         .to_owned()
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"SELECT WHERE "id" = 1 AND "id" = 2 AND "id" = 3 AND "id" = 4"#
     /// );
     /// ```
@@ -531,7 +531,7 @@ pub trait ConditionalStatement {
     ///                 .add(Expr::col(Glyph::Id).eq(4)),
     ///         )
     ///         .to_owned()
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"SELECT WHERE (NOT ("id" = 1 AND "id" = 2)) AND ("id" = 3 AND "id" = 4)"#
     /// );
     ///
@@ -549,7 +549,7 @@ pub trait ConditionalStatement {
     ///                 .add(Expr::col(Glyph::Id).eq(2)),
     ///         )
     ///         .to_owned()
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     r#"SELECT WHERE "id" = 3 AND "id" = 4 AND (NOT ("id" = 1 AND "id" = 2))"#
     /// );
     /// ```
@@ -665,7 +665,7 @@ mod test {
             .to_owned();
 
         assert_eq!(
-            query.to_string(MysqlQueryBuilder),
+            query.to_string(&MysqlQueryBuilder),
             "SELECT `image` FROM `glyph` WHERE 1 = 1 AND 2 = 2 AND (3 = 3 OR 4 = 4)"
         );
     }

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -239,9 +239,9 @@ impl DeleteStatement {
 }
 
 impl QueryStatementBuilder for DeleteStatement {
-    fn build_collect_any_into(
+    fn build_collect_any_into<T: QueryBuilder + ?Sized>(
         &self,
-        query_builder: &dyn QueryBuilder,
+        query_builder: &T,
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     ) {

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -22,15 +22,15 @@ use crate::{
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     query.to_string(MysqlQueryBuilder),
+///     query.to_string(&MysqlQueryBuilder),
 ///     r#"DELETE FROM `glyph` WHERE `id` < 1 OR `id` > 10"#
 /// );
 /// assert_eq!(
-///     query.to_string(PostgresQueryBuilder),
+///     query.to_string(&PostgresQueryBuilder),
 ///     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 /// );
 /// assert_eq!(
-///     query.to_string(SqliteQueryBuilder),
+///     query.to_string(&SqliteQueryBuilder),
 ///     r#"DELETE FROM "glyph" WHERE "id" < 1 OR "id" > 10"#
 /// );
 /// ```
@@ -74,15 +74,15 @@ impl DeleteStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"DELETE FROM `glyph` WHERE `id` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1"#
     /// );
     /// ```
@@ -115,15 +115,15 @@ impl DeleteStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"DELETE FROM `glyph` WHERE `id` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id""#
     /// );
     /// ```
@@ -146,15 +146,15 @@ impl DeleteStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"DELETE FROM `glyph` WHERE `id` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id""#
     /// );
     /// ```
@@ -180,15 +180,15 @@ impl DeleteStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     "INSERT INTO `glyph` (`image`) VALUES ('12A')"
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('12A') RETURNING *"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('12A') RETURNING *"#
     /// );
     /// ```
@@ -221,15 +221,15 @@ impl DeleteStatement {
     ///     let query = update.with(with_clause);
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"WITH `cte` (`id`) AS (SELECT `id` FROM `glyph` WHERE `image` LIKE '0%') DELETE FROM `glyph` WHERE `id` IN (SELECT `id` FROM `cte`)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"WITH "cte" ("id") AS (SELECT "id" FROM "glyph" WHERE "image" LIKE '0%') DELETE FROM "glyph" WHERE "id" IN (SELECT "id" FROM "cte")"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"WITH "cte" ("id") AS (SELECT "id" FROM "glyph" WHERE "image" LIKE '0%') DELETE FROM "glyph" WHERE "id" IN (SELECT "id" FROM "cte")"#
     /// );
     /// ```
@@ -267,7 +267,7 @@ impl QueryStatementWriter for DeleteStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"DELETE FROM `glyph` WHERE `id` = 1"#
     /// );
     ///
@@ -275,14 +275,14 @@ impl QueryStatementWriter for DeleteStatement {
     /// let mut collector = |v| params.push(v);
     ///
     /// assert_eq!(
-    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
+    ///     query.build_collect(&MysqlQueryBuilder, &mut collector),
     ///     r#"DELETE FROM `glyph` WHERE `id` = ?"#
     /// );
     /// assert_eq!(params, vec![Value::Int(Some(1)),]);
     /// ```
-    fn build_collect<T: QueryBuilder>(
+    fn build_collect(
         &self,
-        query_builder: T,
+        query_builder: &dyn QueryBuilder,
         collector: &mut dyn FnMut(Value),
     ) -> String {
         let mut sql = SqlWriter::new();

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -29,15 +29,15 @@ pub(crate) enum InsertValueSource {
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     query.to_string(MysqlQueryBuilder),
+///     query.to_string(&MysqlQueryBuilder),
 ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (5.15, '12A'), (4.21, '123')"#
 /// );
 /// assert_eq!(
-///     query.to_string(PostgresQueryBuilder),
+///     query.to_string(&PostgresQueryBuilder),
 ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (5.15, '12A'), (4.21, '123')"#
 /// );
 /// assert_eq!(
-///     query.to_string(SqliteQueryBuilder),
+///     query.to_string(&SqliteQueryBuilder),
 ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (5.15, '12A'), (4.21, '123')"#
 /// );
 /// ```
@@ -73,11 +73,11 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"REPLACE INTO `glyph` (`aspect`, `image`) VALUES (5.15, '12A')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"REPLACE INTO "glyph" ("aspect", "image") VALUES (5.15, '12A')"#
     /// );
     /// ```
@@ -130,15 +130,15 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (2.1345, '24B'), (5.15, '12A')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2.1345, '24B'), (5.15, '12A')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2.1345, '24B'), (5.15, '12A')"#
     /// );
     /// ```
@@ -192,15 +192,15 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) SELECT `aspect`, `image` FROM `glyph` WHERE `image` LIKE '0%'"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") SELECT "aspect", "image" FROM "glyph" WHERE "image" LIKE '0%'"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") SELECT "aspect", "image" FROM "glyph" WHERE "image" LIKE '0%'"#
     /// );
     /// ```
@@ -239,15 +239,15 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (2, CAST('2020-02-02 00:00:00' AS DATE))"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2, CAST('2020-02-02 00:00:00' AS DATE))"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2, CAST('2020-02-02 00:00:00' AS DATE))"#
     /// );
     /// ```
@@ -321,15 +321,15 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     "INSERT INTO `glyph` (`image`) VALUES ('12A')"
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('12A') RETURNING "id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('12A') RETURNING "id""#
     /// );
     /// ```
@@ -353,15 +353,15 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     "INSERT INTO `glyph` (`image`) VALUES ('12A')"
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('12A') RETURNING "id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('12A') RETURNING "id""#
     /// );
     /// ```
@@ -387,15 +387,15 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     "INSERT INTO `glyph` (`image`) VALUES ('12A')"
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('12A') RETURNING *"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('12A') RETURNING *"#
     /// );
     /// ```
@@ -435,15 +435,15 @@ impl InsertStatement {
     ///     let query = insert.with(with_clause);
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"WITH `cte` (`id`, `image`, `aspect`) AS (SELECT `id`, `image`, `aspect` FROM `glyph`) INSERT INTO `glyph` (`id`, `image`, `aspect`) SELECT `id`, `image`, `aspect` FROM `cte`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"WITH "cte" ("id", "image", "aspect") AS (SELECT "id", "image", "aspect" FROM "glyph") INSERT INTO "glyph" ("id", "image", "aspect") SELECT "id", "image", "aspect" FROM "cte""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"WITH "cte" ("id", "image", "aspect") AS (SELECT "id", "image", "aspect" FROM "glyph") INSERT INTO "glyph" ("id", "image", "aspect") SELECT "id", "image", "aspect" FROM "cte""#
     /// );
     /// ```
@@ -465,15 +465,15 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` VALUES ()"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" VALUES (DEFAULT)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" DEFAULT VALUES"#
     /// );
     ///
@@ -486,15 +486,15 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`image`) VALUES ('ABC')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('ABC')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('ABC')"#
     /// );
     /// ```
@@ -517,15 +517,15 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` VALUES (), (), ()"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" VALUES (DEFAULT), (DEFAULT), (DEFAULT)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" DEFAULT VALUES"#
     /// );
     ///
@@ -538,15 +538,15 @@ impl InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`image`) VALUES ('ABC')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('ABC')"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('ABC')"#
     /// );
     /// ```
@@ -586,7 +586,7 @@ impl QueryStatementWriter for InsertStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (3.1415, '041080')"#
     /// );
     ///
@@ -594,7 +594,7 @@ impl QueryStatementWriter for InsertStatement {
     /// let mut collector = |v| params.push(v);
     ///
     /// assert_eq!(
-    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
+    ///     query.build_collect(&MysqlQueryBuilder, &mut collector),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (?, ?)"#
     /// );
     /// assert_eq!(
@@ -605,9 +605,9 @@ impl QueryStatementWriter for InsertStatement {
     ///     ]
     /// );
     /// ```
-    fn build_collect<T: QueryBuilder>(
+    fn build_collect(
         &self,
-        query_builder: T,
+        query_builder: &dyn QueryBuilder,
         collector: &mut dyn FnMut(Value),
     ) -> String {
         let mut sql = SqlWriter::new();

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -557,9 +557,9 @@ impl InsertStatement {
 }
 
 impl QueryStatementBuilder for InsertStatement {
-    fn build_collect_any_into(
+    fn build_collect_any_into<T: QueryBuilder + ?Sized>(
         &self,
-        query_builder: &dyn QueryBuilder,
+        query_builder: &T,
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     ) {

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -88,15 +88,15 @@ impl OnConflict {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (2, 3) ON DUPLICATE KEY UPDATE `aspect` = VALUES(`aspect`), `image` = VALUES(`image`)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2, 3) ON CONFLICT ("id") DO UPDATE SET "aspect" = "excluded"."aspect", "image" = "excluded"."image""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2, 3) ON CONFLICT ("id") DO UPDATE SET "aspect" = "excluded"."aspect", "image" = "excluded"."image""#
     /// );
     /// ```
@@ -144,15 +144,15 @@ impl OnConflict {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (2, 3) ON DUPLICATE KEY UPDATE `aspect` = '04108048005887010020060000204E0180400400', `image` = 3.1415"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2, 3) ON CONFLICT ("id") DO UPDATE SET "aspect" = '04108048005887010020060000204E0180400400', "image" = 3.1415"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2, 3) ON CONFLICT ("id") DO UPDATE SET "aspect" = '04108048005887010020060000204E0180400400', "image" = 3.1415"#
     /// );
     /// ```
@@ -200,15 +200,15 @@ impl OnConflict {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (2, 3) ON DUPLICATE KEY UPDATE `image` = 1 + 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2, 3) ON CONFLICT ("id") DO UPDATE SET "image" = 1 + 2"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2, 3) ON CONFLICT ("id") DO UPDATE SET "image" = 1 + 2"#
     /// );
     /// ```

--- a/src/query/ordered.rs
+++ b/src/query/ordered.rs
@@ -25,7 +25,7 @@ pub trait OrderedStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
     /// ```
@@ -44,7 +44,7 @@ pub trait OrderedStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     [
     ///         r#"SELECT `aspect`"#,
     ///         r#"FROM `glyph`"#,
@@ -59,7 +59,7 @@ pub trait OrderedStatement {
     /// );
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     [
     ///         r#"SELECT "aspect""#,
     ///         r#"FROM "glyph""#,
@@ -74,7 +74,7 @@ pub trait OrderedStatement {
     /// );
     ///
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     [
     ///         r#"SELECT "aspect""#,
     ///         r#"FROM "glyph""#,
@@ -181,11 +181,11 @@ pub trait OrderedStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "aspect" FROM "glyph" ORDER BY "image" DESC NULLS LAST, "glyph"."aspect" ASC NULLS FIRST"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `aspect` FROM `glyph` ORDER BY `image` IS NULL ASC, `image` DESC, `glyph`.`aspect` IS NULL DESC, `glyph`.`aspect` ASC"#
     /// );
     /// ```

--- a/src/query/returning.rs
+++ b/src/query/returning.rs
@@ -38,11 +38,11 @@ impl Returning {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING *"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING *"#
     /// );
     /// ```
@@ -64,11 +64,11 @@ impl Returning {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id""#
     /// );
     /// ```
@@ -93,11 +93,11 @@ impl Returning {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id", "image""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id", "image""#
     /// );
     /// ```
@@ -124,11 +124,11 @@ impl Returning {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id""#
     /// );
     /// ```
@@ -153,11 +153,11 @@ impl Returning {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id", "image""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id", "image""#
     /// );
     /// ```

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -26,15 +26,15 @@ use crate::{
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     query.to_string(MysqlQueryBuilder),
+///     query.to_string(&MysqlQueryBuilder),
 ///     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` WHERE `size_w` IN (3, 4) AND `character` LIKE 'A%'"#
 /// );
 /// assert_eq!(
-///     query.to_string(PostgresQueryBuilder),
+///     query.to_string(&PostgresQueryBuilder),
 ///     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" WHERE "size_w" IN (3, 4) AND "character" LIKE 'A%'"#
 /// );
 /// assert_eq!(
-///     query.to_string(SqliteQueryBuilder),
+///     query.to_string(&SqliteQueryBuilder),
 ///     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" WHERE "size_w" IN (3, 4) AND "character" LIKE 'A%'"#
 /// );
 /// ```
@@ -200,15 +200,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5"#
     /// );
     /// ```
@@ -246,15 +246,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT 42, MAX(`id`), 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT 42, MAX("id"), 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT 42, MAX("id"), 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 FROM "character""#
     /// );
     /// ```
@@ -282,15 +282,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT MAX(`id`), 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT MAX("id"), 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT MAX("id"), 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 FROM "character""#
     /// );
     /// ```
@@ -333,7 +333,7 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT DISTINCT ON ("character") "character", "size_w", "size_h" FROM "character""#
     /// )
     /// ```
@@ -351,7 +351,7 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character""#
     /// )
     /// ```
@@ -390,15 +390,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character""#
     /// );
     /// ```
@@ -412,15 +412,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`.`character` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character"."character" FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character"."character" FROM "character""#
     /// );
     /// ```
@@ -434,15 +434,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `schema`.`character`.`character` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "schema"."character"."character" FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "schema"."character"."character" FROM "character""#
     /// );
     /// ```
@@ -478,15 +478,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character""#
     /// );
     /// ```
@@ -504,15 +504,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`.`character`, `character`.`size_w`, `character`.`size_h` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character"."character", "character"."size_w", "character"."size_h" FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character"."character", "character"."size_w", "character"."size_h" FROM "character""#
     /// );
     /// ```
@@ -557,15 +557,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` AS `C` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" AS "C" FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" AS "C" FROM "character""#
     /// );
     /// ```
@@ -610,15 +610,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` OVER ( PARTITION BY `font_size` ) FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" OVER ( PARTITION BY "font_size" ) FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" OVER ( PARTITION BY "font_size" ) FROM "character""#
     /// );
     /// ```
@@ -651,15 +651,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` OVER ( PARTITION BY `font_size` ) AS `C` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" OVER ( PARTITION BY "font_size" ) AS "C" FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" OVER ( PARTITION BY "font_size" ) AS "C" FROM "character""#
     /// );
     /// ```
@@ -693,15 +693,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` OVER `w` FROM `character` WINDOW `w` AS PARTITION BY `font_size`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" OVER "w" FROM "character" WINDOW "w" AS PARTITION BY "font_size""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" OVER "w" FROM "character" WINDOW "w" AS PARTITION BY "font_size""#
     /// );
     /// ```
@@ -732,15 +732,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` OVER `w` AS `C` FROM `character` WINDOW `w` AS PARTITION BY `font_size`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" OVER "w" AS "C" FROM "character" WINDOW "w" AS PARTITION BY "font_size""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" OVER "w" AS "C" FROM "character" WINDOW "w" AS PARTITION BY "font_size""#
     /// );
     /// ```
@@ -771,15 +771,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `font_size` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "font_size" FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "font_size" FROM "character""#
     /// );
     /// ```
@@ -793,15 +793,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `font_size` FROM `character`.`glyph`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "font_size" FROM "character"."glyph""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "font_size" FROM "character"."glyph""#
     /// );
     /// ```
@@ -815,15 +815,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `font_size` FROM `database`.`character`.`glyph`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "font_size" FROM "database"."character"."glyph""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "font_size" FROM "database"."character"."glyph""#
     /// );
     /// ```
@@ -842,15 +842,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT * FROM `character`, `font` WHERE `font`.`id` = `character`.`font_id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT * FROM "character", "font" WHERE "font"."id" = "character"."font_id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT * FROM "character", "font" WHERE "font"."id" = "character"."font_id""#
     /// );
     /// ```
@@ -873,15 +873,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT * FROM (VALUES ROW(1, 'hello'), ROW(2, 'world')) AS `x`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT * FROM (VALUES (1, 'hello'), (2, 'world')) AS "x""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT * FROM (VALUES (1, 'hello'), (2, 'world')) AS "x""#
     /// );
     /// ```
@@ -916,15 +916,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `font_size` FROM `character`.`glyph`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "font_size" FROM "character"."glyph""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "font_size" FROM "character"."glyph""#
     /// );
     /// ```
@@ -951,15 +951,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `char`.`character` FROM `character` AS `char`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "char"."character" FROM "character" AS "char""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "char"."character" FROM "character" AS "char""#
     /// );
     /// ```
@@ -975,15 +975,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `alias`.`character` FROM `font`.`character` AS `alias`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "alias"."character" FROM "font"."character" AS "alias""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "alias"."character" FROM "font"."character" AS "alias""#
     /// );
     /// ```
@@ -1044,15 +1044,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `image` FROM (SELECT `image`, `aspect` FROM `glyph`) AS `subglyph`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "image" FROM (SELECT "image", "aspect" FROM "glyph") AS "subglyph""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "image" FROM (SELECT "image", "aspect" FROM "glyph") AS "subglyph""#
     /// );
     /// ```
@@ -1084,15 +1084,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` CROSS JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" CROSS JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" CROSS JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     ///
@@ -1111,15 +1111,15 @@ impl SelectStatement {
     ///         .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` CROSS JOIN `font` ON `character`.`font_id` = `font`.`id` AND `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" CROSS JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" CROSS JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     /// );
     /// ```
@@ -1146,15 +1146,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     ///
@@ -1173,15 +1173,15 @@ impl SelectStatement {
     ///         .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` AND `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     /// );
     /// ```
@@ -1208,15 +1208,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     ///
@@ -1235,15 +1235,15 @@ impl SelectStatement {
     ///         .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id` AND `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     /// );
     /// ```
@@ -1270,15 +1270,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" INNER JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" INNER JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     ///
@@ -1297,15 +1297,15 @@ impl SelectStatement {
     ///         .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id` AND `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" INNER JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" INNER JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     /// );
     /// ```
@@ -1332,15 +1332,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id""#
     /// );
     ///
@@ -1360,15 +1360,15 @@ impl SelectStatement {
     ///         .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id` AND `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     /// );
     /// ```
@@ -1407,15 +1407,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` AS `f` ON `character`.`font_id` = `font`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" AS "f" ON "character"."font_id" = "font"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" AS "f" ON "character"."font_id" = "font"."id""#
     /// );
     ///
@@ -1433,7 +1433,7 @@ impl SelectStatement {
     ///                 .add(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
     ///                 .add(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
     ///         )
-    ///         .to_string(MysqlQueryBuilder),
+    ///         .to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` AS `f` ON `character`.`font_id` = `font`.`id` AND `character`.`font_id` = `font`.`id`"#
     /// );
     /// ```
@@ -1479,15 +1479,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `name` FROM `font` LEFT JOIN (SELECT `id` FROM `glyph`) AS `sub_glyph` ON `font`.`id` = `sub_glyph`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "name" FROM "font" LEFT JOIN (SELECT "id" FROM "glyph") AS "sub_glyph" ON "font"."id" = "sub_glyph"."id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "name" FROM "font" LEFT JOIN (SELECT "id" FROM "glyph") AS "sub_glyph" ON "font"."id" = "sub_glyph"."id""#
     /// );
     ///
@@ -1504,7 +1504,7 @@ impl SelectStatement {
     ///                 .add(Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id))
     ///                 .add(Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id))
     ///         )
-    ///         .to_string(MysqlQueryBuilder),
+    ///         .to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `name` FROM `font` LEFT JOIN (SELECT `id` FROM `glyph`) AS `sub_glyph` ON `font`.`id` = `sub_glyph`.`id` AND `font`.`id` = `sub_glyph`.`id`"#
     /// );
     /// ```
@@ -1549,11 +1549,11 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `name` FROM `font` LEFT JOIN LATERAL (SELECT `id` FROM `glyph`) AS `sub_glyph` ON `font`.`id` = `sub_glyph`.`id`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "name" FROM "font" LEFT JOIN LATERAL (SELECT "id" FROM "glyph") AS "sub_glyph" ON "font"."id" = "sub_glyph"."id""#
     /// );
     ///
@@ -1570,7 +1570,7 @@ impl SelectStatement {
     ///                 .add(Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id))
     ///                 .add(Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id))
     ///         )
-    ///         .to_string(MysqlQueryBuilder),
+    ///         .to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `name` FROM `font` LEFT JOIN LATERAL (SELECT `id` FROM `glyph`) AS `sub_glyph` ON `font`.`id` = `sub_glyph`.`id` AND `font`.`id` = `sub_glyph`.`id`"#
     /// );
     /// ```
@@ -1629,15 +1629,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id` GROUP BY `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id" GROUP BY "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id" GROUP BY "character""#
     /// );
     /// ```
@@ -1656,15 +1656,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id` GROUP BY `character`.`character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id" GROUP BY "character"."character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id" GROUP BY "character"."character""#
     /// );
     /// ```
@@ -1694,15 +1694,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` ON `character`.`font_id` = `font`.`id` GROUP BY `character`.`character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id" GROUP BY "character"."character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character", "font"."name" FROM "character" RIGHT JOIN "font" ON "character"."font_id" = "font"."id" GROUP BY "character"."character""#
     /// );
     /// ```
@@ -1746,15 +1746,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` GROUP BY `size_w`, `size_h`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" GROUP BY "size_w", "size_h""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" GROUP BY "size_w", "size_h""#
     /// );
     /// ```
@@ -1792,7 +1792,7 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `glyph`.`aspect` IN (3, 4) AND (`glyph`.`image` LIKE 'A%' OR `glyph`.`image` LIKE 'B%')"#
     /// );
     /// ```
@@ -1823,15 +1823,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` > 2 AND `aspect` < 8"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2 AND "aspect" < 8"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2 AND "aspect" < 8"#
     /// );
     /// ```
@@ -1863,15 +1863,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` > 2 OR `aspect` < 8"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2 OR "aspect" < 8"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2 OR "aspect" < 8"#
     /// );
     /// ```
@@ -1894,15 +1894,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `aspect` FROM `glyph` LIMIT 10"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "aspect" FROM "glyph" LIMIT 10"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "aspect" FROM "glyph" LIMIT 10"#
     /// );
     /// ```
@@ -1932,15 +1932,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `aspect` FROM `glyph` LIMIT 10 OFFSET 10"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "aspect" FROM "glyph" LIMIT 10 OFFSET 10"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "aspect" FROM "glyph" LIMIT 10 OFFSET 10"#
     /// );
     /// ```
@@ -1970,15 +1970,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 FOR UPDATE"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 FOR UPDATE"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 "#
     /// );
     /// ```
@@ -2006,15 +2006,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 FOR UPDATE OF `glyph`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 FOR UPDATE OF "glyph""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 "#
     /// );
     /// ```
@@ -2046,15 +2046,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 FOR UPDATE NOWAIT"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 FOR UPDATE NOWAIT"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 "#
     /// );
     /// ```
@@ -2082,15 +2082,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 FOR UPDATE OF `glyph` NOWAIT"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 FOR UPDATE OF "glyph" NOWAIT"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 "#
     /// );
     /// ```
@@ -2127,15 +2127,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 FOR SHARE"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 FOR SHARE"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 "#
     /// );
     /// ```
@@ -2158,15 +2158,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 FOR UPDATE"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 FOR UPDATE"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 "#
     /// );
     /// ```
@@ -2194,15 +2194,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 UNION ALL SELECT `character` FROM `character` WHERE `font_id` = 4"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 UNION ALL SELECT "character" FROM "character" WHERE "font_id" = 4"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 UNION ALL SELECT "character" FROM "character" WHERE "font_id" = 4"#
     /// );
     /// ```
@@ -2237,15 +2237,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5 UNION ALL SELECT `character` FROM `character` WHERE `font_id` = 4 UNION SELECT `character` FROM `character` WHERE `font_id` = 3"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 UNION ALL SELECT "character" FROM "character" WHERE "font_id" = 4 UNION SELECT "character" FROM "character" WHERE "font_id" = 3"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 UNION ALL SELECT "character" FROM "character" WHERE "font_id" = 4 UNION SELECT "character" FROM "character" WHERE "font_id" = 3"#
     /// );
     /// ```
@@ -2307,15 +2307,15 @@ impl SelectStatement {
     /// let query = select.with(with_clause).to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"WITH RECURSIVE `cte_traversal` (`id`, `depth`, `next`, `value`) AS (SELECT `id`, 1, `next`, `value` FROM `table` UNION ALL SELECT `id`, `depth` + 1, `next`, `value` FROM `table` INNER JOIN `cte_traversal` ON `cte_traversal`.`next` = `table`.`id`) SELECT * FROM `cte_traversal`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"WITH RECURSIVE "cte_traversal" ("id", "depth", "next", "value") AS (SELECT "id", 1, "next", "value" FROM "table" UNION ALL SELECT "id", "depth" + 1, "next", "value" FROM "table" INNER JOIN "cte_traversal" ON "cte_traversal"."next" = "table"."id") CYCLE "id" SET "looped" USING "traversal_path" SELECT * FROM "cte_traversal""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"WITH RECURSIVE "cte_traversal" ("id", "depth", "next", "value") AS (SELECT "id", 1, "next", "value" FROM "table" UNION ALL SELECT "id", "depth" + 1, "next", "value" FROM "table" INNER JOIN "cte_traversal" ON "cte_traversal"."next" = "table"."id") SELECT * FROM "cte_traversal""#
     /// );
     /// ```
@@ -2337,15 +2337,15 @@ impl SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` OVER `w` AS `C` FROM `character` WINDOW `w` AS PARTITION BY `font_size`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" OVER "w" AS "C" FROM "character" WINDOW "w" AS PARTITION BY "font_size""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" OVER "w" AS "C" FROM "character" WINDOW "w" AS PARTITION BY "font_size""#
     /// );
     /// ```
@@ -2390,7 +2390,7 @@ impl QueryStatementWriter for SelectStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
     ///
@@ -2398,7 +2398,7 @@ impl QueryStatementWriter for SelectStatement {
     /// let mut collector = |v| params.push(v);
     ///
     /// assert_eq!(
-    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
+    ///     query.build_collect(&MysqlQueryBuilder, &mut collector),
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, ?) > ? ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
     /// assert_eq!(
@@ -2406,9 +2406,9 @@ impl QueryStatementWriter for SelectStatement {
     ///     vec![Value::Int(Some(0)), Value::Int(Some(2))]
     /// );
     /// ```
-    fn build_collect<T: QueryBuilder>(
+    fn build_collect(
         &self,
-        query_builder: T,
+        query_builder: &dyn QueryBuilder,
         collector: &mut dyn FnMut(Value),
     ) -> String {
         let mut sql = SqlWriter::new();

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -2359,9 +2359,9 @@ impl SelectStatement {
 }
 
 impl QueryStatementBuilder for SelectStatement {
-    fn build_collect_any_into(
+    fn build_collect_any_into<T: QueryBuilder + ?Sized>(
         &self,
-        query_builder: &dyn QueryBuilder,
+        query_builder: &T,
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     ) {

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 
 pub trait QueryStatementBuilder: Debug {
     /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
-    fn build_any(&self, query_builder: &dyn QueryBuilder) -> (String, Values) {
+    fn build_any<T: QueryBuilder + ?Sized>(&self, query_builder: &T) -> (String, Values) {
         let mut values = Vec::new();
         let mut collector = |v| values.push(v);
         let sql = self.build_collect_any(query_builder, &mut collector);
@@ -16,9 +16,9 @@ pub trait QueryStatementBuilder: Debug {
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters
-    fn build_collect_any(
+    fn build_collect_any<T: QueryBuilder + ?Sized>(
         &self,
-        query_builder: &dyn QueryBuilder,
+        query_builder: &T,
         collector: &mut dyn FnMut(Value),
     ) -> String {
         let mut sql = SqlWriter::new();
@@ -27,9 +27,9 @@ pub trait QueryStatementBuilder: Debug {
     }
 
     /// Build corresponding SQL statement into the SqlWriter for certain database backend and collect query parameters
-    fn build_collect_any_into(
+    fn build_collect_any_into<T: QueryBuilder + ?Sized>(
         &self,
-        query_builder: &dyn QueryBuilder,
+        query_builder: &T,
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     );
@@ -58,7 +58,7 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
     /// ```
-    fn to_string(&self, query_builder: &dyn QueryBuilder) -> String {
+    fn to_string<T: QueryBuilder + ?Sized>(&self, query_builder: &T) -> String {
         let (sql, values) = self.build_any(query_builder);
         inject_parameters(&sql, values.0, query_builder)
     }

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -368,9 +368,9 @@ impl UpdateStatement {
 }
 
 impl QueryStatementBuilder for UpdateStatement {
-    fn build_collect_any_into(
+    fn build_collect_any_into<T: QueryBuilder + ?Sized>(
         &self,
-        query_builder: &dyn QueryBuilder,
+        query_builder: &T,
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     ) {

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -26,15 +26,15 @@ use crate::{
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     query.to_string(MysqlQueryBuilder),
+///     query.to_string(&MysqlQueryBuilder),
 ///     r#"UPDATE `glyph` SET `aspect` = 1.23, `image` = '123' WHERE `id` = 1"#
 /// );
 /// assert_eq!(
-///     query.to_string(PostgresQueryBuilder),
+///     query.to_string(&PostgresQueryBuilder),
 ///     r#"UPDATE "glyph" SET "aspect" = 1.23, "image" = '123' WHERE "id" = 1"#
 /// );
 /// assert_eq!(
-///     query.to_string(SqliteQueryBuilder),
+///     query.to_string(&SqliteQueryBuilder),
 ///     r#"UPDATE "glyph" SET "aspect" = 1.23, "image" = '123' WHERE "id" = 1"#
 /// );
 /// ```
@@ -110,15 +110,15 @@ impl UpdateStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 60 * 24 * 24, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"UPDATE "glyph" SET "aspect" = 60 * 24 * 24, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"UPDATE "glyph" SET "aspect" = 60 * 24 * 24, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1"#
     /// );
     /// ```
@@ -155,15 +155,15 @@ impl UpdateStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '235m' WHERE "id" = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '235m' WHERE "id" = 1"#
     /// );
     /// ```
@@ -193,15 +193,15 @@ impl UpdateStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '235m' WHERE "id" = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '235m' WHERE "id" = 1"#
     /// );
     /// ```
@@ -240,15 +240,15 @@ impl UpdateStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '235m' WHERE "id" = 1 RETURNING "id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '235m' WHERE "id" = 1 RETURNING "id""#
     /// );
     /// ```
@@ -274,15 +274,15 @@ impl UpdateStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '235m' WHERE "id" = 1 RETURNING "id""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '235m' WHERE "id" = 1 RETURNING "id""#
     /// );
     /// ```
@@ -308,15 +308,15 @@ impl UpdateStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     "INSERT INTO `glyph` (`image`) VALUES ('12A')"
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('12A') RETURNING *"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"INSERT INTO "glyph" ("image") VALUES ('12A') RETURNING *"#
     /// );
     /// ```
@@ -350,15 +350,15 @@ impl UpdateStatement {
     ///     let query = update.with(with_clause);
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"WITH `cte` (`id`) AS (SELECT `id` FROM `glyph` WHERE `image` LIKE '0%') UPDATE `glyph` SET `aspect` = 60 * 24 * 24 WHERE `id` IN (SELECT `id` FROM `cte`)"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"WITH "cte" ("id") AS (SELECT "id" FROM "glyph" WHERE "image" LIKE '0%') UPDATE "glyph" SET "aspect" = 60 * 24 * 24 WHERE "id" IN (SELECT "id" FROM "cte")"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"WITH "cte" ("id") AS (SELECT "id" FROM "glyph" WHERE "image" LIKE '0%') UPDATE "glyph" SET "aspect" = 60 * 24 * 24 WHERE "id" IN (SELECT "id" FROM "cte")"#
     /// );
     /// ```
@@ -400,7 +400,7 @@ impl QueryStatementWriter for UpdateStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#
     /// );
     ///
@@ -408,7 +408,7 @@ impl QueryStatementWriter for UpdateStatement {
     /// let mut collector = |v| params.push(v);
     ///
     /// assert_eq!(
-    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
+    ///     query.build_collect(&MysqlQueryBuilder, &mut collector),
     ///     r#"UPDATE `glyph` SET `aspect` = ?, `image` = ? WHERE `id` = ?"#
     /// );
     /// assert_eq!(
@@ -420,9 +420,9 @@ impl QueryStatementWriter for UpdateStatement {
     ///     ]
     /// );
     /// ```
-    fn build_collect<T: QueryBuilder>(
+    fn build_collect(
         &self,
-        query_builder: T,
+        query_builder: &dyn QueryBuilder,
         collector: &mut dyn FnMut(Value),
     ) -> String {
         let mut sql = SqlWriter::new();

--- a/src/query/window.rs
+++ b/src/query/window.rs
@@ -156,15 +156,15 @@ impl WindowStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` OVER ( PARTITION BY `font_size` ROWS UNBOUNDED PRECEDING ) AS `C` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" OVER ( PARTITION BY "font_size" ROWS UNBOUNDED PRECEDING ) AS "C" FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" OVER ( PARTITION BY "font_size" ROWS UNBOUNDED PRECEDING ) AS "C" FROM "character""#
     /// );
     /// ```
@@ -190,15 +190,15 @@ impl WindowStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
+    ///     query.to_string(&MysqlQueryBuilder),
     ///     r#"SELECT `character` OVER ( PARTITION BY `font_size` ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING ) AS `C` FROM `character`"#
     /// );
     /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
+    ///     query.to_string(&PostgresQueryBuilder),
     ///     r#"SELECT "character" OVER ( PARTITION BY "font_size" ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING ) AS "C" FROM "character""#
     /// );
     /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
+    ///     query.to_string(&SqliteQueryBuilder),
     ///     r#"SELECT "character" OVER ( PARTITION BY "font_size" ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING ) AS "C" FROM "character""#
     /// );
     /// ```

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -426,15 +426,15 @@ impl Cycle {
 /// let query = select.with(with_clause).to_owned();
 ///
 /// assert_eq!(
-///     query.to_string(MysqlQueryBuilder),
+///     query.to_string(&MysqlQueryBuilder),
 ///     r#"WITH RECURSIVE `cte_traversal` (`id`, `depth`, `next`, `value`) AS (SELECT `id`, 1, `next`, `value` FROM `table` UNION ALL SELECT `id`, `depth` + 1, `next`, `value` FROM `table` INNER JOIN `cte_traversal` ON `cte_traversal`.`next` = `table`.`id`) SELECT * FROM `cte_traversal`"#
 /// );
 /// assert_eq!(
-///     query.to_string(PostgresQueryBuilder),
+///     query.to_string(&PostgresQueryBuilder),
 ///     r#"WITH RECURSIVE "cte_traversal" ("id", "depth", "next", "value") AS (SELECT "id", 1, "next", "value" FROM "table" UNION ALL SELECT "id", "depth" + 1, "next", "value" FROM "table" INNER JOIN "cte_traversal" ON "cte_traversal"."next" = "table"."id") CYCLE "id" SET "looped" USING "traversal_path" SELECT * FROM "cte_traversal""#
 /// );
 /// assert_eq!(
-///     query.to_string(SqliteQueryBuilder),
+///     query.to_string(&SqliteQueryBuilder),
 ///     r#"WITH RECURSIVE "cte_traversal" ("id", "depth", "next", "value") AS (SELECT "id", 1, "next", "value" FROM "table" UNION ALL SELECT "id", "depth" + 1, "next", "value" FROM "table" INNER JOIN "cte_traversal" ON "cte_traversal"."next" = "table"."id") SELECT * FROM "cte_traversal""#
 /// );
 /// ```
@@ -606,9 +606,9 @@ impl QueryStatementBuilder for WithQuery {
 }
 
 impl QueryStatementWriter for WithQuery {
-    fn build_collect<T: crate::QueryBuilder>(
+    fn build_collect(
         &self,
-        query_builder: T,
+        query_builder: &dyn QueryBuilder,
         collector: &mut dyn FnMut(Value),
     ) -> String {
         let mut sql = SqlWriter::new();

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -591,9 +591,9 @@ impl WithQuery {
 }
 
 impl QueryStatementBuilder for WithQuery {
-    fn build_collect_any_into(
+    fn build_collect_any_into<T: QueryBuilder + ?Sized>(
         &self,
-        query_builder: &dyn QueryBuilder,
+        query_builder: &T,
         sql: &mut SqlWriter,
         collector: &mut dyn FnMut(Value),
     ) {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -11,13 +11,13 @@ pub enum SchemaStatement {
 
 pub trait SchemaStatementBuilder {
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String;
+    fn build(&self, schema_builder: &dyn SchemaBuilder) -> String;
 
     /// Build corresponding SQL statement for certain database backend and return SQL string
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String;
 
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn to_string(&self, schema_builder: &dyn SchemaBuilder) -> String {
         self.build(schema_builder)
     }
 }

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -6,11 +6,11 @@ macro_rules! impl_schema_statement_builder {
             use $crate::{$struct_name, SchemaBuilder, SchemaStatementBuilder};
 
             impl $struct_name {
-                pub fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+                pub fn to_string(&self, schema_builder: &dyn SchemaBuilder) -> String {
                     <Self as SchemaStatementBuilder>::to_string(self, schema_builder)
                 }
 
-                pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+                pub fn build(&self, schema_builder: &dyn SchemaBuilder) -> String {
                     <Self as SchemaStatementBuilder>::build(self, schema_builder)
                 }
 
@@ -32,11 +32,11 @@ macro_rules! impl_query_statement_builder {
             };
 
             impl $struct_name {
-                pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
+                pub fn to_string(&self, query_builder: &dyn QueryBuilder) -> String {
                     <Self as QueryStatementWriter>::to_string(self, query_builder)
                 }
 
-                pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
+                pub fn build(&self, query_builder: &dyn QueryBuilder) -> (String, Values) {
                     <Self as QueryStatementWriter>::build(self, query_builder)
                 }
 

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -32,7 +32,7 @@ macro_rules! impl_query_statement_builder {
             };
 
             impl $struct_name {
-                pub fn to_string(&self, query_builder: &dyn QueryBuilder) -> String {
+                pub fn to_string<T: QueryBuilder + ?Sized>(&self, query_builder: &T) -> String {
                     <Self as QueryStatementWriter>::to_string(self, query_builder)
                 }
 
@@ -40,7 +40,10 @@ macro_rules! impl_query_statement_builder {
                     <Self as QueryStatementWriter>::build(self, query_builder)
                 }
 
-                pub fn build_any(&self, query_builder: &dyn QueryBuilder) -> (String, Values) {
+                pub fn build_any<T: QueryBuilder + ?Sized>(
+                    &self,
+                    query_builder: &T,
+                ) -> (String, Values) {
                     <Self as QueryStatementBuilder>::build_any(self, query_builder)
                 }
             }

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -21,15 +21,15 @@ use crate::{
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     table.to_string(MysqlQueryBuilder),
+///     table.to_string(&MysqlQueryBuilder),
 ///     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
 /// );
 /// assert_eq!(
-///     table.to_string(PostgresQueryBuilder),
+///     table.to_string(&PostgresQueryBuilder),
 ///     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
 /// );
 /// assert_eq!(
-///     table.to_string(SqliteQueryBuilder),
+///     table.to_string(&SqliteQueryBuilder),
 ///     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#,
 /// );
 /// ```
@@ -99,15 +99,15 @@ impl TableAlterStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     table.to_string(MysqlQueryBuilder),
+    ///     table.to_string(&MysqlQueryBuilder),
     ///     r#"ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(&PostgresQueryBuilder),
     ///     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(SqliteQueryBuilder),
+    ///     table.to_string(&SqliteQueryBuilder),
     ///     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#,
     /// );
     /// ```
@@ -138,15 +138,15 @@ impl TableAlterStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     table.to_string(MysqlQueryBuilder),
+    ///     table.to_string(&MysqlQueryBuilder),
     ///     r#"ALTER TABLE `font` ADD COLUMN IF NOT EXISTS `new_col` int NOT NULL DEFAULT 100"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(&PostgresQueryBuilder),
     ///     r#"ALTER TABLE "font" ADD COLUMN IF NOT EXISTS "new_col" integer NOT NULL DEFAULT 100"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(SqliteQueryBuilder),
+    ///     table.to_string(&SqliteQueryBuilder),
     ///     r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#,
     /// );
     /// ```
@@ -176,11 +176,11 @@ impl TableAlterStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     table.to_string(MysqlQueryBuilder),
+    ///     table.to_string(&MysqlQueryBuilder),
     ///     r#"ALTER TABLE `font` MODIFY COLUMN `new_col` bigint DEFAULT 999"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(&PostgresQueryBuilder),
     ///     vec![
     ///         r#"ALTER TABLE "font""#,
     ///         r#"ALTER COLUMN "new_col" TYPE bigint,"#,
@@ -207,15 +207,15 @@ impl TableAlterStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     table.to_string(MysqlQueryBuilder),
+    ///     table.to_string(&MysqlQueryBuilder),
     ///     r#"ALTER TABLE `font` RENAME COLUMN `new_col` TO `new_column`"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(&PostgresQueryBuilder),
     ///     r#"ALTER TABLE "font" RENAME COLUMN "new_col" TO "new_column""#
     /// );
     /// assert_eq!(
-    ///     table.to_string(SqliteQueryBuilder),
+    ///     table.to_string(&SqliteQueryBuilder),
     ///     r#"ALTER TABLE "font" RENAME COLUMN "new_col" TO "new_column""#
     /// );
     /// ```
@@ -243,11 +243,11 @@ impl TableAlterStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     table.to_string(MysqlQueryBuilder),
+    ///     table.to_string(&MysqlQueryBuilder),
     ///     r#"ALTER TABLE `font` DROP COLUMN `new_column`"#
     /// );
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(&PostgresQueryBuilder),
     ///     r#"ALTER TABLE "font" DROP COLUMN "new_column""#
     /// );
     /// // Sqlite not support modifying table column
@@ -295,7 +295,7 @@ impl TableAlterStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     table.to_string(MysqlQueryBuilder),
+    ///     table.to_string(&MysqlQueryBuilder),
     ///     vec![
     ///         r#"ALTER TABLE `character`"#,
     ///         r#"ADD CONSTRAINT `FK_character_glyph`"#,
@@ -309,7 +309,7 @@ impl TableAlterStatement {
     /// );
     ///
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(&PostgresQueryBuilder),
     ///     vec![
     ///         r#"ALTER TABLE "character""#,
     ///         r#"ADD CONSTRAINT "FK_character_glyph""#,
@@ -342,7 +342,7 @@ impl TableAlterStatement {
     ///     .to_owned();
     ///
     /// assert_eq!(
-    ///     table.to_string(MysqlQueryBuilder),
+    ///     table.to_string(&MysqlQueryBuilder),
     ///     vec![
     ///         r#"ALTER TABLE `character`"#,
     ///         r#"DROP FOREIGN KEY `FK_character_glyph`,"#,
@@ -352,7 +352,7 @@ impl TableAlterStatement {
     /// );
     ///
     /// assert_eq!(
-    ///     table.to_string(PostgresQueryBuilder),
+    ///     table.to_string(&PostgresQueryBuilder),
     ///     vec![
     ///         r#"ALTER TABLE "character""#,
     ///         r#"DROP CONSTRAINT "FK_character_glyph","#,
@@ -384,7 +384,7 @@ impl TableAlterStatement {
 }
 
 impl SchemaStatementBuilder for TableAlterStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn build(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
         schema_builder.prepare_table_alter_statement(self, &mut sql);
         sql.result()

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -376,7 +376,7 @@ impl ColumnDef {
     ///                 .interval(Some(PgInterval::Hour), Some(43))
     ///                 .not_null()
     ///         )
-    ///         .to_string(PostgresQueryBuilder),
+    ///         .to_string(&PostgresQueryBuilder),
     ///     vec![
     ///         r#"CREATE TABLE "glyph" ("#,
     ///         r#""I1" interval NOT NULL,"#,

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -30,7 +30,7 @@ use crate::{
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     table.to_string(MysqlQueryBuilder),
+///     table.to_string(&MysqlQueryBuilder),
 ///     vec![
 ///         r#"CREATE TABLE IF NOT EXISTS `character` ("#,
 ///             r#"`id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,"#,
@@ -46,7 +46,7 @@ use crate::{
 ///     ].join(" ")
 /// );
 /// assert_eq!(
-///     table.to_string(PostgresQueryBuilder),
+///     table.to_string(&PostgresQueryBuilder),
 ///     vec![
 ///         r#"CREATE TABLE IF NOT EXISTS "character" ("#,
 ///             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -62,7 +62,7 @@ use crate::{
 ///     ].join(" ")
 /// );
 /// assert_eq!(
-///     table.to_string(SqliteQueryBuilder),
+///     table.to_string(&SqliteQueryBuilder),
 ///     vec![
 ///        r#"CREATE TABLE IF NOT EXISTS "character" ("#,
 ///            r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
@@ -163,7 +163,7 @@ impl TableCreateStatement {
     ///         .table(Glyph::Table)
     ///         .col(ColumnDef::new(Glyph::Id).integer().not_null())
     ///         .index(Index::create().unique().name("idx-glyph-id").col(Glyph::Id))
-    ///         .to_string(MysqlQueryBuilder),
+    ///         .to_string(&MysqlQueryBuilder),
     ///     vec![
     ///         "CREATE TABLE `glyph` (",
     ///         "`id` int NOT NULL,",
@@ -192,7 +192,7 @@ impl TableCreateStatement {
     ///     .col(ColumnDef::new(Glyph::Image).string().not_null())
     ///     .primary_key(Index::create().col(Glyph::Id).col(Glyph::Image));
     /// assert_eq!(
-    ///     statement.to_string(MysqlQueryBuilder),
+    ///     statement.to_string(&MysqlQueryBuilder),
     ///     vec![
     ///         "CREATE TABLE `glyph` (",
     ///         "`id` int NOT NULL,",
@@ -203,7 +203,7 @@ impl TableCreateStatement {
     ///     .join(" ")
     /// );
     /// assert_eq!(
-    ///     statement.to_string(PostgresQueryBuilder),
+    ///     statement.to_string(&PostgresQueryBuilder),
     ///     vec![
     ///         "CREATE TABLE \"glyph\" (",
     ///         "\"id\" integer NOT NULL,",
@@ -214,7 +214,7 @@ impl TableCreateStatement {
     ///     .join(" ")
     /// );
     /// assert_eq!(
-    ///     statement.to_string(SqliteQueryBuilder),
+    ///     statement.to_string(&SqliteQueryBuilder),
     ///     vec![
     ///         r#"CREATE TABLE "glyph" ("#,
     ///         r#""id" integer NOT NULL,"#,
@@ -297,7 +297,7 @@ impl TableCreateStatement {
 }
 
 impl SchemaStatementBuilder for TableCreateStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn build(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
         schema_builder.prepare_table_create_statement(self, &mut sql);
         sql.result()

--- a/src/table/drop.rs
+++ b/src/table/drop.rs
@@ -13,15 +13,15 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     table.to_string(MysqlQueryBuilder),
+///     table.to_string(&MysqlQueryBuilder),
 ///     r#"DROP TABLE `glyph`, `character`"#
 /// );
 /// assert_eq!(
-///     table.to_string(PostgresQueryBuilder),
+///     table.to_string(&PostgresQueryBuilder),
 ///     r#"DROP TABLE "glyph", "character""#
 /// );
 /// assert_eq!(
-///     table.to_string(SqliteQueryBuilder),
+///     table.to_string(&SqliteQueryBuilder),
 ///     r#"DROP TABLE "glyph", "character""#
 /// );
 /// ```
@@ -92,7 +92,7 @@ impl TableDropStatement {
 }
 
 impl SchemaStatementBuilder for TableDropStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn build(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
         schema_builder.prepare_table_drop_statement(self, &mut sql);
         sql.result()

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -68,7 +68,7 @@ impl Table {
 
 impl TableStatement {
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn build<T: SchemaBuilder>(&self, table_builder: T) -> String {
+    pub fn build(&self, table_builder: &dyn SchemaBuilder) -> String {
         match self {
             Self::Create(stat) => stat.build(table_builder),
             Self::Alter(stat) => stat.build(table_builder),
@@ -90,7 +90,7 @@ impl TableStatement {
     }
 
     /// Build corresponding SQL statement for certain database backend and return SQL string
-    pub fn to_string<T: SchemaBuilder>(&self, table_builder: T) -> String {
+    pub fn to_string(&self, table_builder: &dyn SchemaBuilder) -> String {
         match self {
             Self::Create(stat) => stat.to_string(table_builder),
             Self::Alter(stat) => stat.to_string(table_builder),

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -12,15 +12,15 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 ///     .to_owned();
 ///
 /// assert_eq!(
-///     table.to_string(MysqlQueryBuilder),
+///     table.to_string(&MysqlQueryBuilder),
 ///     r#"RENAME TABLE `font` TO `font_new`"#
 /// );
 /// assert_eq!(
-///     table.to_string(PostgresQueryBuilder),
+///     table.to_string(&PostgresQueryBuilder),
 ///     r#"ALTER TABLE "font" RENAME TO "font_new""#
 /// );
 /// assert_eq!(
-///     table.to_string(SqliteQueryBuilder),
+///     table.to_string(&SqliteQueryBuilder),
 ///     r#"ALTER TABLE "font" RENAME TO "font_new""#
 /// );
 /// ```
@@ -65,7 +65,7 @@ impl TableRenameStatement {
 }
 
 impl SchemaStatementBuilder for TableRenameStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn build(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
         schema_builder.prepare_table_rename_statement(self, &mut sql);
         sql.result()

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -10,15 +10,15 @@ use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder
 /// let table = Table::truncate().table(Font::Table).to_owned();
 ///
 /// assert_eq!(
-///     table.to_string(MysqlQueryBuilder),
+///     table.to_string(&MysqlQueryBuilder),
 ///     r#"TRUNCATE TABLE `font`"#
 /// );
 /// assert_eq!(
-///     table.to_string(PostgresQueryBuilder),
+///     table.to_string(&PostgresQueryBuilder),
 ///     r#"TRUNCATE TABLE "font""#
 /// );
 /// assert_eq!(
-///     table.to_string(SqliteQueryBuilder),
+///     table.to_string(&SqliteQueryBuilder),
 ///     r#"TRUNCATE TABLE "font""#
 /// );
 /// ```
@@ -56,7 +56,7 @@ impl TableTruncateStatement {
 }
 
 impl SchemaStatementBuilder for TableTruncateStatement {
-    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn build(&self, schema_builder: &dyn SchemaBuilder) -> String {
         let mut sql = SqlWriter::new();
         schema_builder.prepare_table_truncate_statement(self, &mut sql);
         sql.result()

--- a/src/types.rs
+++ b/src/types.rs
@@ -471,7 +471,10 @@ mod tests {
         let query = Query::select().column(Alias::new("hel\"lo")).to_owned();
 
         #[cfg(feature = "backend-postgres")]
-        assert_eq!(query.to_string(&PostgresQueryBuilder), r#"SELECT "hel""lo""#);
+        assert_eq!(
+            query.to_string(&PostgresQueryBuilder),
+            r#"SELECT "hel""lo""#
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -444,17 +444,17 @@ mod tests {
 
         #[cfg(feature = "backend-mysql")]
         assert_eq!(
-            query.to_string(MysqlQueryBuilder),
+            query.to_string(&MysqlQueryBuilder),
             r#"SELECT `hello-World_`"#
         );
         #[cfg(feature = "backend-postgres")]
         assert_eq!(
-            query.to_string(PostgresQueryBuilder),
+            query.to_string(&PostgresQueryBuilder),
             r#"SELECT "hello-World_""#
         );
         #[cfg(feature = "backend-sqlite")]
         assert_eq!(
-            query.to_string(SqliteQueryBuilder),
+            query.to_string(&SqliteQueryBuilder),
             r#"SELECT "hello-World_""#
         );
     }
@@ -464,14 +464,14 @@ mod tests {
         let query = Query::select().column(Alias::new("hel`lo")).to_owned();
 
         #[cfg(feature = "backend-mysql")]
-        assert_eq!(query.to_string(MysqlQueryBuilder), r#"SELECT `hel``lo`"#);
+        assert_eq!(query.to_string(&MysqlQueryBuilder), r#"SELECT `hel``lo`"#);
         #[cfg(feature = "backend-sqlite")]
-        assert_eq!(query.to_string(SqliteQueryBuilder), r#"SELECT "hel`lo""#);
+        assert_eq!(query.to_string(&SqliteQueryBuilder), r#"SELECT "hel`lo""#);
 
         let query = Query::select().column(Alias::new("hel\"lo")).to_owned();
 
         #[cfg(feature = "backend-postgres")]
-        assert_eq!(query.to_string(PostgresQueryBuilder), r#"SELECT "hel""lo""#);
+        assert_eq!(query.to_string(&PostgresQueryBuilder), r#"SELECT "hel""lo""#);
     }
 
     #[test]
@@ -479,15 +479,15 @@ mod tests {
         let query = Query::select().column(Alias::new("hel``lo")).to_owned();
 
         #[cfg(feature = "backend-mysql")]
-        assert_eq!(query.to_string(MysqlQueryBuilder), r#"SELECT `hel````lo`"#);
+        assert_eq!(query.to_string(&MysqlQueryBuilder), r#"SELECT `hel````lo`"#);
         #[cfg(feature = "backend-sqlite")]
-        assert_eq!(query.to_string(SqliteQueryBuilder), r#"SELECT "hel``lo""#);
+        assert_eq!(query.to_string(&SqliteQueryBuilder), r#"SELECT "hel``lo""#);
 
         let query = Query::select().column(Alias::new("hel\"\"lo")).to_owned();
 
         #[cfg(feature = "backend-postgres")]
         assert_eq!(
-            query.to_string(PostgresQueryBuilder),
+            query.to_string(&PostgresQueryBuilder),
             r#"SELECT "hel""""lo""#
         );
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1529,15 +1529,15 @@ mod tests {
         let formatted = "2020-01-01 02:02:02 +08:00";
 
         assert_eq!(
-            query.to_string(MysqlQueryBuilder),
+            query.to_string(&MysqlQueryBuilder),
             format!("SELECT '{}'", formatted)
         );
         assert_eq!(
-            query.to_string(PostgresQueryBuilder),
+            query.to_string(&PostgresQueryBuilder),
             format!("SELECT '{}'", formatted)
         );
         assert_eq!(
-            query.to_string(SqliteQueryBuilder),
+            query.to_string(&SqliteQueryBuilder),
             format!("SELECT '{}'", formatted)
         );
     }
@@ -1596,15 +1596,15 @@ mod tests {
         let formatted = "2020-01-01 02:02:02 +0800";
 
         assert_eq!(
-            query.to_string(MysqlQueryBuilder),
+            query.to_string(&MysqlQueryBuilder),
             format!("SELECT '{}'", formatted)
         );
         assert_eq!(
-            query.to_string(PostgresQueryBuilder),
+            query.to_string(&PostgresQueryBuilder),
             format!("SELECT '{}'", formatted)
         );
         assert_eq!(
-            query.to_string(SqliteQueryBuilder),
+            query.to_string(&SqliteQueryBuilder),
             format!("SELECT '{}'", formatted)
         );
     }

--- a/tests/mysql/foreign_key.rs
+++ b/tests/mysql/foreign_key.rs
@@ -9,7 +9,7 @@ fn create_1() {
             .to(Font::Table, Font::Id)
             .on_delete(ForeignKeyAction::Cascade)
             .on_update(ForeignKeyAction::Cascade)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         vec![
             "ALTER TABLE `character`",
             "ADD CONSTRAINT `FK_2e303c3a712662f1fc2a4d0aad6`",
@@ -26,7 +26,7 @@ fn drop_1() {
         ForeignKey::drop()
             .name("FK_2e303c3a712662f1fc2a4d0aad6")
             .table(Char::Table)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "ALTER TABLE `character` DROP FOREIGN KEY `FK_2e303c3a712662f1fc2a4d0aad6`"
     );
 }

--- a/tests/mysql/index.rs
+++ b/tests/mysql/index.rs
@@ -7,7 +7,7 @@ fn create_1() {
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
             .col(Glyph::Aspect)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "CREATE INDEX `idx-glyph-aspect` ON `glyph` (`aspect`)"
     );
 }
@@ -21,7 +21,7 @@ fn create_2() {
             .table(Glyph::Table)
             .col(Glyph::Aspect)
             .col(Glyph::Image)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "CREATE UNIQUE INDEX `idx-glyph-aspect-image` ON `glyph` (`aspect`, `image`)"
     );
 }
@@ -34,7 +34,7 @@ fn create_3() {
             .name("idx-glyph-image")
             .table(Glyph::Table)
             .col(Glyph::Image)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "CREATE FULLTEXT INDEX `idx-glyph-image` ON `glyph` (`image`)"
     );
 }
@@ -47,7 +47,7 @@ fn create_4() {
             .name("idx-glyph-image")
             .table(Glyph::Table)
             .col(Glyph::Image)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "CREATE INDEX `idx-glyph-image` ON `glyph` (`image`) USING HASH"
     );
 }
@@ -58,7 +58,7 @@ fn drop_1() {
         Index::drop()
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "DROP INDEX `idx-glyph-aspect` ON `glyph`"
     );
 }

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -9,7 +9,7 @@ fn select_1() {
             .from(Char::Table)
             .limit(10)
             .offset(100)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character`, `size_w`, `size_h` FROM `character` LIMIT 10 OFFSET 100"
     );
 }
@@ -21,7 +21,7 @@ fn select_2() {
             .columns([Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
             .and_where(Expr::col(Char::SizeW).eq(3))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3"
     );
 }
@@ -36,7 +36,7 @@ fn select_3() {
             .from(Char::Table)
             .and_where(Expr::col(Char::SizeW).eq(3))
             .and_where(Expr::col(Char::SizeH).eq(4))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 AND `size_h` = 4"
     );
 }
@@ -53,7 +53,7 @@ fn select_4() {
                     .take(),
                 Alias::new("subglyph")
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `image` FROM (SELECT `image`, `aspect` FROM `glyph`) AS `subglyph`"
     );
 }
@@ -65,7 +65,7 @@ fn select_5() {
             .column((Glyph::Table, Glyph::Image))
             .from(Glyph::Table)
             .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `glyph`.`image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4)"
     );
 }
@@ -79,7 +79,7 @@ fn select_6() {
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
             .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` > 2"
     );
 }
@@ -91,7 +91,7 @@ fn select_7() {
             .columns([Glyph::Aspect,])
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2"
     );
 }
@@ -105,7 +105,7 @@ fn select_8() {
             ])
             .from(Char::Table)
             .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id`"
     );
 }
@@ -120,7 +120,7 @@ fn select_9() {
             .from(Char::Table)
             .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
             .inner_join(Glyph::Table, Expr::tbl(Char::Table, Char::Character).equals(Glyph::Table, Glyph::Image))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` INNER JOIN `glyph` ON `character`.`character` = `glyph`.`image`"
     );
 }
@@ -137,7 +137,7 @@ fn select_10() {
                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
                 .and(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON (`character`.`font_id` = `font`.`id`) AND (`character`.`font_id` = `font`.`id`)"
     );
 }
@@ -153,7 +153,7 @@ fn select_11() {
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by(Glyph::Image, Order::Desc)
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"
     );
 }
@@ -171,7 +171,7 @@ fn select_12() {
                 (Glyph::Id, Order::Asc),
                 (Glyph::Aspect, Order::Desc),
             ])
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `id` ASC, `aspect` DESC"
     );
 }
@@ -189,7 +189,7 @@ fn select_13() {
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
             ])
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `glyph`.`id` ASC, `glyph`.`aspect` DESC"
     );
 }
@@ -209,7 +209,7 @@ fn select_14() {
                 (Glyph::Table, Glyph::Aspect),
             ])
             .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `id`, `aspect`, MAX(`image`) FROM `glyph` GROUP BY `glyph`.`id`, `glyph`.`aspect` HAVING `aspect` > 2"
     );
 }
@@ -221,7 +221,7 @@ fn select_15() {
             .columns([Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE `font_id` IS NULL"
     );
 }
@@ -234,7 +234,7 @@ fn select_16() {
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
             .and_where(Expr::col(Char::Character).is_not_null())
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE `font_id` IS NULL AND `character` IS NOT NULL"
     );
 }
@@ -246,7 +246,7 @@ fn select_17() {
             .columns([(Glyph::Table, Glyph::Image),])
             .from(Glyph::Table)
             .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).between(3, 5))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `glyph`.`image` FROM `glyph` WHERE `glyph`.`aspect` BETWEEN 3 AND 5"
     );
 }
@@ -261,7 +261,7 @@ fn select_18() {
             .from(Glyph::Table)
             .and_where(Expr::col(Glyph::Aspect).between(3, 5))
             .and_where(Expr::col(Glyph::Aspect).not_between(8, 10))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `aspect` FROM `glyph` WHERE (`aspect` BETWEEN 3 AND 5) AND (`aspect` NOT BETWEEN 8 AND 10)"
     );
 }
@@ -273,7 +273,7 @@ fn select_19() {
             .columns([Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::Character).eq("A"))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE `character` = 'A'"
     );
 }
@@ -285,7 +285,7 @@ fn select_20() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where(Expr::col(Char::Character).like("A"))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE `character` LIKE 'A'"
     );
 }
@@ -301,7 +301,7 @@ fn select_21() {
             .or_where(Expr::col(Char::Character).like("A%"))
             .or_where(Expr::col(Char::Character).like("%B"))
             .or_where(Expr::col(Char::Character).like("%C%"))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE `character` LIKE 'A%' OR `character` LIKE '%B' OR `character` LIKE '%C%'"
     );
 }
@@ -323,7 +323,7 @@ fn select_22() {
                     Expr::col(Char::Character).like("F").or(Expr::col(Char::Character).like("G"))
                 )
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE (`character` LIKE 'C' OR ((`character` LIKE 'D') AND (`character` LIKE 'E'))) AND ((`character` LIKE 'F') OR (`character` LIKE 'G'))"
     );
 }
@@ -335,7 +335,7 @@ fn select_23() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where_option(None)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character`"
     );
 }
@@ -353,7 +353,7 @@ fn select_24() {
                 },
                 |_| ()
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE `font_id` = 5"
     );
 }
@@ -369,7 +369,7 @@ fn select_25() {
                     .mul(2)
                     .equals(Expr::col(Char::SizeH).div(2))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE `size_w` * 2 = `size_h` / 2"
     );
 }
@@ -385,7 +385,7 @@ fn select_26() {
                     .mul(2)
                     .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE (`size_w` + 1) * 2 = (`size_h` / 2) - 1"
     );
 }
@@ -401,7 +401,7 @@ fn select_27() {
             .and_where(Expr::col(Char::SizeW).eq(3))
             .and_where(Expr::col(Char::SizeH).eq(4))
             .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 AND `size_h` = 4 AND `size_h` = 5"
     );
 }
@@ -417,7 +417,7 @@ fn select_28() {
             .or_where(Expr::col(Char::SizeW).eq(3))
             .or_where(Expr::col(Char::SizeH).eq(4))
             .or_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 OR `size_h` = 4 OR `size_h` = 5"
     );
 }
@@ -434,7 +434,7 @@ fn select_29() {
             .and_where(Expr::col(Char::SizeW).eq(3))
             .or_where(Expr::col(Char::SizeH).eq(4))
             .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` = 3 OR `size_h` = 4 AND `size_h` = 5"
     );
 }
@@ -452,7 +452,7 @@ fn select_30() {
                     .add(Expr::col(Char::SizeH).div(3))
                     .equals(Expr::value(4))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE (`size_w` * 2) + (`size_h` / 3) = 4"
     );
 }
@@ -462,7 +462,7 @@ fn select_31() {
     assert_eq!(
         Query::select()
             .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(Expr::value(i)) }))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9"
     );
 }
@@ -473,7 +473,7 @@ fn select_32() {
         Query::select()
             .expr_as(Expr::col(Char::Character), Alias::new("C"))
             .from(Char::Table)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `character` AS `C` FROM `character`"
     );
 }
@@ -488,7 +488,7 @@ fn select_33() {
                 Expr::col(Glyph::Aspect)
                     .in_subquery(Query::select().expr(Expr::cust("3 + 2 * 2")).take())
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `image` FROM `glyph` WHERE `aspect` IN (SELECT 3 + 2 * 2)"
     );
 }
@@ -512,7 +512,7 @@ fn select_34a() {
                     .and(Expr::col(Glyph::Aspect).lt(18))
             )
             .or_having(Expr::col(Glyph::Aspect).gt(32))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         vec![
             "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect`",
             "HAVING ((`aspect` > 2) OR (`aspect` < 8))",
@@ -542,7 +542,7 @@ fn select_34b() {
                     .gt(22)
                     .or(Expr::col(Glyph::Aspect).lt(28))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         vec![
             "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect`",
             "HAVING ((`aspect` > 2) OR (`aspect` < 8))",
@@ -558,7 +558,7 @@ fn select_35() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .and_where(Expr::col(Glyph::Aspect).is_null())
-        .build(sea_query::MysqlQueryBuilder);
+        .build(&sea_query::MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -573,7 +573,7 @@ fn select_36() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Expr::col(Glyph::Aspect).is_null()))
-        .build(sea_query::MysqlQueryBuilder);
+        .build(&sea_query::MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -588,7 +588,7 @@ fn select_37() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
-        .build(sea_query::MysqlQueryBuilder);
+        .build(&sea_query::MysqlQueryBuilder);
 
     assert_eq!(statement, r#"SELECT `id` FROM `glyph`"#);
     assert_eq!(values.0, vec![]);
@@ -604,7 +604,7 @@ fn select_38() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::MysqlQueryBuilder);
+        .build(&sea_query::MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -623,7 +623,7 @@ fn select_39() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::MysqlQueryBuilder);
+        .build(&sea_query::MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -644,7 +644,7 @@ fn select_40() {
                 Expr::col(Glyph::Aspect).lt(8)
             ]
         ])
-        .to_string(sea_query::MysqlQueryBuilder);
+        .to_string(&sea_query::MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -661,7 +661,7 @@ fn select_41() {
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect])
             .cond_having(any![Expr::col(Glyph::Aspect).gt(2)])
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` > 2"
     );
 }
@@ -676,7 +676,7 @@ fn select_42() {
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -690,7 +690,7 @@ fn select_43() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::all().add_option::<SimpleExpr>(None))
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(statement, "SELECT `id` FROM `glyph`");
 }
@@ -705,7 +705,7 @@ fn select_44() {
                 .not()
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8))),
         )
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -724,7 +724,7 @@ fn select_45() {
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -742,7 +742,7 @@ fn select_46() {
                 .not()
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8))),
         )
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -761,7 +761,7 @@ fn select_47() {
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -783,7 +783,7 @@ fn select_48() {
                 .less_than(Expr::tuple([Expr::value(8), Expr::value(100)])),
             ))),
         )
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -805,7 +805,7 @@ fn select_48a() {
                 .in_tuples([(8, String::from("100"))]),
             ))),
         )
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -818,7 +818,7 @@ fn select_49() {
     let statement = sea_query::Query::select()
         .expr(Expr::asterisk())
         .from(Char::Table)
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(statement, r#"SELECT * FROM `character`"#);
 }
@@ -833,7 +833,7 @@ fn select_50() {
             Font::Table,
             Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
         )
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -854,7 +854,7 @@ fn select_51() {
                 Order::Asc,
                 NullOrdering::Last
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         [
             r#"SELECT `aspect`"#,
             r#"FROM `glyph`"#,
@@ -879,7 +879,7 @@ fn select_52() {
                 (Glyph::Id, Order::Asc, NullOrdering::First),
                 (Glyph::Aspect, Order::Desc, NullOrdering::Last),
             ])
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         [
             r#"SELECT `aspect`"#,
             r#"FROM `glyph`"#,
@@ -908,7 +908,7 @@ fn select_53() {
                     NullOrdering::Last
                 ),
             ])
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         [
             r#"SELECT `aspect`"#,
             r#"FROM `glyph`"#,
@@ -929,7 +929,7 @@ fn select_54() {
         .from(Char::Table)
         .from(Font::Table)
         .and_where(Expr::tbl(Font::Table, Font::Id).equals(Char::Table, Char::FontId))
-        .to_string(MysqlQueryBuilder);
+        .to_string(&MysqlQueryBuilder);
 
     assert_eq!(
         statement,
@@ -949,7 +949,7 @@ fn select_55() {
                 Order::Field(Values(vec![4.into(), 5.into(), 1.into(), 3.into(),]))
             )
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         [
             r#"SELECT `aspect`"#,
             r#"FROM `glyph`"#,
@@ -978,7 +978,7 @@ fn select_56() {
                 Glyph::Id,
                 Order::Field(Values(vec![4.into(), 5.into(), 1.into(), 3.into(),]))
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         [
             r#"SELECT `aspect`"#,
             r#"FROM `glyph`"#,
@@ -1014,7 +1014,7 @@ fn select_57() {
         .to_owned();
 
     assert_eq!(
-        query.to_string(MysqlQueryBuilder),
+        query.to_string(&MysqlQueryBuilder),
         r#"SELECT (CASE WHEN (`glyph`.`aspect` > 0) THEN 'positive' WHEN (`glyph`.`aspect` < 0) THEN 'negative' ELSE 'zero' END) AS `polarity` FROM `glyph`"#
     );
 }
@@ -1026,7 +1026,7 @@ fn select_58() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where(Expr::col(Char::Character).like(LikeExpr::str("A").escape('\\')))
-            .build(MysqlQueryBuilder),
+            .build(&MysqlQueryBuilder),
         (
             r#"SELECT `character` FROM `character` WHERE `character` LIKE ? ESCAPE '\\'"#
                 .to_owned(),
@@ -1049,7 +1049,7 @@ fn insert_2() {
                 "04108048005887010020060000204E0180400400".into(),
                 3.1415.into(),
             ])
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "INSERT INTO `glyph` (`image`, `aspect`) VALUES ('04108048005887010020060000204E0180400400', 3.1415)"
     );
 }
@@ -1072,7 +1072,7 @@ fn insert_3() {
                 Value::String(None),
                 2.1345.into(),
             ])
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "INSERT INTO `glyph` (`image`, `aspect`) VALUES ('04108048005887010020060000204E0180400400', 3.1415), (NULL, 2.1345)"
     );
 }
@@ -1085,7 +1085,7 @@ fn insert_4() {
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
             .values_panic(vec![chrono::NaiveDateTime::from_timestamp(0, 0).into()])
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "INSERT INTO `glyph` (`image`) VALUES ('1970-01-01 00:00:00')"
     );
 }
@@ -1101,7 +1101,7 @@ fn insert_8() {
             .values_panic(vec![date!(1970 - 01 - 01)
                 .with_time(time!(00:00:00))
                 .into()])
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "INSERT INTO `glyph` (`image`) VALUES ('1970-01-01 00:00:00')"
     );
 }
@@ -1114,7 +1114,7 @@ fn insert_5() {
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
             .values_panic(vec![uuid::Uuid::nil().into()])
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "INSERT INTO `glyph` (`image`) VALUES ('00000000-0000-0000-0000-000000000000')"
     );
 }
@@ -1125,7 +1125,7 @@ fn insert_6() {
         Query::insert()
             .into_table(Glyph::Table)
             .or_default_values()
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "INSERT INTO `glyph` VALUES ()"
     );
 }
@@ -1137,7 +1137,7 @@ fn insert_7() {
             .into_table(Glyph::Table)
             .or_default_values()
             .returning_col(Glyph::Id)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "INSERT INTO `glyph` VALUES ()"
     );
 }
@@ -1166,7 +1166,7 @@ fn insert_from_select() {
             )
             .unwrap()
             .to_owned()
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         r#"INSERT INTO `glyph` (`aspect`, `image`) SELECT `aspect`, `image` FROM `glyph` WHERE `image` LIKE '%'"#
     );
 }
@@ -1187,7 +1187,7 @@ fn insert_on_conflict_0() {
                     .update_columns([Glyph::Aspect, Glyph::Image])
                     .to_owned()
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1213,7 +1213,7 @@ fn insert_on_conflict_1() {
                     .update_column(Glyph::Aspect)
                     .to_owned()
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1239,7 +1239,7 @@ fn insert_on_conflict_2() {
                     .update_columns([Glyph::Aspect, Glyph::Image])
                     .to_owned()
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1268,7 +1268,7 @@ fn insert_on_conflict_3() {
                     ])
                     .to_owned()
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1294,7 +1294,7 @@ fn insert_on_conflict_4() {
                     .update_expr((Glyph::Image, Expr::val(1).add(2)))
                     .to_owned()
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1316,7 +1316,7 @@ fn update_1() {
             .and_where(Expr::col(Glyph::Id).eq(1))
             .order_by(Glyph::Id, Order::Asc)
             .limit(1)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "UPDATE `glyph` SET `aspect` = 2.1345, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1 ORDER BY `id` ASC LIMIT 1"
     );
 }
@@ -1333,7 +1333,7 @@ fn update_3() {
             .and_where(Expr::col(Glyph::Id).eq(1))
             .order_by(Glyph::Id, Order::Asc)
             .limit(1)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "UPDATE `glyph` SET `aspect` = 60 * 24 * 24, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1 ORDER BY `id` ASC LIMIT 1"
     );
 }
@@ -1350,7 +1350,7 @@ fn update_4() {
             .and_where(Expr::col(Glyph::Id).eq(1))
             .order_by(Glyph::Id, Order::Asc)
             .limit(1)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "UPDATE `glyph` SET `aspect` = `aspect` + 1, `image` = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE `id` = 1 ORDER BY `id` ASC LIMIT 1"
     );
 }
@@ -1363,7 +1363,7 @@ fn delete_1() {
             .and_where(Expr::col(Glyph::Id).eq(1))
             .order_by(Glyph::Id, Order::Asc)
             .limit(1)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "DELETE FROM `glyph` WHERE `id` = 1 ORDER BY `id` ASC LIMIT 1"
     );
 }

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -17,7 +17,7 @@ fn create_1() {
             .engine("InnoDB")
             .character_set("utf8mb4")
             .collate("utf8mb4_unicode_ci")
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         vec![
             "CREATE TABLE `glyph` (",
             "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
@@ -47,7 +47,7 @@ fn create_2() {
             .engine("InnoDB")
             .character_set("utf8mb4")
             .collate("utf8mb4_unicode_ci")
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         vec![
             "CREATE TABLE `font` (",
             "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
@@ -93,7 +93,7 @@ fn create_3() {
             .engine("InnoDB")
             .character_set("utf8mb4")
             .collate("utf8mb4_unicode_ci")
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         vec![
             "CREATE TABLE IF NOT EXISTS `character` (",
             "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
@@ -122,7 +122,7 @@ fn create_4() {
                     .not_null()
                     .extra("ANYTHING I WANT TO SAY".to_owned())
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         vec![
             "CREATE TABLE `glyph` (",
             "`id` int NOT NULL ANYTHING I WANT TO SAY",
@@ -139,7 +139,7 @@ fn create_5() {
             .table(Glyph::Table)
             .col(ColumnDef::new(Glyph::Id).integer().not_null())
             .index(Index::create().unique().name("idx-glyph-id").col(Glyph::Id))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         vec![
             "CREATE TABLE `glyph` (",
             "`id` int NOT NULL,",
@@ -162,7 +162,7 @@ fn create_6() {
             .col(ColumnDef::new(BinaryType::Blob).blob(BlobSize::Blob(None)))
             .col(ColumnDef::new(BinaryType::MediumBlob).blob(BlobSize::Medium))
             .col(ColumnDef::new(BinaryType::LongBlob).blob(BlobSize::Long))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         vec![
             "CREATE TABLE `binary_type` (",
             "`binlen` binary(32),",
@@ -185,7 +185,7 @@ fn create_7() {
             .col(ColumnDef::new(Char::Character).binary())
             .col(ColumnDef::new(Char::FontSize).binary_len(10))
             .col(ColumnDef::new(Char::SizeW).var_binary(10))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         vec![
             "CREATE TABLE `character` (",
             "`character` blob,",
@@ -204,7 +204,7 @@ fn drop_1() {
             .table(Glyph::Table)
             .table(Char::Table)
             .cascade()
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "DROP TABLE `glyph`, `character` CASCADE"
     );
 }
@@ -214,7 +214,7 @@ fn truncate_1() {
     assert_eq!(
         Table::truncate()
             .table(Font::Table)
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "TRUNCATE TABLE `font`"
     );
 }
@@ -230,7 +230,7 @@ fn alter_1() {
                     .not_null()
                     .default(100)
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"
     );
 }
@@ -245,7 +245,7 @@ fn alter_2() {
                     .big_integer()
                     .default(999)
             )
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "ALTER TABLE `font` MODIFY COLUMN `new_col` bigint DEFAULT 999"
     );
 }
@@ -256,7 +256,7 @@ fn alter_3() {
         Table::alter()
             .table(Font::Table)
             .rename_column(Alias::new("new_col"), Alias::new("new_column"))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "ALTER TABLE `font` RENAME COLUMN `new_col` TO `new_column`"
     );
 }
@@ -267,7 +267,7 @@ fn alter_4() {
         Table::alter()
             .table(Font::Table)
             .drop_column(Alias::new("new_column"))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "ALTER TABLE `font` DROP COLUMN `new_column`"
     );
 }
@@ -277,7 +277,7 @@ fn alter_5() {
     assert_eq!(
         Table::rename()
             .table(Font::Table, Alias::new("font_new"))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "RENAME TABLE `font` TO `font_new`"
     );
 }
@@ -285,7 +285,7 @@ fn alter_5() {
 #[test]
 #[should_panic(expected = "No alter option found")]
 fn alter_6() {
-    Table::alter().to_string(MysqlQueryBuilder);
+    Table::alter().to_string(&MysqlQueryBuilder);
 }
 
 #[test]
@@ -295,7 +295,7 @@ fn alter_7() {
             .table(Font::Table)
             .drop_column(Alias::new("new_column"))
             .rename_column(Font::Name, Alias::new("name_new"))
-            .to_string(MysqlQueryBuilder),
+            .to_string(&MysqlQueryBuilder),
         "ALTER TABLE `font` DROP COLUMN `new_column`, RENAME COLUMN `name` TO `name_new`"
     );
 }

--- a/tests/postgres/foreign_key.rs
+++ b/tests/postgres/foreign_key.rs
@@ -9,7 +9,7 @@ fn create_1() {
             .to(Font::Table, Font::Id)
             .on_delete(ForeignKeyAction::Cascade)
             .on_update(ForeignKeyAction::Cascade)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"ALTER TABLE "character" ADD CONSTRAINT "FK_2e303c3a712662f1fc2a4d0aad6""#,
             r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
@@ -28,7 +28,7 @@ fn create_2() {
             .to(Font::Table, Font::Id)
             .on_delete(ForeignKeyAction::Cascade)
             .on_update(ForeignKeyAction::Cascade)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"ALTER TABLE "schema"."character" ADD CONSTRAINT "FK_2e303c3a712662f1fc2a4d0aad6""#,
             r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
@@ -44,7 +44,7 @@ fn drop_1() {
         ForeignKey::drop()
             .name("FK_2e303c3a712662f1fc2a4d0aad6")
             .table(Char::Table)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TABLE "character" DROP CONSTRAINT "FK_2e303c3a712662f1fc2a4d0aad6""#
     );
 }
@@ -55,7 +55,7 @@ fn drop_2() {
         ForeignKey::drop()
             .name("FK_2e303c3a712662f1fc2a4d0aad6")
             .table((Alias::new("schema"), Char::Table))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TABLE "schema"."character" DROP CONSTRAINT "FK_2e303c3a712662f1fc2a4d0aad6""#
     );
 }

--- a/tests/postgres/index.rs
+++ b/tests/postgres/index.rs
@@ -7,7 +7,7 @@ fn create_1() {
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
             .col(Glyph::Aspect)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
     );
 }
@@ -21,7 +21,7 @@ fn create_2() {
             .table(Glyph::Table)
             .col(Glyph::Aspect)
             .col(Glyph::Image)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"CREATE UNIQUE INDEX "idx-glyph-aspect-image" ON "glyph" ("aspect", "image")"#
     );
 }
@@ -34,7 +34,7 @@ fn create_3() {
             .name("idx-glyph-image")
             .table(Glyph::Table)
             .col(Glyph::Image)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"CREATE INDEX "idx-glyph-image" ON "glyph" USING GIN ("image")"#
     );
 }
@@ -48,7 +48,7 @@ fn create_4() {
             .name("idx-glyph-image")
             .table(Glyph::Table)
             .col(Glyph::Image)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"CREATE INDEX IF NOT EXISTS "idx-glyph-image" ON "glyph" USING GIN ("image")"#
     );
 }
@@ -62,7 +62,7 @@ fn create_5() {
             .table((Alias::new("schema"), Glyph::Table))
             .col(Glyph::Aspect)
             .col(Glyph::Image)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"CREATE UNIQUE INDEX "idx-glyph-aspect-image" ON "schema"."glyph" ("aspect", "image")"#
     );
 }
@@ -72,7 +72,7 @@ fn drop_1() {
     assert_eq!(
         Index::drop()
             .name("idx-glyph-aspect")
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DROP INDEX "idx-glyph-aspect""#
     );
 }
@@ -83,7 +83,7 @@ fn drop_2() {
         Index::drop()
             .name("idx-glyph-aspect")
             .table((Alias::new("schema"), Glyph::Table))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DROP INDEX "schema"."idx-glyph-aspect""#
     );
 }
@@ -94,7 +94,7 @@ fn drop_3() {
         Index::drop()
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DROP INDEX "idx-glyph-aspect""#
     );
 }
@@ -105,5 +105,5 @@ fn drop_4() {
     Index::drop()
         .name("idx-glyph-aspect")
         .table((Alias::new("database"), Alias::new("schema"), Glyph::Table))
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 }

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -9,7 +9,7 @@ fn select_1() {
             .from(Char::Table)
             .limit(10)
             .offset(100)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" LIMIT 10 OFFSET 100"#
     );
 }
@@ -21,7 +21,7 @@ fn select_2() {
             .columns([Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
             .and_where(Expr::col(Char::SizeW).eq(3))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3"#
     );
 }
@@ -34,7 +34,7 @@ fn select_3() {
             .from(Char::Table)
             .and_where(Expr::col(Char::SizeW).eq(3))
             .and_where(Expr::col(Char::SizeH).eq(4))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 AND "size_h" = 4"#
     );
 }
@@ -51,7 +51,7 @@ fn select_4() {
                     .take(),
                 Alias::new("subglyph")
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "aspect" FROM (SELECT "image", "aspect" FROM "glyph") AS "subglyph""#
     );
 }
@@ -63,7 +63,7 @@ fn select_5() {
             .column((Glyph::Table, Glyph::Image))
             .from(Glyph::Table)
             .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "glyph"."image" FROM "glyph" WHERE "glyph"."aspect" IN (3, 4)"#
     );
 }
@@ -77,7 +77,7 @@ fn select_6() {
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
             .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2"#
     );
 }
@@ -89,7 +89,7 @@ fn select_7() {
             .columns([Glyph::Aspect,])
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2"#
     );
 }
@@ -104,7 +104,7 @@ fn select_8() {
                 Font::Table,
                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id""#
     );
 }
@@ -123,7 +123,7 @@ fn select_9() {
                 Glyph::Table,
                 Expr::tbl(Char::Table, Char::Character).equals(Glyph::Table, Glyph::Image)
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" INNER JOIN "glyph" ON "character"."character" = "glyph"."image""#
     );
 }
@@ -140,7 +140,7 @@ fn select_10() {
                     .equals(Font::Table, Font::Id)
                     .and(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON ("character"."font_id" = "font"."id") AND ("character"."font_id" = "font"."id")"#
     );
 }
@@ -154,7 +154,7 @@ fn select_11() {
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by(Glyph::Image, Order::Desc)
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2 ORDER BY "image" DESC, "glyph"."aspect" ASC"#
     );
 }
@@ -167,7 +167,7 @@ fn select_12() {
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by_columns(vec![(Glyph::Id, Order::Asc), (Glyph::Aspect, Order::Desc),])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2 ORDER BY "id" ASC, "aspect" DESC"#
     );
 }
@@ -183,7 +183,7 @@ fn select_13() {
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
             ])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2 ORDER BY "glyph"."id" ASC, "glyph"."aspect" DESC"#
     );
 }
@@ -200,7 +200,7 @@ fn select_14() {
                 (Glyph::Table, Glyph::Aspect),
             ])
             .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "id", "aspect", MAX("image") FROM "glyph" GROUP BY "glyph"."id", "glyph"."aspect" HAVING "aspect" > 2"#
     );
 }
@@ -212,7 +212,7 @@ fn select_15() {
             .columns([Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "font_id" IS NULL"#
     );
 }
@@ -225,7 +225,7 @@ fn select_16() {
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
             .and_where(Expr::col(Char::Character).is_not_null())
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "font_id" IS NULL AND "character" IS NOT NULL"#
     );
 }
@@ -237,7 +237,7 @@ fn select_17() {
             .columns([(Glyph::Table, Glyph::Image),])
             .from(Glyph::Table)
             .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).between(3, 5))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "glyph"."image" FROM "glyph" WHERE "glyph"."aspect" BETWEEN 3 AND 5"#
     );
 }
@@ -250,7 +250,7 @@ fn select_18() {
             .from(Glyph::Table)
             .and_where(Expr::col(Glyph::Aspect).between(3, 5))
             .and_where(Expr::col(Glyph::Aspect).not_between(8, 10))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE ("aspect" BETWEEN 3 AND 5) AND ("aspect" NOT BETWEEN 8 AND 10)"#
     );
 }
@@ -262,7 +262,7 @@ fn select_19() {
             .columns([Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::Character).eq("A"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "character" = 'A'"#
     );
 }
@@ -274,7 +274,7 @@ fn select_20() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where(Expr::col(Char::Character).like("A"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "character" LIKE 'A'"#
     );
 }
@@ -288,7 +288,7 @@ fn select_21() {
             .or_where(Expr::col(Char::Character).like("A%"))
             .or_where(Expr::col(Char::Character).like("%B"))
             .or_where(Expr::col(Char::Character).like("%C%"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "character" LIKE 'A%' OR "character" LIKE '%B' OR "character" LIKE '%C%'"#
     );
 }
@@ -314,7 +314,7 @@ fn select_22() {
                             .or(Expr::col(Char::Character).like("G"))
                     )
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR (("character" LIKE 'D') AND ("character" LIKE 'E'))) AND (("character" LIKE 'F') OR ("character" LIKE 'G'))"#
     );
 }
@@ -326,7 +326,7 @@ fn select_23() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where_option(None)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character""#
     );
 }
@@ -344,7 +344,7 @@ fn select_24() {
                 },
                 |_| ()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "font_id" = 5"#
     );
 }
@@ -360,7 +360,7 @@ fn select_25() {
                     .mul(2)
                     .equals(Expr::col(Char::SizeH).div(2))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "size_w" * 2 = "size_h" / 2"#
     );
 }
@@ -376,7 +376,7 @@ fn select_26() {
                     .mul(2)
                     .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#
     );
 }
@@ -390,7 +390,7 @@ fn select_27() {
             .and_where(Expr::col(Char::SizeW).eq(3))
             .and_where(Expr::col(Char::SizeH).eq(4))
             .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 AND "size_h" = 4 AND "size_h" = 5"#
     );
 }
@@ -404,7 +404,7 @@ fn select_28() {
             .or_where(Expr::col(Char::SizeW).eq(3))
             .or_where(Expr::col(Char::SizeH).eq(4))
             .or_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 OR "size_h" = 4 OR "size_h" = 5"#
     );
 }
@@ -419,7 +419,7 @@ fn select_29() {
             .and_where(Expr::col(Char::SizeW).eq(3))
             .or_where(Expr::col(Char::SizeH).eq(4))
             .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 OR "size_h" = 4 AND "size_h" = 5"#
     );
 }
@@ -436,7 +436,7 @@ fn select_30() {
                     .add(Expr::col(Char::SizeH).div(3))
                     .equals(Expr::value(4))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" * 2) + ("size_h" / 3) = 4"#
     );
 }
@@ -446,7 +446,7 @@ fn select_31() {
     assert_eq!(
         Query::select()
             .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(Expr::value(i)) }))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9"#
     );
 }
@@ -457,7 +457,7 @@ fn select_32() {
         Query::select()
             .expr_as(Expr::col(Char::Character), Alias::new("C"))
             .from(Char::Table)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "character" AS "C" FROM "character""#
     );
 }
@@ -472,7 +472,7 @@ fn select_33() {
                 Expr::col(Glyph::Aspect)
                     .in_subquery(Query::select().expr(Expr::cust("3 + 2 * 2")).take())
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "image" FROM "glyph" WHERE "aspect" IN (SELECT 3 + 2 * 2)"#
     );
 }
@@ -496,7 +496,7 @@ fn select_34a() {
                     .and(Expr::col(Glyph::Aspect).lt(18))
             )
             .or_having(Expr::col(Glyph::Aspect).gt(32))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect""#,
             r#"HAVING (("aspect" > 2) OR ("aspect" < 8))"#,
@@ -526,7 +526,7 @@ fn select_34b() {
                     .gt(22)
                     .or(Expr::col(Glyph::Aspect).lt(28))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect""#,
             r#"HAVING (("aspect" > 2) OR ("aspect" < 8))"#,
@@ -542,7 +542,7 @@ fn select_35() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .and_where(Expr::col(Glyph::Aspect).is_null())
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -557,7 +557,7 @@ fn select_36() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Expr::col(Glyph::Aspect).is_null()))
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -572,7 +572,7 @@ fn select_37() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     assert_eq!(statement, r#"SELECT "id" FROM "glyph""#);
     assert_eq!(values.0, vec![]);
@@ -588,7 +588,7 @@ fn select_38() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::PostgresQueryBuilder);
+        .build(&sea_query::PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -607,7 +607,7 @@ fn select_39() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::PostgresQueryBuilder);
+        .build(&sea_query::PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -628,7 +628,7 @@ fn select_40() {
                 Expr::col(Glyph::Aspect).lt(8)
             ]
         ])
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -645,7 +645,7 @@ fn select_41() {
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect])
             .cond_having(any![Expr::col(Glyph::Aspect).gt(2)])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2"#
     );
 }
@@ -660,7 +660,7 @@ fn select_42() {
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -674,7 +674,7 @@ fn select_43() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::all().add_option::<SimpleExpr>(None))
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(statement, r#"SELECT "id" FROM "glyph""#);
 }
@@ -689,7 +689,7 @@ fn select_44() {
                 .not()
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8))),
         )
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -708,7 +708,7 @@ fn select_45() {
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -726,7 +726,7 @@ fn select_46() {
                 .not()
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8))),
         )
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -745,7 +745,7 @@ fn select_47() {
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -767,7 +767,7 @@ fn select_48() {
                 .less_than(Expr::tuple([Expr::value(8), Expr::value(100)])),
             ))),
         )
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -789,7 +789,7 @@ fn select_48a() {
                 .in_tuples([(8, String::from("100"))]),
             ))),
         )
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -802,7 +802,7 @@ fn select_49() {
     let statement = Query::select()
         .expr(Expr::asterisk())
         .from(Char::Table)
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(statement, r#"SELECT * FROM "character""#);
 }
@@ -817,7 +817,7 @@ fn select_50() {
             Font::Table,
             Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
         )
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -838,7 +838,7 @@ fn select_51() {
                 Order::Asc,
                 NullOrdering::Last
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         [
             r#"SELECT "aspect""#,
             r#"FROM "glyph""#,
@@ -861,7 +861,7 @@ fn select_52() {
                 (Glyph::Id, Order::Asc, NullOrdering::First),
                 (Glyph::Aspect, Order::Desc, NullOrdering::Last),
             ])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         [
             r#"SELECT "aspect""#,
             r#"FROM "glyph""#,
@@ -888,7 +888,7 @@ fn select_53() {
                     NullOrdering::Last
                 ),
             ])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         [
             r#"SELECT "aspect""#,
             r#"FROM "glyph""#,
@@ -916,7 +916,7 @@ fn select_54() {
                     NullOrdering::Last
                 ),
             ])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         [
             r#"SELECT DISTINCT ON ("aspect") "aspect""#,
             r#"FROM "glyph""#,
@@ -935,7 +935,7 @@ fn select_55() {
         .from(Char::Table)
         .from(Font::Table)
         .and_where(Expr::tbl(Font::Table, Font::Id).equals(Char::Table, Char::FontId))
-        .to_string(PostgresQueryBuilder);
+        .to_string(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -960,7 +960,7 @@ fn select_56() {
                 ]))
             )
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         [
             r#"SELECT "aspect""#,
             r#"FROM "glyph""#,
@@ -994,7 +994,7 @@ fn select_57() {
                     Value::Int(Some(3))
                 ]))
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         [
             r#"SELECT "aspect""#,
             r#"FROM "glyph""#,
@@ -1026,7 +1026,7 @@ fn select_58() {
         .from(Alias::new("cte"))
         .to_owned();
     assert_eq!(
-        select.with(with_clause).to_string(PostgresQueryBuilder),
+        select.with(with_clause).to_string(&PostgresQueryBuilder),
         [
             r#"WITH "cte" AS"#,
             r#"(SELECT "id", "image", "aspect""#,
@@ -1057,7 +1057,7 @@ fn select_59() {
         .to_owned();
 
     assert_eq!(
-        query.to_string(PostgresQueryBuilder),
+        query.to_string(&PostgresQueryBuilder),
         r#"SELECT (CASE WHEN ("glyph"."aspect" > 0) THEN 'positive' WHEN ("glyph"."aspect" < 0) THEN 'negative' ELSE 'zero' END) AS "polarity" FROM "glyph""#
     );
 }
@@ -1068,12 +1068,12 @@ fn select_60() {
         .column(Character::Id)
         .from(Character::Table)
         .and_where(Expr::col(Character::FontSize).eq(3))
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     let (statement, values) = Query::select()
         .expr(Expr::cust_with_values(&cust_query[6..], cust_values.0))
         .limit(5)
-        .build(PostgresQueryBuilder);
+        .build(&PostgresQueryBuilder);
 
     assert_eq!(
         statement,
@@ -1089,7 +1089,7 @@ fn select_61() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where(Expr::col(Char::Character).like(LikeExpr::str("A").escape('\\')))
-            .build(PostgresQueryBuilder),
+            .build(&PostgresQueryBuilder),
         (
             r#"SELECT "character" FROM "character" WHERE "character" LIKE $1 ESCAPE E'\\'"#
                 .to_owned(),
@@ -1114,7 +1114,7 @@ fn select_62() {
         .from(Alias::new("cte"))
         .to_owned();
     assert_eq!(
-        select.with(with_clause).to_string(PostgresQueryBuilder),
+        select.with(with_clause).to_string(&PostgresQueryBuilder),
         [
             r#"WITH "cte" AS"#,
             r#"(SELECT * FROM (VALUES (1, 'hello'), (2, 'world')) AS "x")"#,
@@ -1136,7 +1136,7 @@ fn insert_2() {
                 "04108048005887010020060000204E0180400400".into(),
                 3.1415.into(),
             ])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#
     );
 }
@@ -1153,7 +1153,7 @@ fn insert_3() {
                 3.1415.into(),
             ])
             .values_panic(vec![Value::String(None), 2.1345.into(),])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415), (NULL, 2.1345)"#
     );
 }
@@ -1166,7 +1166,7 @@ fn insert_4() {
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
             .values_panic(vec![chrono::NaiveDateTime::from_timestamp(0, 0).into()])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         "INSERT INTO \"glyph\" (\"image\") VALUES ('1970-01-01 00:00:00')"
     );
 }
@@ -1182,7 +1182,7 @@ fn insert_9() {
             .values_panic(vec![date!(1970 - 01 - 01)
                 .with_time(time!(00:00:00))
                 .into()])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         "INSERT INTO \"glyph\" (\"image\") VALUES ('1970-01-01 00:00:00')"
     );
 }
@@ -1195,7 +1195,7 @@ fn insert_5() {
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
             .values_panic(vec![uuid::Uuid::nil().into()])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         "INSERT INTO \"glyph\" (\"image\") VALUES ('00000000-0000-0000-0000-000000000000')"
     );
 }
@@ -1225,7 +1225,7 @@ fn insert_from_select() {
             )
             .unwrap()
             .to_owned()
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"INSERT INTO "glyph" ("aspect", "image") SELECT "aspect", "image" FROM "glyph" WHERE "image" LIKE '%'"#
     );
 }
@@ -1253,7 +1253,7 @@ fn insert_6() -> sea_query::error::Result<()> {
         .into_table(Glyph::Table)
         .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
         .select_from(select)?;
-    let sql = insert.with(with_clause).to_string(PostgresQueryBuilder);
+    let sql = insert.with(with_clause).to_string(&PostgresQueryBuilder);
     assert_eq!(
         sql.as_str(),
         [
@@ -1270,7 +1270,7 @@ fn insert_7() {
         Query::insert()
             .into_table(Glyph::Table)
             .or_default_values()
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"INSERT INTO "glyph" VALUES (DEFAULT)"#
     );
 }
@@ -1282,7 +1282,7 @@ fn insert_8() {
             .into_table(Glyph::Table)
             .or_default_values()
             .returning_col(Glyph::Id)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"INSERT INTO "glyph" VALUES (DEFAULT) RETURNING "id""#
     );
 }
@@ -1303,7 +1303,7 @@ fn insert_on_conflict_1() {
                     .update_column(Glyph::Aspect)
                     .to_owned()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         [
             r#"INSERT INTO "glyph" ("aspect", "image")"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1329,7 +1329,7 @@ fn insert_on_conflict_2() {
                     .update_columns([Glyph::Aspect, Glyph::Image])
                     .to_owned()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         [
             r#"INSERT INTO "glyph" ("aspect", "image")"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1358,7 +1358,7 @@ fn insert_on_conflict_3() {
                     ])
                     .to_owned()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         [
             r#"INSERT INTO "glyph" ("aspect", "image")"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1384,7 +1384,7 @@ fn insert_on_conflict_4() {
                     .update_expr((Glyph::Image, Expr::val(1).add(2)))
                     .to_owned()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         [
             r#"INSERT INTO "glyph" ("aspect", "image")"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1406,7 +1406,7 @@ fn insert_returning_all_columns() {
                 3.1415.into(),
             ])
             .returning(Query::returning().all())
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415) RETURNING *"#
     );
 }
@@ -1423,7 +1423,7 @@ fn insert_returning_specific_columns() {
                 3.1415.into(),
             ])
             .returning(Query::returning().columns([Glyph::Id, Glyph::Image,]))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415) RETURNING "id", "image""#
     );
 }
@@ -1441,7 +1441,7 @@ fn update_1() {
                 ),
             ])
             .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1"#
     );
 }
@@ -1457,7 +1457,7 @@ fn update_3() {
                 "24B0E11951B03B07F8300FD003983F03F0780060".into()
             ),])
             .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = 60 * 24 * 24, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1"#
     );
 }
@@ -1475,7 +1475,7 @@ fn update_4() {
             .and_where(Expr::col(Glyph::Id).eq(1))
             .order_by(Glyph::Id, Order::Asc)
             .limit(1)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = "aspect" + 1, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1 ORDER BY "id" ASC LIMIT 1"#
     );
 }
@@ -1492,7 +1492,7 @@ fn update_returning_all_columns() {
             ),])
             .and_where(Expr::col(Glyph::Id).eq(1))
             .returning(Query::returning().all())
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = 60 * 24 * 24, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1 RETURNING *"#
     );
 }
@@ -1509,7 +1509,7 @@ fn update_returning_specified_columns() {
             ),])
             .and_where(Expr::col(Glyph::Id).eq(1))
             .returning(Query::returning().columns([Glyph::Id, Glyph::Image]))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = 60 * 24 * 24, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1 RETURNING "id", "image""#
     );
 }
@@ -1520,7 +1520,7 @@ fn delete_1() {
         Query::delete()
             .from_table(Glyph::Table)
             .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DELETE FROM "glyph" WHERE "id" = 1"#
     );
 }
@@ -1584,7 +1584,7 @@ fn delete_returning_all_columns() {
             .from_table(Glyph::Table)
             .and_where(Expr::col(Glyph::Id).eq(1))
             .returning(Query::returning().all())
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING *"#
     );
 }
@@ -1596,7 +1596,7 @@ fn delete_returning_specific_columns() {
             .from_table(Glyph::Table)
             .and_where(Expr::col(Glyph::Id).eq(1))
             .returning(Query::returning().columns([Glyph::Id, Glyph::Image]))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id", "image""#
     );
 }
@@ -1608,7 +1608,7 @@ fn delete_returning_specific_exprs() {
             .from_table(Glyph::Table)
             .and_where(Expr::col(Glyph::Id).eq(1))
             .returning(Query::returning().exprs([Expr::col(Glyph::Id), Expr::col(Glyph::Image)]))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id", "image""#
     );
 }

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -14,7 +14,7 @@ fn create_1() {
             )
             .col(ColumnDef::new(Glyph::Aspect).double().not_null())
             .col(ColumnDef::new(Glyph::Image).text())
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -41,7 +41,7 @@ fn create_2() {
             .col(ColumnDef::new(Font::Name).string().not_null())
             .col(ColumnDef::new(Font::Variant).string_len(255).not_null())
             .col(ColumnDef::new(Font::Language).string_len(255).not_null())
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "font" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -84,7 +84,7 @@ fn create_3() {
                     .on_delete(ForeignKeyAction::Cascade)
                     .on_update(ForeignKeyAction::Cascade)
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
@@ -108,7 +108,7 @@ fn create_4() {
         Table::create()
             .table(Glyph::Table)
             .col(ColumnDef::new(Glyph::Image).custom(Glyph::Aspect))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![r#"CREATE TABLE "glyph" ("#, r#""image" aspect"#, r#")"#,].join(" ")
     );
 }
@@ -120,7 +120,7 @@ fn create_5() {
             .table(Glyph::Table)
             .col(ColumnDef::new(Glyph::Image).json())
             .col(ColumnDef::new(Glyph::Aspect).json_binary())
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""image" json,"#,
@@ -142,7 +142,7 @@ fn create_6() {
                     .not_null()
                     .extra("ANYTHING I WANT TO SAY".to_owned())
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""id" integer NOT NULL ANYTHING I WANT TO SAY"#,
@@ -162,7 +162,7 @@ fn create_7() {
                     .interval(None, None)
                     .not_null()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""aspect" interval NOT NULL"#,
@@ -182,7 +182,7 @@ fn create_8() {
                     .interval(Some(PgInterval::YearToMonth), None)
                     .not_null()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""aspect" interval YEAR TO MONTH NOT NULL"#,
@@ -202,7 +202,7 @@ fn create_9() {
                     .interval(None, Some(42))
                     .not_null()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""aspect" interval(42) NOT NULL"#,
@@ -222,7 +222,7 @@ fn create_10() {
                     .interval(Some(PgInterval::Hour), Some(43))
                     .not_null()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""aspect" interval HOUR(43) NOT NULL"#,
@@ -242,7 +242,7 @@ fn create_11() {
                     .timestamp_with_time_zone_len(0)
                     .not_null()
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "character" ("#,
             r#""created_at" timestamp(0) with time zone NOT NULL"#,
@@ -264,7 +264,7 @@ fn create_12() {
             .col(ColumnDef::new(BinaryType::Blob).blob(BlobSize::Blob(None)))
             .col(ColumnDef::new(BinaryType::MediumBlob).blob(BlobSize::Medium))
             .col(ColumnDef::new(BinaryType::LongBlob).blob(BlobSize::Long))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "binary_type" ("#,
             r#""binlen" bytea,"#,
@@ -288,7 +288,7 @@ fn create_13() {
             .col(ColumnDef::new(Char::Character).binary())
             .col(ColumnDef::new(Char::FontSize).binary_len(10))
             .col(ColumnDef::new(Char::SizeW).var_binary(10))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "character" ("#,
             r#""character" bytea,"#,
@@ -306,7 +306,7 @@ fn create_14() {
         Table::create()
             .table((Alias::new("schema"), Glyph::Table))
             .col(ColumnDef::new(Glyph::Image).custom(Glyph::Aspect))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"CREATE TABLE "schema"."glyph" ("#,
             r#""image" aspect"#,
@@ -323,7 +323,7 @@ fn drop_1() {
             .table(Glyph::Table)
             .table(Char::Table)
             .cascade()
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DROP TABLE "glyph", "character" CASCADE"#
     );
 }
@@ -335,7 +335,7 @@ fn drop_2() {
             .table((Alias::new("schema1"), Glyph::Table))
             .table((Alias::new("schema2"), Char::Table))
             .cascade()
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DROP TABLE "schema1"."glyph", "schema2"."character" CASCADE"#
     );
 }
@@ -345,7 +345,7 @@ fn truncate_1() {
     assert_eq!(
         Table::truncate()
             .table(Font::Table)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"TRUNCATE TABLE "font""#
     );
 }
@@ -355,7 +355,7 @@ fn truncate_2() {
     assert_eq!(
         Table::truncate()
             .table((Alias::new("schema"), Font::Table))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"TRUNCATE TABLE "schema"."font""#
     );
 }
@@ -371,7 +371,7 @@ fn alter_1() {
                     .not_null()
                     .default(100)
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
     );
 }
@@ -386,7 +386,7 @@ fn alter_2() {
                     .big_integer()
                     .default(999)
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"ALTER TABLE "font""#,
             r#"ALTER COLUMN "new_col" TYPE bigint,"#,
@@ -402,7 +402,7 @@ fn alter_3() {
         Table::alter()
             .table(Font::Table)
             .rename_column(Alias::new("new_col"), Alias::new("new_column"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TABLE "font" RENAME COLUMN "new_col" TO "new_column""#
     );
 }
@@ -413,7 +413,7 @@ fn alter_4() {
         Table::alter()
             .table(Font::Table)
             .drop_column(Alias::new("new_column"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TABLE "font" DROP COLUMN "new_column""#
     );
 }
@@ -424,7 +424,7 @@ fn alter_5() {
         Table::alter()
             .table((Alias::new("schema"), Font::Table))
             .rename_column(Alias::new("new_col"), Alias::new("new_column"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TABLE "schema"."font" RENAME COLUMN "new_col" TO "new_column""#
     );
 }
@@ -432,7 +432,7 @@ fn alter_5() {
 #[test]
 #[should_panic(expected = "No alter option found")]
 fn alter_6() {
-    Table::alter().to_string(PostgresQueryBuilder);
+    Table::alter().to_string(&PostgresQueryBuilder);
 }
 
 #[test]
@@ -442,7 +442,7 @@ fn alter_7() {
             .table(Font::Table)
             .add_column(ColumnDef::new(Alias::new("new_col")).integer())
             .rename_column(Font::Name, Alias::new("name_new"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TABLE "font" ADD COLUMN "new_col" integer, RENAME COLUMN "name" TO "name_new""#
     );
 }
@@ -453,7 +453,7 @@ fn alter_8() {
         Table::alter()
             .table(Font::Table)
             .modify_column(ColumnDef::new(Font::Language).null())
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         vec![
             r#"ALTER TABLE "font""#,
             r#"ALTER COLUMN "language" DROP NOT NULL"#,
@@ -467,7 +467,7 @@ fn rename_1() {
     assert_eq!(
         Table::rename()
             .table(Font::Table, Alias::new("font_new"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TABLE "font" RENAME TO "font_new""#
     );
 }
@@ -480,7 +480,7 @@ fn rename_2() {
                 (Alias::new("schema"), Font::Table),
                 (Alias::new("schema"), Alias::new("font_new")),
             )
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TABLE "schema"."font" RENAME TO "schema"."font_new""#
     );
 }

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -8,7 +8,7 @@ fn create_1() {
         Type::create()
             .as_enum(Font::Table)
             .values(vec![Font::Name, Font::Variant, Font::Language])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"CREATE TYPE "font" AS ENUM ('name', 'variant', 'language')"#
     );
 }
@@ -19,7 +19,7 @@ fn create_2() {
         Type::create()
             .as_enum((Alias::new("schema"), Font::Table))
             .values(vec![Font::Name, Font::Variant, Font::Language])
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"CREATE TYPE "schema"."font" AS ENUM ('name', 'variant', 'language')"#
     );
 }
@@ -31,7 +31,7 @@ fn drop_1() {
             .if_exists()
             .name(Font::Table)
             .restrict()
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DROP TYPE IF EXISTS "font" RESTRICT"#
     )
 }
@@ -41,7 +41,7 @@ fn drop_2() {
     assert_eq!(
         Type::drop()
             .name(Font::Table)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DROP TYPE "font""#
     );
 }
@@ -53,7 +53,7 @@ fn drop_3() {
             .if_exists()
             .name(Font::Table)
             .cascade()
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DROP TYPE IF EXISTS "font" CASCADE"#
     );
 }
@@ -63,7 +63,7 @@ fn drop_4() {
     assert_eq!(
         Type::drop()
             .name((Alias::new("schema"), Font::Table))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"DROP TYPE "schema"."font""#
     );
 }
@@ -74,7 +74,7 @@ fn alter_1() {
         Type::alter()
             .name(Font::Table)
             .add_value(Alias::new("weight"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TYPE "font" ADD VALUE 'weight'"#
     )
 }
@@ -85,7 +85,7 @@ fn alter_2() {
             .name(Font::Table)
             .add_value(Alias::new("weight"))
             .before(Font::Variant)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TYPE "font" ADD VALUE 'weight' BEFORE 'variant'"#
     )
 }
@@ -97,7 +97,7 @@ fn alter_3() {
             .name(Font::Table)
             .add_value(Alias::new("weight"))
             .after(Font::Variant)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TYPE "font" ADD VALUE 'weight' AFTER 'variant'"#
     )
 }
@@ -108,7 +108,7 @@ fn alter_4() {
         Type::alter()
             .name(Font::Table)
             .rename_to(Alias::new("typeface"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TYPE "font" RENAME TO 'typeface'"#
     )
 }
@@ -119,7 +119,7 @@ fn alter_5() {
         Type::alter()
             .name(Font::Table)
             .rename_value(Font::Variant, Font::Language)
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TYPE "font" RENAME VALUE 'variant' TO 'language'"#
     )
 }
@@ -130,7 +130,7 @@ fn alter_6() {
         Type::alter()
             .name((Alias::new("schema"), Font::Table))
             .rename_to(Alias::new("typeface"))
-            .to_string(PostgresQueryBuilder),
+            .to_string(&PostgresQueryBuilder),
         r#"ALTER TYPE "schema"."font" RENAME TO 'typeface'"#
     )
 }

--- a/tests/sqlite/index.rs
+++ b/tests/sqlite/index.rs
@@ -7,7 +7,7 @@ fn create_1() {
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
             .col(Glyph::Aspect)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"CREATE INDEX "idx-glyph-aspect" ON "glyph" ("aspect")"#
     );
 }
@@ -21,7 +21,7 @@ fn create_2() {
             .table(Glyph::Table)
             .col(Glyph::Aspect)
             .col(Glyph::Image)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"CREATE UNIQUE INDEX "idx-glyph-aspect-image" ON "glyph" ("aspect", "image")"#
     );
 }
@@ -36,7 +36,7 @@ fn create_3() {
             .table(Glyph::Table)
             .col(Glyph::Aspect)
             .col(Glyph::Image)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"CREATE UNIQUE INDEX IF NOT EXISTS "idx-glyph-aspect-image" ON "glyph" ("aspect", "image")"#
     );
 }
@@ -47,7 +47,7 @@ fn drop_1() {
         Index::drop()
             .name("idx-glyph-aspect")
             .table(Glyph::Table)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"DROP INDEX "idx-glyph-aspect" ON "glyph""#
     );
 }

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -9,7 +9,7 @@ fn select_1() {
             .from(Char::Table)
             .limit(10)
             .offset(100)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" LIMIT 10 OFFSET 100"#
     );
 }
@@ -21,7 +21,7 @@ fn select_2() {
             .columns([Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
             .and_where(Expr::col(Char::SizeW).eq(3))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3"#
     );
 }
@@ -34,7 +34,7 @@ fn select_3() {
             .from(Char::Table)
             .and_where(Expr::col(Char::SizeW).eq(3))
             .and_where(Expr::col(Char::SizeH).eq(4))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 AND "size_h" = 4"#
     );
 }
@@ -51,7 +51,7 @@ fn select_4() {
                     .take(),
                 Alias::new("subglyph")
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "image" FROM (SELECT "image", "aspect" FROM "glyph") AS "subglyph""#
     );
 }
@@ -63,7 +63,7 @@ fn select_5() {
             .column((Glyph::Table, Glyph::Image))
             .from(Glyph::Table)
             .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "glyph"."image" FROM "glyph" WHERE "glyph"."aspect" IN (3, 4)"#
     );
 }
@@ -77,7 +77,7 @@ fn select_6() {
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect,])
             .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2"#
     );
 }
@@ -89,7 +89,7 @@ fn select_7() {
             .columns([Glyph::Aspect,])
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE IFNULL("aspect", 0) > 2"#
     );
 }
@@ -104,7 +104,7 @@ fn select_8() {
                 Font::Table,
                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id""#
     );
 }
@@ -123,7 +123,7 @@ fn select_9() {
                 Glyph::Table,
                 Expr::tbl(Char::Table, Char::Character).equals(Glyph::Table, Glyph::Image),
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" INNER JOIN "glyph" ON "character"."character" = "glyph"."image""#
     );
 }
@@ -140,7 +140,7 @@ fn select_10() {
                     .equals(Font::Table, Font::Id)
                     .and(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)),
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON ("character"."font_id" = "font"."id") AND ("character"."font_id" = "font"."id")"#
     );
 }
@@ -154,7 +154,7 @@ fn select_11() {
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by(Glyph::Image, Order::Desc)
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE IFNULL("aspect", 0) > 2 ORDER BY "image" DESC, "glyph"."aspect" ASC"#
     );
 }
@@ -167,7 +167,7 @@ fn select_12() {
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
             .order_by_columns(vec![(Glyph::Id, Order::Asc), (Glyph::Aspect, Order::Desc)])
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE IFNULL("aspect", 0) > 2 ORDER BY "id" ASC, "aspect" DESC"#
     );
 }
@@ -183,7 +183,7 @@ fn select_13() {
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
             ])
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE IFNULL("aspect", 0) > 2 ORDER BY "glyph"."id" ASC, "glyph"."aspect" DESC"#
     );
 }
@@ -200,7 +200,7 @@ fn select_14() {
                 (Glyph::Table, Glyph::Aspect),
             ])
             .and_having(Expr::col(Glyph::Aspect).gt(2))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "id", "aspect", MAX("image") FROM "glyph" GROUP BY "glyph"."id", "glyph"."aspect" HAVING "aspect" > 2"#
     );
 }
@@ -212,7 +212,7 @@ fn select_15() {
             .columns([Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "font_id" IS NULL"#
     );
 }
@@ -225,7 +225,7 @@ fn select_16() {
             .from(Char::Table)
             .and_where(Expr::col(Char::FontId).is_null())
             .and_where(Expr::col(Char::Character).is_not_null())
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "font_id" IS NULL AND "character" IS NOT NULL"#
     );
 }
@@ -237,7 +237,7 @@ fn select_17() {
             .columns([(Glyph::Table, Glyph::Image),])
             .from(Glyph::Table)
             .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).between(3, 5))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "glyph"."image" FROM "glyph" WHERE "glyph"."aspect" BETWEEN 3 AND 5"#
     );
 }
@@ -250,7 +250,7 @@ fn select_18() {
             .from(Glyph::Table)
             .and_where(Expr::col(Glyph::Aspect).between(3, 5))
             .and_where(Expr::col(Glyph::Aspect).not_between(8, 10))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE ("aspect" BETWEEN 3 AND 5) AND ("aspect" NOT BETWEEN 8 AND 10)"#
     );
 }
@@ -262,7 +262,7 @@ fn select_19() {
             .columns([Char::Character])
             .from(Char::Table)
             .and_where(Expr::col(Char::Character).eq("A"))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "character" = 'A'"#
     );
 }
@@ -274,7 +274,7 @@ fn select_20() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where(Expr::col(Char::Character).like("A"))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "character" LIKE 'A'"#
     );
 }
@@ -288,7 +288,7 @@ fn select_21() {
             .or_where(Expr::col(Char::Character).like("A%"))
             .or_where(Expr::col(Char::Character).like("%B"))
             .or_where(Expr::col(Char::Character).like("%C%"))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "character" LIKE 'A%' OR "character" LIKE '%B' OR "character" LIKE '%C%'"#
     );
 }
@@ -314,7 +314,7 @@ fn select_22() {
                             .or(Expr::col(Char::Character).like("G"))
                     )
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR (("character" LIKE 'D') AND ("character" LIKE 'E'))) AND (("character" LIKE 'F') OR ("character" LIKE 'G'))"#
     );
 }
@@ -326,7 +326,7 @@ fn select_23() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where_option(None)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character""#
     );
 }
@@ -344,7 +344,7 @@ fn select_24() {
                 },
                 |_| ()
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "font_id" = 5"#
     );
 }
@@ -360,7 +360,7 @@ fn select_25() {
                     .mul(2)
                     .equals(Expr::col(Char::SizeH).div(2))
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "size_w" * 2 = "size_h" / 2"#
     );
 }
@@ -376,7 +376,7 @@ fn select_26() {
                     .mul(2)
                     .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#
     );
 }
@@ -390,7 +390,7 @@ fn select_27() {
             .and_where(Expr::col(Char::SizeW).eq(3))
             .and_where(Expr::col(Char::SizeH).eq(4))
             .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 AND "size_h" = 4 AND "size_h" = 5"#
     );
 }
@@ -404,7 +404,7 @@ fn select_28() {
             .or_where(Expr::col(Char::SizeW).eq(3))
             .or_where(Expr::col(Char::SizeH).eq(4))
             .or_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 OR "size_h" = 4 OR "size_h" = 5"#
     );
 }
@@ -419,7 +419,7 @@ fn select_29() {
             .and_where(Expr::col(Char::SizeW).eq(3))
             .or_where(Expr::col(Char::SizeH).eq(4))
             .and_where(Expr::col(Char::SizeH).eq(5))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" = 3 OR "size_h" = 4 AND "size_h" = 5"#
     );
 }
@@ -436,7 +436,7 @@ fn select_30() {
                     .add(Expr::col(Char::SizeH).div(3))
                     .equals(Expr::value(4))
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" * 2) + ("size_h" / 3) = 4"#
     );
 }
@@ -446,7 +446,7 @@ fn select_31() {
     assert_eq!(
         Query::select()
             .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(Expr::value(i)) }))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9"#
     );
 }
@@ -457,7 +457,7 @@ fn select_32() {
         Query::select()
             .expr_as(Expr::col(Char::Character), Alias::new("C"))
             .from(Char::Table)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "character" AS "C" FROM "character""#
     );
 }
@@ -472,7 +472,7 @@ fn select_33() {
                 Expr::col(Glyph::Aspect)
                     .in_subquery(Query::select().expr(Expr::cust("3 + 2 * 2")).take())
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "image" FROM "glyph" WHERE "aspect" IN (SELECT 3 + 2 * 2)"#
     );
 }
@@ -496,7 +496,7 @@ fn select_34a() {
                     .and(Expr::col(Glyph::Aspect).lt(18))
             )
             .or_having(Expr::col(Glyph::Aspect).gt(32))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         vec![
             r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect""#,
             r#"HAVING (("aspect" > 2) OR ("aspect" < 8))"#,
@@ -526,7 +526,7 @@ fn select_34b() {
                     .gt(22)
                     .or(Expr::col(Glyph::Aspect).lt(28))
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         vec![
             r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect""#,
             r#"HAVING (("aspect" > 2) OR ("aspect" < 8))"#,
@@ -542,7 +542,7 @@ fn select_35() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .and_where(Expr::col(Glyph::Aspect).is_null())
-        .build(sea_query::SqliteQueryBuilder);
+        .build(&sea_query::SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -557,7 +557,7 @@ fn select_36() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Expr::col(Glyph::Aspect).is_null()))
-        .build(sea_query::SqliteQueryBuilder);
+        .build(&sea_query::SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -572,7 +572,7 @@ fn select_37() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
-        .build(sea_query::SqliteQueryBuilder);
+        .build(&sea_query::SqliteQueryBuilder);
 
     assert_eq!(statement, r#"SELECT "id" FROM "glyph""#);
     assert_eq!(values.0, vec![]);
@@ -588,7 +588,7 @@ fn select_38() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::SqliteQueryBuilder);
+        .build(&sea_query::SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -607,7 +607,7 @@ fn select_39() {
                 .add(Expr::col(Glyph::Aspect).is_null())
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .build(sea_query::SqliteQueryBuilder);
+        .build(&sea_query::SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -628,7 +628,7 @@ fn select_40() {
                 Expr::col(Glyph::Aspect).lt(8)
             ]
         ])
-        .to_string(sea_query::SqliteQueryBuilder);
+        .to_string(&sea_query::SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -645,7 +645,7 @@ fn select_41() {
             .from(Glyph::Table)
             .group_by_columns(vec![Glyph::Aspect])
             .cond_having(any![Expr::col(Glyph::Aspect).gt(2)])
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2"#
     );
 }
@@ -660,7 +660,7 @@ fn select_42() {
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -674,7 +674,7 @@ fn select_43() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(Cond::all().add_option::<SimpleExpr>(None))
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(statement, r#"SELECT "id" FROM "glyph""#);
 }
@@ -689,7 +689,7 @@ fn select_44() {
                 .not()
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8))),
         )
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -708,7 +708,7 @@ fn select_45() {
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -726,7 +726,7 @@ fn select_46() {
                 .not()
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8))),
         )
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -745,7 +745,7 @@ fn select_47() {
                 .add_option(Some(Expr::col(Glyph::Aspect).lt(8)))
                 .add(Expr::col(Glyph::Aspect).is_not_null()),
         )
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -767,7 +767,7 @@ fn select_48() {
                 .less_than(Expr::tuple([Expr::value(8), Expr::value(100)])),
             ))),
         )
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -789,7 +789,7 @@ fn select_48a() {
                 .in_tuples([(8, String::from("100"))]),
             ))),
         )
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -802,7 +802,7 @@ fn select_49() {
     let statement = sea_query::Query::select()
         .expr(Expr::asterisk())
         .from(Char::Table)
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(statement, r#"SELECT * FROM "character""#);
 }
@@ -817,7 +817,7 @@ fn select_50() {
             Font::Table,
             Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
         )
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -838,7 +838,7 @@ fn select_51() {
                 Order::Asc,
                 NullOrdering::Last
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         [
             r#"SELECT "aspect""#,
             r#"FROM "glyph""#,
@@ -861,7 +861,7 @@ fn select_52() {
                 (Glyph::Id, Order::Asc, NullOrdering::First),
                 (Glyph::Aspect, Order::Desc, NullOrdering::Last),
             ])
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         [
             r#"SELECT "aspect""#,
             r#"FROM "glyph""#,
@@ -888,7 +888,7 @@ fn select_53() {
                     NullOrdering::Last
                 ),
             ])
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         [
             r#"SELECT "aspect""#,
             r#"FROM "glyph""#,
@@ -907,7 +907,7 @@ fn select_54() {
         .from(Char::Table)
         .from(Font::Table)
         .and_where(Expr::tbl(Font::Table, Font::Id).equals(Char::Table, Char::FontId))
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 
     assert_eq!(
         statement,
@@ -932,7 +932,7 @@ fn select_55() {
                 ]))
             )
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         [
             r#"SELECT "aspect""#,
             r#"FROM "glyph""#,
@@ -966,7 +966,7 @@ fn select_56() {
                     Value::Int(Some(3))
                 ]))
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         [
             r#"SELECT "aspect""#,
             r#"FROM "glyph""#,
@@ -1002,7 +1002,7 @@ fn select_57() {
         .to_owned();
 
     assert_eq!(
-        query.to_string(SqliteQueryBuilder),
+        query.to_string(&SqliteQueryBuilder),
         r#"SELECT (CASE WHEN ("glyph"."aspect" > 0) THEN 'positive' WHEN ("glyph"."aspect" < 0) THEN 'negative' ELSE 'zero' END) AS "polarity" FROM "glyph""#
     );
 }
@@ -1014,7 +1014,7 @@ fn select_58() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where(Expr::col(Char::Character).like(LikeExpr::str("A").escape('\\')))
-            .build(SqliteQueryBuilder),
+            .build(&SqliteQueryBuilder),
         (
             r#"SELECT "character" FROM "character" WHERE "character" LIKE ? ESCAPE '\'"#.to_owned(),
             Values(vec!["A".into()])
@@ -1033,7 +1033,7 @@ fn insert_2() {
                 "04108048005887010020060000204E0180400400".into(),
                 3.1415.into(),
             ])
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#
     );
 }
@@ -1050,7 +1050,7 @@ fn insert_3() {
                 3.1415.into(),
             ])
             .values_panic(vec![Value::Double(None), 2.1345.into()])
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415), (NULL, 2.1345)"#
     );
 }
@@ -1063,7 +1063,7 @@ fn insert_4() {
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
             .values_panic(vec![chrono::NaiveDateTime::from_timestamp(0, 0).into()])
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"INSERT INTO "glyph" ("image") VALUES ('1970-01-01 00:00:00')"#
     );
 }
@@ -1079,7 +1079,7 @@ fn insert_8() {
             .values_panic(vec![date!(1970 - 01 - 01)
                 .with_time(time!(00:00:00))
                 .into()])
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"INSERT INTO "glyph" ("image") VALUES ('1970-01-01 00:00:00')"#
     );
 }
@@ -1108,7 +1108,7 @@ fn insert_from_select() {
             )
             .unwrap()
             .to_owned()
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"INSERT INTO "glyph" ("aspect", "image") SELECT "aspect", "image" FROM "glyph" WHERE "image" LIKE '%'"#
     );
 }
@@ -1121,7 +1121,7 @@ fn insert_5() {
             .into_table(Glyph::Table)
             .columns([Glyph::Image])
             .values_panic(vec![uuid::Uuid::nil().into()])
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"INSERT INTO "glyph" ("image") VALUES ('00000000-0000-0000-0000-000000000000')"#
     );
 }
@@ -1132,7 +1132,7 @@ fn insert_6() {
         Query::insert()
             .into_table(Glyph::Table)
             .or_default_values()
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"INSERT INTO "glyph" DEFAULT VALUES"#
     );
 }
@@ -1144,7 +1144,7 @@ fn insert_7() {
             .into_table(Glyph::Table)
             .or_default_values()
             .returning_col(Glyph::Id)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"INSERT INTO "glyph" DEFAULT VALUES RETURNING "id""#
     );
 }
@@ -1165,7 +1165,7 @@ fn insert_on_conflict_1() {
                     .update_column(Glyph::Aspect)
                     .to_owned()
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         [
             r#"INSERT INTO "glyph" ("aspect", "image")"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1191,7 +1191,7 @@ fn insert_on_conflict_2() {
                     .update_columns([Glyph::Aspect, Glyph::Image])
                     .to_owned()
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         [
             r#"INSERT INTO "glyph" ("aspect", "image")"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1220,7 +1220,7 @@ fn insert_on_conflict_3() {
                     ])
                     .to_owned()
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         [
             r#"INSERT INTO "glyph" ("aspect", "image")"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1246,7 +1246,7 @@ fn insert_on_conflict_4() {
                     .update_expr((Glyph::Image, Expr::val(1).add(2)))
                     .to_owned()
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         [
             r#"INSERT INTO "glyph" ("aspect", "image")"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
@@ -1268,7 +1268,7 @@ fn insert_returning_all_columns() {
                 3.1415.into(),
             ])
             .returning(Query::returning().all())
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415) RETURNING *"#
     );
 }
@@ -1285,7 +1285,7 @@ fn insert_returning_specific_columns() {
                 3.1415.into(),
             ])
             .returning(Query::returning().columns([Glyph::Id, Glyph::Image]))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"INSERT INTO "glyph" ("image", "aspect") VALUES ('04108048005887010020060000204E0180400400', 3.1415) RETURNING "id", "image""#
     );
 }
@@ -1303,7 +1303,7 @@ fn update_1() {
                 ),
             ])
             .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = 2.1345, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1"#
     );
 }
@@ -1319,7 +1319,7 @@ fn update_3() {
                 "24B0E11951B03B07F8300FD003983F03F0780060".into()
             ),])
             .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = 60 * 24 * 24, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1"#
     );
 }
@@ -1337,7 +1337,7 @@ fn update_4() {
             .and_where(Expr::col(Glyph::Id).eq(1))
             .order_by(Glyph::Id, Order::Asc)
             .limit(1)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = "aspect" + 1, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1 ORDER BY "id" ASC LIMIT 1"#
     );
 }
@@ -1354,7 +1354,7 @@ fn update_returning_all_columns() {
             ),])
             .and_where(Expr::col(Glyph::Id).eq(1))
             .returning(Query::returning().all())
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = 60 * 24 * 24, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1 RETURNING *"#
     );
 }
@@ -1371,7 +1371,7 @@ fn update_returning_specified_columns() {
             ),])
             .and_where(Expr::col(Glyph::Id).eq(1))
             .returning(Query::returning().columns([Glyph::Id, Glyph::Image]))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"UPDATE "glyph" SET "aspect" = 60 * 24 * 24, "image" = '24B0E11951B03B07F8300FD003983F03F0780060' WHERE "id" = 1 RETURNING "id", "image""#
     );
 }
@@ -1382,7 +1382,7 @@ fn delete_1() {
         Query::delete()
             .from_table(Glyph::Table)
             .and_where(Expr::col(Glyph::Id).eq(1))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"DELETE FROM "glyph" WHERE "id" = 1"#
     );
 }
@@ -1452,7 +1452,7 @@ fn delete_returning_all_columns() {
             .from_table(Glyph::Table)
             .and_where(Expr::col(Glyph::Id).eq(1))
             .returning(Query::returning().all())
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING *"#
     );
 }
@@ -1464,7 +1464,7 @@ fn delete_returning_specific_columns() {
             .from_table(Glyph::Table)
             .and_where(Expr::col(Glyph::Id).eq(1))
             .returning(Query::returning().columns([Glyph::Id, Glyph::Image]))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id", "image""#
     );
 }
@@ -1476,7 +1476,7 @@ fn delete_returning_specific_exprs() {
             .from_table(Glyph::Table)
             .and_where(Expr::col(Glyph::Id).eq(1))
             .returning(Query::returning().exprs([Expr::col(Glyph::Id), Expr::col(Glyph::Image)]))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id", "image""#
     );
 }

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -14,7 +14,7 @@ fn create_1() {
             )
             .col(ColumnDef::new(Glyph::Aspect).double().not_null())
             .col(ColumnDef::new(Glyph::Image).text())
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         vec![
             r#"CREATE TABLE "glyph" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
@@ -41,7 +41,7 @@ fn create_2() {
             .col(ColumnDef::new(Font::Name).string().not_null())
             .col(ColumnDef::new(Font::Variant).string().not_null())
             .col(ColumnDef::new(Font::Language).string().not_null())
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         vec![
             r#"CREATE TABLE "font" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
@@ -83,7 +83,7 @@ fn create_3() {
                     .on_delete(ForeignKeyAction::Cascade)
                     .on_update(ForeignKeyAction::Cascade)
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         vec![
             r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
@@ -111,7 +111,7 @@ fn create_4() {
             .col(ColumnDef::new(BinaryType::Blob).blob(BlobSize::Blob(None)))
             .col(ColumnDef::new(BinaryType::MediumBlob).blob(BlobSize::Medium))
             .col(ColumnDef::new(BinaryType::LongBlob).blob(BlobSize::Long))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         vec![
             r#"CREATE TABLE "binary_type" ("#,
             r#""binlen" binary(32),"#,
@@ -135,7 +135,7 @@ fn create_5() {
             .col(ColumnDef::new(Char::Character).binary())
             .col(ColumnDef::new(Char::FontSize).binary_len(10))
             .col(ColumnDef::new(Char::SizeW).var_binary(10))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         vec![
             r#"CREATE TABLE "character" ("#,
             r#""character" blob,"#,
@@ -177,7 +177,7 @@ fn create_with_unique_index() {
                     .on_update(ForeignKeyAction::Cascade)
             )
             .index(Index::create().unique().col(Char::SizeH).col(Char::SizeW))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         vec![
             r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
@@ -222,7 +222,7 @@ fn create_with_primary_unique_index() {
                     .on_update(ForeignKeyAction::Cascade)
             )
             .index(Index::create().unique().primary().col(Char::SizeH).col(Char::SizeW))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         vec![
             r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" integer NOT NULL,"#,
@@ -246,7 +246,7 @@ fn drop_1() {
             .table(Glyph::Table)
             .table(Char::Table)
             .cascade()
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"DROP TABLE "glyph", "character""#
     );
 }
@@ -256,7 +256,7 @@ fn truncate_1() {
     assert_eq!(
         Table::truncate()
             .table(Font::Table)
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"TRUNCATE TABLE "font""#
     );
 }
@@ -272,7 +272,7 @@ fn alter_1() {
                     .not_null()
                     .default(99)
             )
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 99"#
     );
 }
@@ -283,7 +283,7 @@ fn alter_2() {
     Table::alter()
         .table(Font::Table)
         .modify_column(ColumnDef::new(Alias::new("new_col")).double())
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 }
 
 #[test]
@@ -292,7 +292,7 @@ fn alter_3() {
         Table::alter()
             .table(Font::Table)
             .rename_column(Alias::new("new_col"), Alias::new("new_column"))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"ALTER TABLE "font" RENAME COLUMN "new_col" TO "new_column""#
     );
 }
@@ -303,7 +303,7 @@ fn alter_4() {
     Table::alter()
         .table(Font::Table)
         .drop_column(Alias::new("new_column"))
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 }
 
 #[test]
@@ -311,7 +311,7 @@ fn alter_5() {
     assert_eq!(
         Table::rename()
             .table(Font::Table, Alias::new("font_new"))
-            .to_string(SqliteQueryBuilder),
+            .to_string(&SqliteQueryBuilder),
         r#"ALTER TABLE "font" RENAME TO "font_new""#
     );
 }
@@ -319,7 +319,7 @@ fn alter_5() {
 #[test]
 #[should_panic(expected = "No alter option found")]
 fn alter_6() {
-    Table::alter().to_string(SqliteQueryBuilder);
+    Table::alter().to_string(&SqliteQueryBuilder);
 }
 
 #[test]
@@ -328,5 +328,5 @@ fn alter_7() {
         .table(Font::Table)
         .add_column(ColumnDef::new(Alias::new("new_col")).integer())
         .rename_column(Font::Name, Alias::new("name_new"))
-        .to_string(SqliteQueryBuilder);
+        .to_string(&SqliteQueryBuilder);
 }


### PR DESCRIPTION
fix #420 

Then, sea-orm call `sea-query` crate, not always use Object owership with `use sea_query::{MysqlQueryBuilder, PostgresQueryBuilder, SqliteQueryBuilder};`

