### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ sea-query-derive = { version = "^0.2.0", path = "sea-query-derive", optional = t
 sea-query-driver = { version = "^0.2.0", path = "sea-query-driver", optional = true }
 serde_json = { version = "^1", optional = true }
 bytes = { version = "^1", optional = true }
-chrono = { version = "^0", default-features = false, features = ["clock"], optional = true }
-postgres-types = { version = "^0", optional = true }
+chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
+postgres-types = { version = "0.2", optional = true }
 rust_decimal = { version = "^1", optional = true }
 bigdecimal = { version = "^0.3", optional = true }
 uuid = { version = "^1", optional = true }


### PR DESCRIPTION

PR Info
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.

