### PR TITLE
`ColumnDef` with default expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ let table = Table::create()
     .col(ColumnDef::new(Char::Character).string().not_null())
     .col(ColumnDef::new(Char::SizeW).integer().not_null())
     .col(ColumnDef::new(Char::SizeH).integer().not_null())
-    .col(ColumnDef::new(Char::FontId).integer().default(Value::Int(None)))
+    .col(ColumnDef::new(Char::FontId).integer().default_value(Value::Int(None)))
     .foreign_key(
         ForeignKey::create()
             .name("FK_2e303c3a712662f1fc2a4d0aad6")
@@ -510,7 +510,7 @@ let table = Table::alter()
         ColumnDef::new(Alias::new("new_col"))
             .integer()
             .not_null()
-            .default(100),
+            .default_value(100),
     )
     .to_owned();
 

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -118,19 +118,6 @@ impl TableBuilder for MysqlQueryBuilder {
         }
     }
 
-    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut SqlWriter) {
-        match column_spec {
-            ColumnSpec::Null => write!(sql, "NULL"),
-            ColumnSpec::NotNull => write!(sql, "NOT NULL"),
-            ColumnSpec::Default(value) => write!(sql, "DEFAULT {}", self.value_to_string(value)),
-            ColumnSpec::AutoIncrement => write!(sql, "AUTO_INCREMENT"),
-            ColumnSpec::UniqueKey => write!(sql, "UNIQUE"),
-            ColumnSpec::PrimaryKey => write!(sql, "PRIMARY KEY"),
-            ColumnSpec::Extra(string) => write!(sql, "{}", string),
-        }
-        .unwrap()
-    }
-
     fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut SqlWriter) {
         if alter.options.is_empty() {
             panic!("No alter option found")
@@ -202,5 +189,9 @@ impl TableBuilder for MysqlQueryBuilder {
         if let Some(to_name) = &rename.to_name {
             self.prepare_table_ref_table_stmt(to_name, sql);
         }
+    }
+
+    fn column_spec_auto_increment_keyword(&self) -> &str {
+        "AUTO_INCREMENT"
     }
 }

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -107,21 +107,6 @@ impl TableBuilder for PostgresQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut SqlWriter) {
-        match column_spec {
-            ColumnSpec::Null => write!(sql, "NULL"),
-            ColumnSpec::NotNull => write!(sql, "NOT NULL"),
-            ColumnSpec::Default(value) => {
-                write!(sql, "DEFAULT {}", self.value_to_string(value))
-            }
-            ColumnSpec::AutoIncrement => write!(sql, ""),
-            ColumnSpec::UniqueKey => write!(sql, "UNIQUE"),
-            ColumnSpec::PrimaryKey => write!(sql, "PRIMARY KEY"),
-            ColumnSpec::Extra(string) => write!(sql, "{}", string),
-        }
-        .unwrap()
-    }
-
     fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut SqlWriter) {
         if alter.options.is_empty() {
             panic!("No alter option found")
@@ -216,6 +201,10 @@ impl TableBuilder for PostgresQueryBuilder {
         if let Some(to_name) = &rename.to_name {
             self.prepare_table_ref_table_stmt(to_name, sql);
         }
+    }
+
+    fn column_spec_auto_increment_keyword(&self) -> &str {
+        ""
     }
 }
 

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -121,19 +121,6 @@ impl TableBuilder for SqliteQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut SqlWriter) {
-        match column_spec {
-            ColumnSpec::Null => write!(sql, "NULL"),
-            ColumnSpec::NotNull => write!(sql, "NOT NULL"),
-            ColumnSpec::Default(value) => write!(sql, "DEFAULT {}", self.value_to_string(value)),
-            ColumnSpec::AutoIncrement => write!(sql, "AUTOINCREMENT"),
-            ColumnSpec::UniqueKey => write!(sql, "UNIQUE"),
-            ColumnSpec::PrimaryKey => write!(sql, "PRIMARY KEY"),
-            ColumnSpec::Extra(string) => write!(sql, "{}", string),
-        }
-        .unwrap()
-    }
-
     fn prepare_table_drop_opt(&self, _drop_opt: &TableDropOpt, _sql: &mut dyn std::fmt::Write) {
         // SQLite does not support table drop options
     }
