### PR TITLE
Struct like `ColumnType::Enum` variant & store `String` in `DynIden`

### DIFF
--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -98,7 +98,14 @@ impl TableBuilder for MysqlQueryBuilder {
                 ColumnType::JsonBinary => "json".into(),
                 ColumnType::Uuid => "binary(16)".into(),
                 ColumnType::Custom(iden) => iden.to_string(),
-                ColumnType::Enum(_, variants) => format!("ENUM('{}')", variants.join("', '")),
+                ColumnType::Enum { variants, .. } => format!(
+                    "ENUM('{}')",
+                    variants
+                        .iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<_>>()
+                        .join("', '")
+                ),
                 ColumnType::Array(_) => unimplemented!("Array is not available in MySQL."),
                 ColumnType::Cidr => unimplemented!("Cidr is not available in MySQL."),
                 ColumnType::Inet => unimplemented!("Inet is not available in MySQL."),

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -98,7 +98,7 @@ impl TableBuilder for PostgresQueryBuilder {
                 ColumnType::Uuid => "uuid".into(),
                 ColumnType::Array(elem_type) => format!("{}[]", elem_type.as_ref().unwrap()),
                 ColumnType::Custom(iden) => iden.to_string(),
-                ColumnType::Enum(name, _) => name.into(),
+                ColumnType::Enum { name, .. } => name.to_string(),
                 ColumnType::Cidr => "cidr".into(),
                 ColumnType::Inet => "inet".into(),
                 ColumnType::MacAddr => "macaddr".into(),

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -111,7 +111,7 @@ impl TableBuilder for SqliteQueryBuilder {
                 ColumnType::JsonBinary => "text".into(),
                 ColumnType::Uuid => "text(36)".into(),
                 ColumnType::Custom(iden) => iden.to_string(),
-                ColumnType::Enum(_, _) => "text".into(),
+                ColumnType::Enum { .. } => "text".into(),
                 ColumnType::Array(_) => unimplemented!("Array is not available in Sqlite."),
                 ColumnType::Cidr => unimplemented!("Cidr is not available in Sqlite."),
                 ColumnType::Inet => unimplemented!("Inet is not available in Sqlite."),

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -41,7 +41,10 @@ pub enum ColumnType {
     JsonBinary,
     Uuid,
     Custom(DynIden),
-    Enum(String, Vec<String>),
+    Enum {
+        name: DynIden,
+        variants: Vec<DynIden>,
+    },
     Array(Option<String>),
     Cidr,
     Inet,
@@ -508,14 +511,14 @@ impl ColumnDef {
     /// Set column type as enum.
     pub fn enumeration<N, S, V>(&mut self, name: N, variants: V) -> &mut Self
     where
-        N: ToString,
-        S: ToString,
+        N: IntoIden,
+        S: IntoIden,
         V: IntoIterator<Item = S>,
     {
-        self.types = Some(ColumnType::Enum(
-            name.to_string(),
-            variants.into_iter().map(|v| v.to_string()).collect(),
-        ));
+        self.types = Some(ColumnType::Enum {
+            name: name.into_iden(),
+            variants: variants.into_iter().map(IntoIden::into_iden).collect(),
+        });
         self
     }
 

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -497,11 +497,11 @@ impl ColumnDef {
     }
 
     /// Use a custom type on this column.
-    pub fn custom<T: 'static>(&mut self, n: T) -> &mut Self
+    pub fn custom<T>(&mut self, name: T) -> &mut Self
     where
-        T: Iden,
+        T: IntoIden,
     {
-        self.types = Some(ColumnType::Custom(SeaRc::new(n)));
+        self.types = Some(ColumnType::Custom(name.into_iden()));
         self
     }
 


### PR DESCRIPTION
## PR Info

- In response to https://github.com/SeaQL/sea-orm/pull/973#discussion_r962339773

## Breaking Changes

- [x] `ColumnType::Enum` variant is a struct variant, it used to be tuple variant
- [x] `ColumnDef::enumeration()` method now take parameters impl `IntoIden`, it used to take `String`

## Changes

- [x] `ColumnDef::custom()` method now take parameters impl `IntoIden`, it used to take `Iden`
