### PR TITLE
Cleanup `IndexBuilder` trait methods

### DIFF
--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -1,18 +1,6 @@
 use super::*;
 
 impl IndexBuilder for PostgresQueryBuilder {
-    fn prepare_table_index_expression(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
-        if create.index.name.is_some() {
-            write!(sql, "CONSTRAINT ").unwrap();
-            self.prepare_index_name(&create.index.name, sql);
-            write!(sql, " ").unwrap();
-        }
-
-        self.prepare_index_prefix(create, sql);
-
-        self.prepare_index_columns(&create.index.columns, sql);
-    }
-
     fn prepare_index_create_statement(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
         write!(sql, "CREATE ").unwrap();
         self.prepare_index_prefix(create, sql);

--- a/src/backend/sqlite/index.rs
+++ b/src/backend/sqlite/index.rs
@@ -4,9 +4,9 @@ impl IndexBuilder for SqliteQueryBuilder {
     fn prepare_table_index_expression(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
         if create.index.name.is_some() {
             write!(sql, "CONSTRAINT ").unwrap();
+            self.prepare_index_name(&create.index.name, sql);
+            write!(sql, " ").unwrap();
         }
-        self.prepare_index_name(&create.index.name, sql);
-        write!(sql, " ").unwrap();
 
         self.prepare_index_prefix(create, sql);
 

--- a/src/backend/sqlite/index.rs
+++ b/src/backend/sqlite/index.rs
@@ -1,18 +1,6 @@
 use super::*;
 
 impl IndexBuilder for SqliteQueryBuilder {
-    fn prepare_table_index_expression(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
-        if create.index.name.is_some() {
-            write!(sql, "CONSTRAINT ").unwrap();
-            self.prepare_index_name(&create.index.name, sql);
-            write!(sql, " ").unwrap();
-        }
-
-        self.prepare_index_prefix(create, sql);
-
-        self.prepare_index_columns(&create.index.columns, sql);
-    }
-
     fn prepare_index_create_statement(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
         write!(sql, "CREATE ").unwrap();
         self.prepare_index_prefix(create, sql);

--- a/src/backend/sqlite/index.rs
+++ b/src/backend/sqlite/index.rs
@@ -6,6 +6,7 @@ impl IndexBuilder for SqliteQueryBuilder {
             write!(sql, "CONSTRAINT ").unwrap();
         }
         self.prepare_index_name(&create.index.name, sql);
+        write!(sql, " ").unwrap();
 
         self.prepare_index_prefix(create, sql);
 

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -240,6 +240,59 @@ fn create_with_primary_unique_index() {
 }
 
 #[test]
+fn create_with_unique_index_constraint() {
+    assert_eq!(
+        Table::create()
+            .table(Char::Table)
+            .if_not_exists()
+            .col(
+                ColumnDef::new(Char::Id)
+                    .integer()
+                    .not_null()
+                    .auto_increment()
+                    .primary_key(),
+            )
+            .col(ColumnDef::new(Char::FontSize).integer().not_null())
+            .col(ColumnDef::new(Char::Character).string().not_null())
+            .col(ColumnDef::new(Char::SizeW).integer().not_null())
+            .col(ColumnDef::new(Char::SizeH).integer().not_null())
+            .col(
+                ColumnDef::new(Char::FontId)
+                    .integer()
+                    .default(Value::Int(None)),
+            )
+            .foreign_key(
+                ForeignKey::create()
+                    .from(Char::Table, Char::FontId)
+                    .to(Font::Table, Font::Id)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .on_update(ForeignKeyAction::Cascade),
+            )
+            .index(
+                Index::create()
+                    .name("idx-sizehw")
+                    .table(Char::Table)
+                    .col(Char::SizeH)
+                    .col(Char::SizeW)
+                    .unique(),
+            )
+            .to_string(SqliteQueryBuilder),
+        vec![
+            r#"CREATE TABLE IF NOT EXISTS "character" ("#,
+            r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
+            r#""font_size" integer NOT NULL,"#,
+            r#""character" text NOT NULL,"#,
+            r#""size_w" integer NOT NULL,"#,
+            r#""size_h" integer NOT NULL,"#,
+            r#""font_id" integer DEFAULT NULL,"#,
+            r#"CONSTRAINT "idx-sizehw" UNIQUE ("size_h", "size_w"),"#,
+            r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id") ON DELETE CASCADE ON UPDATE CASCADE"#,
+            r#")"#,
+        ].join(" ")
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Table::drop()


### PR DESCRIPTION
## PR Info

[Per discussion here](https://github.com/SeaQL/sea-query/pull/411#issuecomment-1220404874), we could clean up the `IndexBuilder` trait methods.

- Dependencies:
  - [#411](https://github.com/SeaQL/sea-query/pull/411)

## Changes

- `PostgresQueryBuilder` and `SqliteQueryBuilder` could use the default `prepare_table_index_expression` from `IndexBuilder`.
- `MysqlQueryBuilder` implements its own `prepare_table_index_expression` method.
- All 3 backend query builders implement their own `prepare_index_create_statement` (each differs slightly).