@@ -185,5 +172,9 @@ impl TableBuilder for SqliteQueryBuilder {
         if let Some(to_name) = &rename.to_name {
             self.prepare_table_ref_table_stmt(to_name, sql);
         }
+    }
+
+    fn column_spec_auto_increment_keyword(&self) -> &str {
+        "AUTOINCREMENT"
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,7 +467,7 @@
 //!     .col(ColumnDef::new(Char::Character).string().not_null())
 //!     .col(ColumnDef::new(Char::SizeW).integer().not_null())
 //!     .col(ColumnDef::new(Char::SizeH).integer().not_null())
-//!     .col(ColumnDef::new(Char::FontId).integer().default(Value::Int(None)))
+//!     .col(ColumnDef::new(Char::FontId).integer().default_value(Value::Int(None)))
 //!     .foreign_key(
 //!         ForeignKey::create()
 //!             .name("FK_2e303c3a712662f1fc2a4d0aad6")
@@ -536,7 +536,7 @@
 //!         ColumnDef::new(Alias::new("new_col"))
 //!             .integer()
 //!             .not_null()
-//!             .default(100),
+//!             .default_value(100),
 //!     )
 //!     .to_owned();
 //!

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -48,6 +48,17 @@ where
     output.into_iter().collect()
 }
 
+pub(crate) fn collect_parameters_as_string<F>(query_builder: &dyn QueryBuilder, f: F) -> String
+where
+    F: Fn(&mut SqlWriter, &mut dyn FnMut(Value)),
+{
+    let mut sql = SqlWriter::new();
+    let mut values = Vec::new();
+    let mut collector = |v| values.push(v);
+    f(&mut sql, &mut collector);
+    inject_parameters(&sql.string, values, query_builder)
+}
+
 impl SqlWriter {
     pub fn new() -> Self {
         Self {

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -16,7 +16,7 @@ use crate::{
 ///         ColumnDef::new(Alias::new("new_col"))
 ///             .integer()
 ///             .not_null()
-///             .default(100),
+///             .default_value(100),
 ///     )
 ///     .to_owned();
 ///
@@ -94,7 +94,7 @@ impl TableAlterStatement {
     ///         ColumnDef::new(Alias::new("new_col"))
     ///             .integer()
     ///             .not_null()
-    ///             .default(100),
+    ///             .default_value(100),
     ///     )
     ///     .to_owned();
     ///
@@ -133,7 +133,7 @@ impl TableAlterStatement {
     ///         ColumnDef::new(Alias::new("new_col"))
     ///             .integer()
     ///             .not_null()
-    ///             .default(100),
+    ///             .default_value(100),
     ///     )
     ///     .to_owned();
     ///
@@ -171,7 +171,7 @@ impl TableAlterStatement {
     ///     .modify_column(
     ///         ColumnDef::new(Alias::new("new_col"))
     ///             .big_integer()
-    ///             .default(999),
+    ///             .default_value(999),
     ///     )
     ///     .to_owned();
     ///

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -1,4 +1,4 @@
-use crate::{types::*, value::*};
+use crate::{expr::*, types::*, value::*};
 
 /// Specification of a table column
 #[derive(Debug, Clone)]
@@ -53,7 +53,7 @@ pub enum ColumnType {
 pub enum ColumnSpec {
     Null,
     NotNull,
-    Default(Value),
+    Default(SimpleExpr),
     AutoIncrement,
     UniqueKey,
     PrimaryKey,
@@ -148,13 +148,30 @@ impl ColumnDef {
         self
     }
 
+    /// Alias of [`ColumnDef::default_expr`].
+    /// If you want to specify a default value, please use [`ColumnDef::default_value`].
+    pub fn default<T>(&mut self, expr: T) -> &mut Self
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.default_expr(expr)
+    }
+
+    /// Set default expression of a column
+    pub fn default_expr<T>(&mut self, expr: T) -> &mut Self
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.spec.push(ColumnSpec::Default(expr.into()));
+        self
+    }
+
     /// Set default value of a column
-    pub fn default<T>(&mut self, value: T) -> &mut Self
+    pub fn default_value<T>(&mut self, value: T) -> &mut Self
     where
         T: Into<Value>,
     {
-        self.spec.push(ColumnSpec::Default(value.into()));
-        self
+        self.default_expr(Expr::val(value))
     }
 
     /// Set column auto increment

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -18,7 +18,7 @@ use crate::{
 ///     .col(ColumnDef::new(Char::Character).string().not_null())
 ///     .col(ColumnDef::new(Char::SizeW).integer().not_null())
 ///     .col(ColumnDef::new(Char::SizeH).integer().not_null())
-///     .col(ColumnDef::new(Char::FontId).integer().default(Value::Int(None)))
+///     .col(ColumnDef::new(Char::FontId).integer().default_value(Value::Int(None)))
 ///     .foreign_key(
 ///         ForeignKey::create()
 ///             .name("FK_2e303c3a712662f1fc2a4d0aad6")

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -80,7 +80,7 @@ fn create_3() {
             .col(
                 ColumnDef::new(Char::FontId)
                     .integer_len(11)
-                    .default(Value::Int(None))
+                    .default_value(Value::Int(None))
             )
             .foreign_key(
                 ForeignKey::create()
@@ -228,7 +228,7 @@ fn alter_1() {
                 ColumnDef::new(Alias::new("new_col"))
                     .integer()
                     .not_null()
-                    .default(100)
+                    .default_value(100)
             )
             .to_string(MysqlQueryBuilder),
         "ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"
@@ -243,7 +243,7 @@ fn alter_2() {
             .modify_column(
                 ColumnDef::new(Alias::new("new_col"))
                     .big_integer()
-                    .default(999)
+                    .default_value(999)
             )
             .to_string(MysqlQueryBuilder),
         "ALTER TABLE `font` MODIFY COLUMN `new_col` bigint DEFAULT 999"

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -74,7 +74,7 @@ fn create_3() {
             .col(
                 ColumnDef::new(Char::FontId)
                     .integer()
-                    .default(Value::Int(None))
+                    .default_value(Value::Int(None))
             )
             .foreign_key(
                 ForeignKey::create()
@@ -369,7 +369,7 @@ fn alter_1() {
                 ColumnDef::new(Alias::new("new_col"))
                     .integer()
                     .not_null()
-                    .default(100)
+                    .default_value(100)
             )
             .to_string(PostgresQueryBuilder),
         r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
@@ -384,7 +384,7 @@ fn alter_2() {
             .modify_column(
                 ColumnDef::new(Alias::new("new_col"))
                     .big_integer()
-                    .default(999)
+                    .default_value(999)
             )
             .to_string(PostgresQueryBuilder),
         vec![

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -74,7 +74,7 @@ fn create_3() {
             .col(
                 ColumnDef::new(Char::FontId)
                     .integer()
-                    .default(Value::Int(None))
+                    .default_value(Value::Int(None))
             )
             .foreign_key(
                 ForeignKey::create()
@@ -167,7 +167,7 @@ fn create_with_unique_index() {
             .col(
                 ColumnDef::new(Char::FontId)
                     .integer()
-                    .default(Value::Int(None))
+                    .default_value(Value::Int(None))
             )
             .foreign_key(
                 ForeignKey::create()
@@ -212,7 +212,7 @@ fn create_with_primary_unique_index() {
             .col(
                 ColumnDef::new(Char::FontId)
                     .integer()
-                    .default(Value::Int(None))
+                    .default_value(Value::Int(None))
             )
             .foreign_key(
                 ForeignKey::create()
@@ -270,7 +270,7 @@ fn alter_1() {
                 ColumnDef::new(Alias::new("new_col"))
                     .integer()
                     .not_null()
-                    .default(99)
+                    .default_value(99)
             )
             .to_string(SqliteQueryBuilder),
         r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 99"#


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-query/issues/347

## Adds

- [x] `ColumnDef::default_expr()` setting the default expression of a column
- [x] `ColumnDef::default_value()` setting the default value of a column

## Breaking Changes

- [x] `ColumnDef::default()` now takes `Into<SimpleExpr>` instead of `Into<Value>`. Users are advised to use `ColumnDef::default_value()`.