### PR TITLE
issues-347 Add SqlWriter trait

### DIFF
--- a/src/backend/foreign_key_builder.rs
+++ b/src/backend/foreign_key_builder.rs
@@ -12,7 +12,7 @@ pub trait ForeignKeyBuilder: QuotedBuilder + TableRefBuilder {
     fn prepare_foreign_key_create_statement(
         &self,
         create: &ForeignKeyCreateStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
     ) {
         self.prepare_foreign_key_create_statement_internal(create, sql, Mode::Alter)
     }
@@ -21,7 +21,7 @@ pub trait ForeignKeyBuilder: QuotedBuilder + TableRefBuilder {
     fn prepare_foreign_key_drop_statement(
         &self,
         drop: &ForeignKeyDropStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
     ) {
         self.prepare_foreign_key_drop_statement_internal(drop, sql, Mode::Alter)
     }
@@ -30,7 +30,7 @@ pub trait ForeignKeyBuilder: QuotedBuilder + TableRefBuilder {
     fn prepare_foreign_key_action(
         &self,
         foreign_key_action: &ForeignKeyAction,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
     ) {
         write!(
             sql,
@@ -47,14 +47,14 @@ pub trait ForeignKeyBuilder: QuotedBuilder + TableRefBuilder {
     }
 
     /// Translate [`TableRef`] into SQL statement.
-    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut SqlWriter);
+    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter);
 
     #[doc(hidden)]
     /// Internal function to factor foreign key drop in table and outside.
     fn prepare_foreign_key_drop_statement_internal(
         &self,
         drop: &ForeignKeyDropStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
         mode: Mode,
     );
 
@@ -63,7 +63,7 @@ pub trait ForeignKeyBuilder: QuotedBuilder + TableRefBuilder {
     fn prepare_foreign_key_create_statement_internal(
         &self,
         create: &ForeignKeyCreateStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
         mode: Mode,
     );
 }

--- a/src/backend/index_builder.rs
+++ b/src/backend/index_builder.rs
@@ -4,7 +4,11 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
     /// Translate [`IndexCreateStatement`] into SQL expression.
     /// This is the default implementation for `PostgresQueryBuilder` and `SqliteQueryBuilder`.
     /// `MysqlQueryBuilder` overrides this default implementation.
-    fn prepare_table_index_expression(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
+    fn prepare_table_index_expression(
+        &self,
+        create: &IndexCreateStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
         if create.index.name.is_some() {
             write!(sql, "CONSTRAINT ").unwrap();
             self.prepare_index_name(&create.index.name, sql);
@@ -17,25 +21,29 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
     }
 
     /// Translate [`IndexCreateStatement`] into SQL statement.
-    fn prepare_index_create_statement(&self, create: &IndexCreateStatement, sql: &mut SqlWriter);
+    fn prepare_index_create_statement(
+        &self,
+        create: &IndexCreateStatement,
+        sql: &mut dyn SqlWriter,
+    );
 
     /// Translate [`TableRef`] into SQL statement.
-    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut SqlWriter);
+    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter);
 
     /// Translate [`IndexDropStatement`] into SQL statement.
-    fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut SqlWriter);
+    fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut dyn SqlWriter);
 
     #[doc(hidden)]
     /// Write the index type (Btree, hash, ...).
-    fn prepare_index_type(&self, _col_index_type: &Option<IndexType>, _sql: &mut SqlWriter) {}
+    fn prepare_index_type(&self, _col_index_type: &Option<IndexType>, _sql: &mut dyn SqlWriter) {}
 
     #[doc(hidden)]
     /// Write the index prefix (primary, unique, ...).
-    fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut SqlWriter);
+    fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut dyn SqlWriter);
 
     #[doc(hidden)]
     /// Write the column index prefix.
-    fn write_column_index_prefix(&self, col_prefix: &Option<u32>, sql: &mut SqlWriter) {
+    fn write_column_index_prefix(&self, col_prefix: &Option<u32>, sql: &mut dyn SqlWriter) {
         if let Some(prefix) = col_prefix {
             write!(sql, " ({})", prefix).unwrap();
         }
@@ -43,7 +51,7 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
 
     #[doc(hidden)]
     /// Write the column index prefix.
-    fn prepare_index_columns(&self, columns: &[IndexColumn], sql: &mut SqlWriter) {
+    fn prepare_index_columns(&self, columns: &[IndexColumn], sql: &mut dyn SqlWriter) {
         write!(sql, " (").unwrap();
         columns.iter().fold(true, |first, col| {
             if !first {
@@ -64,7 +72,7 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
 
     #[doc(hidden)]
     /// Write index name.
-    fn prepare_index_name(&self, name: &Option<String>, sql: &mut SqlWriter) {
+    fn prepare_index_name(&self, name: &Option<String>, sql: &mut dyn SqlWriter) {
         if let Some(name) = name {
             write!(sql, "{}{}{}", self.quote(), name, self.quote()).unwrap();
         }

--- a/src/backend/index_builder.rs
+++ b/src/backend/index_builder.rs
@@ -9,10 +9,8 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
         create: &IndexCreateStatement,
         sql: &mut dyn SqlWriter,
     ) {
-        if create.index.name.is_some() {
-            write!(sql, "CONSTRAINT ").unwrap();
-            self.prepare_index_name(&create.index.name, sql);
-            write!(sql, " ").unwrap();
+        if let Some(name) = &create.index.name {
+            write!(sql, "CONSTRAINT {}{}{} ", self.quote(), name, self.quote()).unwrap();
         }
 
         self.prepare_index_prefix(create, sql);
@@ -68,13 +66,5 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
             false
         });
         write!(sql, ")").unwrap();
-    }
-
-    #[doc(hidden)]
-    /// Write index name.
-    fn prepare_index_name(&self, name: &Option<String>, sql: &mut dyn SqlWriter) {
-        if let Some(name) = name {
-            write!(sql, "{}{}{}", self.quote(), name, self.quote()).unwrap();
-        }
     }
 }

--- a/src/backend/index_builder.rs
+++ b/src/backend/index_builder.rs
@@ -52,7 +52,7 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
     #[doc(hidden)]
     /// Write the column index prefix.
     fn prepare_index_columns(&self, columns: &[IndexColumn], sql: &mut dyn SqlWriter) {
-        write!(sql, " (").unwrap();
+        write!(sql, "(").unwrap();
         columns.iter().fold(true, |first, col| {
             if !first {
                 write!(sql, ", ").unwrap();

--- a/src/backend/index_builder.rs
+++ b/src/backend/index_builder.rs
@@ -57,7 +57,7 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            col.name.prepare(sql, self.quote());
+            col.name.prepare(sql.as_writer(), self.quote());
             self.write_column_index_prefix(&col.prefix, sql);
             if let Some(order) = &col.order {
                 match order {

--- a/src/backend/mysql/foreign_key.rs
+++ b/src/backend/mysql/foreign_key.rs
@@ -50,7 +50,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            col.prepare(sql, self.quote());
+            col.prepare(sql.as_writer(), self.quote());
             false
         });
         write!(sql, ")").unwrap();
@@ -70,7 +70,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                col.prepare(sql, self.quote());
+                col.prepare(sql.as_writer(), self.quote());
                 false
             });
         write!(sql, ")").unwrap();

--- a/src/backend/mysql/foreign_key.rs
+++ b/src/backend/mysql/foreign_key.rs
@@ -1,6 +1,13 @@
 use super::*;
 
 impl ForeignKeyBuilder for MysqlQueryBuilder {
+    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
+        match table_ref {
+            TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
+            _ => panic!("Not supported"),
+        }
+    }
+
     fn prepare_foreign_key_drop_statement_internal(
         &self,
         drop: &ForeignKeyDropStatement,
@@ -83,13 +90,6 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
         if let Some(foreign_key_action) = &create.foreign_key.on_update {
             write!(sql, " ON UPDATE ").unwrap();
             self.prepare_foreign_key_action(foreign_key_action, sql);
-        }
-    }
-
-    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
-        match table_ref {
-            TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
-            _ => panic!("Not supported"),
         }
     }
 }

--- a/src/backend/mysql/foreign_key.rs
+++ b/src/backend/mysql/foreign_key.rs
@@ -45,7 +45,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
         }
         write!(sql, " FOREIGN KEY ").unwrap();
 
-        write!(sql, " (").unwrap();
+        write!(sql, "(").unwrap();
         create.foreign_key.columns.iter().fold(true, |first, col| {
             if !first {
                 write!(sql, ", ").unwrap();

--- a/src/backend/mysql/foreign_key.rs
+++ b/src/backend/mysql/foreign_key.rs
@@ -4,7 +4,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
     fn prepare_foreign_key_drop_statement_internal(
         &self,
         drop: &ForeignKeyDropStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
         mode: Mode,
     ) {
         if mode == Mode::Alter {
@@ -24,7 +24,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
     fn prepare_foreign_key_create_statement_internal(
         &self,
         create: &ForeignKeyCreateStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
         mode: Mode,
     ) {
         if mode == Mode::Alter {
@@ -86,7 +86,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
         }
     }
 
-    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut SqlWriter) {
+    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
             _ => panic!("Not supported"),

--- a/src/backend/mysql/index.rs
+++ b/src/backend/mysql/index.rs
@@ -7,11 +7,16 @@ impl IndexBuilder for MysqlQueryBuilder {
         sql: &mut dyn SqlWriter,
     ) {
         self.prepare_index_prefix(create, sql);
-        write!(sql, "KEY ").unwrap();
+        write!(sql, " KEY ").unwrap();
 
-        self.prepare_index_name(&create.index.name, sql);
+        if let Some(name) = &create.index.name {
+            write!(sql, "{}{}{} ", self.quote(), name, self.quote()).unwrap();
+        }
 
         self.prepare_index_type(&create.index_type, sql);
+        if matches!(create.index_type, Some(IndexType::FullText)) {
+            write!(sql, " ").unwrap();
+        }
 
         self.prepare_index_columns(&create.index.columns, sql);
     }
@@ -23,9 +28,16 @@ impl IndexBuilder for MysqlQueryBuilder {
     ) {
         write!(sql, "CREATE ").unwrap();
         self.prepare_index_prefix(create, sql);
-        write!(sql, "INDEX ").unwrap();
+        if create.unique || create.primary || matches!(create.index_type, Some(IndexType::FullText))
+        {
+            write!(sql, " INDEX ").unwrap();
+        } else {
+            write!(sql, "INDEX ").unwrap();
+        }
 
-        self.prepare_index_name(&create.index.name, sql);
+        if let Some(name) = &create.index.name {
+            write!(sql, "{}{}{}", self.quote(), name, self.quote()).unwrap();
+        }
 
         write!(sql, " ON ").unwrap();
         if let Some(table) = &create.table {
@@ -75,13 +87,13 @@ impl IndexBuilder for MysqlQueryBuilder {
 
     fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut dyn SqlWriter) {
         if create.primary {
-            write!(sql, "PRIMARY ").unwrap();
+            write!(sql, "PRIMARY").unwrap();
         }
         if create.unique {
-            write!(sql, "UNIQUE ").unwrap();
+            write!(sql, "UNIQUE").unwrap();
         }
         if matches!(create.index_type, Some(IndexType::FullText)) {
-            write!(sql, "FULLTEXT ").unwrap();
+            write!(sql, "FULLTEXT").unwrap();
         }
     }
 }

--- a/src/backend/mysql/index.rs
+++ b/src/backend/mysql/index.rs
@@ -1,7 +1,11 @@
 use super::*;
 
 impl IndexBuilder for MysqlQueryBuilder {
-    fn prepare_table_index_expression(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
+    fn prepare_table_index_expression(
+        &self,
+        create: &IndexCreateStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
         self.prepare_index_prefix(create, sql);
         write!(sql, "KEY ").unwrap();
 
@@ -12,7 +16,11 @@ impl IndexBuilder for MysqlQueryBuilder {
         self.prepare_index_columns(&create.index.columns, sql);
     }
 
-    fn prepare_index_create_statement(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
+    fn prepare_index_create_statement(
+        &self,
+        create: &IndexCreateStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
         write!(sql, "CREATE ").unwrap();
         self.prepare_index_prefix(create, sql);
         write!(sql, "INDEX ").unwrap();
@@ -29,7 +37,7 @@ impl IndexBuilder for MysqlQueryBuilder {
         self.prepare_index_type(&create.index_type, sql);
     }
 
-    fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut SqlWriter) {
+    fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "DROP INDEX ").unwrap();
         if let Some(name) = &drop.index.name {
             write!(sql, "`{}`", name).unwrap();
@@ -40,7 +48,7 @@ impl IndexBuilder for MysqlQueryBuilder {
             self.prepare_table_ref_index_stmt(table, sql);
         }
     }
-    fn prepare_index_type(&self, col_index_type: &Option<IndexType>, sql: &mut SqlWriter) {
+    fn prepare_index_type(&self, col_index_type: &Option<IndexType>, sql: &mut dyn SqlWriter) {
         if let Some(index_type) = col_index_type {
             if !matches!(index_type, IndexType::FullText) {
                 write!(
@@ -58,7 +66,7 @@ impl IndexBuilder for MysqlQueryBuilder {
         }
     }
 
-    fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
+    fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut dyn SqlWriter) {
         if create.primary {
             write!(sql, "PRIMARY ").unwrap();
         }
@@ -70,7 +78,7 @@ impl IndexBuilder for MysqlQueryBuilder {
         }
     }
 
-    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut SqlWriter) {
+    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
             _ => panic!("Not supported"),

--- a/src/backend/mysql/index.rs
+++ b/src/backend/mysql/index.rs
@@ -31,12 +31,18 @@ impl IndexBuilder for MysqlQueryBuilder {
         if let Some(table) = &create.table {
             self.prepare_table_ref_index_stmt(table, sql);
         }
-
+        write!(sql, " ").unwrap();
         self.prepare_index_columns(&create.index.columns, sql);
 
         self.prepare_index_type(&create.index_type, sql);
     }
 
+    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
+        match table_ref {
+            TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
+            _ => panic!("Not supported"),
+        }
+    }
     fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "DROP INDEX ").unwrap();
         if let Some(name) = &drop.index.name {
@@ -48,6 +54,7 @@ impl IndexBuilder for MysqlQueryBuilder {
             self.prepare_table_ref_index_stmt(table, sql);
         }
     }
+
     fn prepare_index_type(&self, col_index_type: &Option<IndexType>, sql: &mut dyn SqlWriter) {
         if let Some(index_type) = col_index_type {
             if !matches!(index_type, IndexType::FullText) {
@@ -75,13 +82,6 @@ impl IndexBuilder for MysqlQueryBuilder {
         }
         if matches!(create.index_type, Some(IndexType::FullText)) {
             write!(sql, "FULLTEXT ").unwrap();
-        }
-    }
-
-    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
-        match table_ref {
-            TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
-            _ => panic!("Not supported"),
         }
     }
 }

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -52,7 +52,7 @@ impl QueryBuilder for MysqlQueryBuilder {
 
     fn prepare_on_conflict_excluded_table(&self, col: &DynIden, sql: &mut dyn SqlWriter) {
         write!(sql, "VALUES(").unwrap();
-        col.prepare(sql, self.quote());
+        col.prepare(sql.as_writer(), self.quote());
         write!(sql, ")").unwrap();
     }
 

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -43,7 +43,7 @@ impl QueryBuilder for MysqlQueryBuilder {
     }
 
     fn prepare_on_conflict_keywords(&self, sql: &mut dyn SqlWriter) {
-        write!(sql, " ON DUPLICATE KEY ").unwrap();
+        write!(sql, " ON DUPLICATE KEY").unwrap();
     }
 
     fn prepare_on_conflict_do_update_keywords(&self, sql: &mut dyn SqlWriter) {
@@ -74,5 +74,9 @@ impl QueryBuilder for MysqlQueryBuilder {
 
     fn values_list_tuple_prefix(&self) -> &str {
         "ROW"
+    }
+
+    fn prepare_value(&self, value: &Value, sql: &mut dyn SqlWriter) {
+        sql.push_param(value.clone(), self as _);
     }
 }

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -118,17 +118,8 @@ impl TableBuilder for MysqlQueryBuilder {
         }
     }
 
-    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut dyn SqlWriter) {
-        match column_spec {
-            ColumnSpec::Null => write!(sql, "NULL"),
-            ColumnSpec::NotNull => write!(sql, "NOT NULL"),
-            ColumnSpec::Default(value) => write!(sql, "DEFAULT {}", self.value_to_string(value)),
-            ColumnSpec::AutoIncrement => write!(sql, "AUTO_INCREMENT"),
-            ColumnSpec::UniqueKey => write!(sql, "UNIQUE"),
-            ColumnSpec::PrimaryKey => write!(sql, "PRIMARY KEY"),
-            ColumnSpec::Extra(string) => write!(sql, "{}", string),
-        }
-        .unwrap()
+    fn column_spec_auto_increment_keyword(&self) -> &str {
+        "AUTO_INCREMENT"
     }
 
     fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut dyn SqlWriter) {

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl TableBuilder for MysqlQueryBuilder {
-    fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut SqlWriter) {
+    fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter) {
         column_def.name.prepare(sql, self.quote());
 
         if let Some(column_type) = &column_def.types {
@@ -15,7 +15,7 @@ impl TableBuilder for MysqlQueryBuilder {
         }
     }
 
-    fn prepare_column_type(&self, column_type: &ColumnType, sql: &mut SqlWriter) {
+    fn prepare_column_type(&self, column_type: &ColumnType, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "{}",
@@ -118,7 +118,7 @@ impl TableBuilder for MysqlQueryBuilder {
         }
     }
 
-    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut SqlWriter) {
+    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut dyn SqlWriter) {
         match column_spec {
             ColumnSpec::Null => write!(sql, "NULL"),
             ColumnSpec::NotNull => write!(sql, "NOT NULL"),
@@ -131,7 +131,7 @@ impl TableBuilder for MysqlQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut SqlWriter) {
+    fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut dyn SqlWriter) {
         if alter.options.is_empty() {
             panic!("No alter option found")
         };
@@ -193,7 +193,11 @@ impl TableBuilder for MysqlQueryBuilder {
         });
     }
 
-    fn prepare_table_rename_statement(&self, rename: &TableRenameStatement, sql: &mut SqlWriter) {
+    fn prepare_table_rename_statement(
+        &self,
+        rename: &TableRenameStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
         write!(sql, "RENAME TABLE ").unwrap();
         if let Some(from_name) = &rename.from_name {
             self.prepare_table_ref_table_stmt(from_name, sql);

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl TableBuilder for MysqlQueryBuilder {
     fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter) {
-        column_def.name.prepare(sql, self.quote());
+        column_def.name.prepare(sql.as_writer(), self.quote());
 
         if let Some(column_type) = &column_def.types {
             write!(sql, " ").unwrap();
@@ -161,13 +161,13 @@ impl TableBuilder for MysqlQueryBuilder {
                 }
                 TableAlterOption::RenameColumn(from_name, to_name) => {
                     write!(sql, "RENAME COLUMN ").unwrap();
-                    from_name.prepare(sql, self.quote());
+                    from_name.prepare(sql.as_writer(), self.quote());
                     write!(sql, " TO ").unwrap();
-                    to_name.prepare(sql, self.quote());
+                    to_name.prepare(sql.as_writer(), self.quote());
                 }
                 TableAlterOption::DropColumn(column_name) => {
                     write!(sql, "DROP COLUMN ").unwrap();
-                    column_name.prepare(sql, self.quote());
+                    column_name.prepare(sql.as_writer(), self.quote());
                 }
                 TableAlterOption::DropForeignKey(name) => {
                     let mut foreign_key = TableForeignKey::new();

--- a/src/backend/postgres/foreign_key.rs
+++ b/src/backend/postgres/foreign_key.rs
@@ -49,7 +49,7 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            col.prepare(sql, self.quote());
+            col.prepare(sql.as_writer(), self.quote());
             false
         });
         write!(sql, ")").unwrap();
@@ -69,7 +69,7 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                col.prepare(sql, self.quote());
+                col.prepare(sql.as_writer(), self.quote());
                 false
             });
         write!(sql, ")").unwrap();

--- a/src/backend/postgres/foreign_key.rs
+++ b/src/backend/postgres/foreign_key.rs
@@ -4,7 +4,7 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
     fn prepare_foreign_key_drop_statement_internal(
         &self,
         drop: &ForeignKeyDropStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
         mode: Mode,
     ) {
         if mode == Mode::Alter {
@@ -24,7 +24,7 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
     fn prepare_foreign_key_create_statement_internal(
         &self,
         create: &ForeignKeyCreateStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
         mode: Mode,
     ) {
         if mode == Mode::Alter {
@@ -85,7 +85,7 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
         }
     }
 
-    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut SqlWriter) {
+    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(_)
             | TableRef::SchemaTable(_, _)

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -22,8 +22,17 @@ impl IndexBuilder for PostgresQueryBuilder {
         }
 
         self.prepare_index_type(&create.index_type, sql);
-
+        write!(sql, " ").unwrap();
         self.prepare_index_columns(&create.index.columns, sql);
+    }
+
+    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
+        match table_ref {
+            TableRef::Table(_) | TableRef::SchemaTable(_, _) => {
+                self.prepare_table_ref_iden(table_ref, sql)
+            }
+            _ => panic!("Not supported"),
+        }
     }
 
     fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut dyn SqlWriter) {
@@ -65,15 +74,6 @@ impl IndexBuilder for PostgresQueryBuilder {
         }
         if create.unique {
             write!(sql, "UNIQUE ").unwrap();
-        }
-    }
-
-    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
-        match table_ref {
-            TableRef::Table(_) | TableRef::SchemaTable(_, _) => {
-                self.prepare_table_ref_iden(table_ref, sql)
-            }
-            _ => panic!("Not supported"),
         }
     }
 }

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -1,7 +1,11 @@
 use super::*;
 
 impl IndexBuilder for PostgresQueryBuilder {
-    fn prepare_index_create_statement(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
+    fn prepare_index_create_statement(
+        &self,
+        create: &IndexCreateStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
         write!(sql, "CREATE ").unwrap();
         self.prepare_index_prefix(create, sql);
         write!(sql, "INDEX ").unwrap();
@@ -22,7 +26,7 @@ impl IndexBuilder for PostgresQueryBuilder {
         self.prepare_index_columns(&create.index.columns, sql);
     }
 
-    fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut SqlWriter) {
+    fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "DROP INDEX ").unwrap();
         if let Some(table) = &drop.table {
             match table {
@@ -39,7 +43,7 @@ impl IndexBuilder for PostgresQueryBuilder {
         }
     }
 
-    fn prepare_index_type(&self, col_index_type: &Option<IndexType>, sql: &mut SqlWriter) {
+    fn prepare_index_type(&self, col_index_type: &Option<IndexType>, sql: &mut dyn SqlWriter) {
         if let Some(index_type) = col_index_type {
             write!(
                 sql,
@@ -55,7 +59,7 @@ impl IndexBuilder for PostgresQueryBuilder {
         }
     }
 
-    fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
+    fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut dyn SqlWriter) {
         if create.primary {
             write!(sql, "PRIMARY KEY ").unwrap();
         }
@@ -64,7 +68,7 @@ impl IndexBuilder for PostgresQueryBuilder {
         }
     }
 
-    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut SqlWriter) {
+    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(_) | TableRef::SchemaTable(_, _) => {
                 self.prepare_table_ref_iden(table_ref, sql)

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -14,7 +14,9 @@ impl IndexBuilder for PostgresQueryBuilder {
             write!(sql, "IF NOT EXISTS ").unwrap();
         }
 
-        self.prepare_index_name(&create.index.name, sql);
+        if let Some(name) = &create.index.name {
+            write!(sql, "{}{}{}", self.quote(), name, self.quote()).unwrap();
+        }
 
         write!(sql, " ON ").unwrap();
         if let Some(table) = &create.table {

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -32,7 +32,7 @@ impl IndexBuilder for PostgresQueryBuilder {
             match table {
                 TableRef::Table(_) => {}
                 TableRef::SchemaTable(schema, _) => {
-                    schema.prepare(sql, self.quote());
+                    schema.prepare(sql.as_writer(), self.quote());
                     write!(sql, ".").unwrap();
                 }
                 _ => panic!("Not supported"),

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -101,4 +101,8 @@ impl QueryBuilder for PostgresQueryBuilder {
             _ => {}
         };
     }
+
+    fn prepare_value(&self, value: &Value, sql: &mut dyn SqlWriter) {
+        sql.push_param(value.clone(), self as _);
+    }
 }

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -93,7 +93,7 @@ impl QueryBuilder for PostgresQueryBuilder {
                     if !first {
                         write!(sql, ", ").unwrap();
                     }
-                    c.prepare(sql, self.quote());
+                    c.prepare(sql.as_writer(), self.quote());
                     false
                 });
                 write!(sql, ")").unwrap();

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl TableBuilder for PostgresQueryBuilder {
     fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter) {
-        column_def.name.prepare(sql, self.quote());
+        column_def.name.prepare(sql.as_writer(), self.quote());
 
         self.prepare_column_type_check_auto_increment(column_def, sql);
 
@@ -150,7 +150,7 @@ impl TableBuilder for PostgresQueryBuilder {
                 TableAlterOption::ModifyColumn(column_def) => {
                     if column_def.types.is_some() {
                         write!(sql, "ALTER COLUMN ").unwrap();
-                        column_def.name.prepare(sql, self.quote());
+                        column_def.name.prepare(sql.as_writer(), self.quote());
                         write!(sql, " TYPE").unwrap();
                         self.prepare_column_type_check_auto_increment(column_def, sql);
                     }
@@ -163,7 +163,7 @@ impl TableBuilder for PostgresQueryBuilder {
                         } else {
                             write!(sql, " ALTER COLUMN ").unwrap();
                         }
-                        column_def.name.prepare(sql, self.quote());
+                        column_def.name.prepare(sql.as_writer(), self.quote());
                         match column_spec {
                             ColumnSpec::Null => write!(sql, " DROP NOT NULL").unwrap(),
                             _ => {
@@ -175,13 +175,13 @@ impl TableBuilder for PostgresQueryBuilder {
                 }
                 TableAlterOption::RenameColumn(from_name, to_name) => {
                     write!(sql, "RENAME COLUMN ").unwrap();
-                    from_name.prepare(sql, self.quote());
+                    from_name.prepare(sql.as_writer(), self.quote());
                     write!(sql, " TO ").unwrap();
-                    to_name.prepare(sql, self.quote());
+                    to_name.prepare(sql.as_writer(), self.quote());
                 }
                 TableAlterOption::DropColumn(column_name) => {
                     write!(sql, "DROP COLUMN ").unwrap();
-                    column_name.prepare(sql, self.quote());
+                    column_name.prepare(sql.as_writer(), self.quote());
                 }
                 TableAlterOption::DropForeignKey(name) => {
                     let mut foreign_key = TableForeignKey::new();

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl TableBuilder for PostgresQueryBuilder {
-    fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut SqlWriter) {
+    fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter) {
         column_def.name.prepare(sql, self.quote());
 
         self.prepare_column_type_check_auto_increment(column_def, sql);
@@ -15,7 +15,7 @@ impl TableBuilder for PostgresQueryBuilder {
         }
     }
 
-    fn prepare_column_type(&self, column_type: &ColumnType, sql: &mut SqlWriter) {
+    fn prepare_column_type(&self, column_type: &ColumnType, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "{}",
@@ -107,7 +107,7 @@ impl TableBuilder for PostgresQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut SqlWriter) {
+    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut dyn SqlWriter) {
         match column_spec {
             ColumnSpec::Null => write!(sql, "NULL"),
             ColumnSpec::NotNull => write!(sql, "NOT NULL"),
@@ -122,7 +122,7 @@ impl TableBuilder for PostgresQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut SqlWriter) {
+    fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut dyn SqlWriter) {
         if alter.options.is_empty() {
             panic!("No alter option found")
         };
@@ -207,7 +207,11 @@ impl TableBuilder for PostgresQueryBuilder {
         });
     }
 
-    fn prepare_table_rename_statement(&self, rename: &TableRenameStatement, sql: &mut SqlWriter) {
+    fn prepare_table_rename_statement(
+        &self,
+        rename: &TableRenameStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
         write!(sql, "ALTER TABLE ").unwrap();
         if let Some(from_name) = &rename.from_name {
             self.prepare_table_ref_table_stmt(from_name, sql);
@@ -223,7 +227,7 @@ impl PostgresQueryBuilder {
     fn prepare_column_type_check_auto_increment(
         &self,
         column_def: &ColumnDef,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
     ) {
         if let Some(column_type) = &column_def.types {
             write!(sql, " ").unwrap();

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -107,19 +107,8 @@ impl TableBuilder for PostgresQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut dyn SqlWriter) {
-        match column_spec {
-            ColumnSpec::Null => write!(sql, "NULL"),
-            ColumnSpec::NotNull => write!(sql, "NOT NULL"),
-            ColumnSpec::Default(value) => {
-                write!(sql, "DEFAULT {}", self.value_to_string(value))
-            }
-            ColumnSpec::AutoIncrement => write!(sql, ""),
-            ColumnSpec::UniqueKey => write!(sql, "UNIQUE"),
-            ColumnSpec::PrimaryKey => write!(sql, "PRIMARY KEY"),
-            ColumnSpec::Extra(string) => write!(sql, "{}", string),
-        }
-        .unwrap()
+    fn column_spec_auto_increment_keyword(&self) -> &str {
+        ""
     }
 
     fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut dyn SqlWriter) {
@@ -161,7 +150,7 @@ impl TableBuilder for PostgresQueryBuilder {
                         if column_def.types.is_some() {
                             write!(sql, ", ALTER COLUMN ").unwrap();
                         } else {
-                            write!(sql, " ALTER COLUMN ").unwrap();
+                            write!(sql, "ALTER COLUMN ").unwrap();
                         }
                         column_def.name.prepare(sql.as_writer(), self.quote());
                         match column_spec {

--- a/src/backend/postgres/types.rs
+++ b/src/backend/postgres/types.rs
@@ -2,12 +2,7 @@ use super::*;
 use crate::extension::postgres::*;
 
 impl TypeBuilder for PostgresQueryBuilder {
-    fn prepare_type_create_statement(
-        &self,
-        create: &TypeCreateStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_type_create_statement(&self, create: &TypeCreateStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "CREATE TYPE ").unwrap();
 
         if let Some(name) = &create.name {
@@ -26,19 +21,14 @@ impl TypeBuilder for PostgresQueryBuilder {
                 if count > 0 {
                     write!(sql, ", ").unwrap();
                 }
-                self.prepare_value(&val.to_string().into(), sql, collector);
+                self.prepare_value(&val.to_string().into(), sql);
             }
 
             write!(sql, ")").unwrap();
         }
     }
 
-    fn prepare_type_drop_statement(
-        &self,
-        drop: &TypeDropStatement,
-        sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_type_drop_statement(&self, drop: &TypeDropStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "DROP TYPE ").unwrap();
 
         if drop.if_exists {
@@ -55,12 +45,7 @@ impl TypeBuilder for PostgresQueryBuilder {
         }
     }
 
-    fn prepare_type_alter_statement(
-        &self,
-        alter: &TypeAlterStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_type_alter_statement(&self, alter: &TypeAlterStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "ALTER TYPE ").unwrap();
 
         if let Some(name) = &alter.name {
@@ -68,13 +53,13 @@ impl TypeBuilder for PostgresQueryBuilder {
         }
 
         if let Some(option) = &alter.option {
-            self.prepare_alter_type_opt(option, sql, collector)
+            self.prepare_alter_type_opt(option, sql)
         }
     }
 }
 
 impl PostgresQueryBuilder {
-    fn prepare_create_as_type(&self, as_type: &TypeAs, sql: &mut SqlWriter) {
+    fn prepare_create_as_type(&self, as_type: &TypeAs, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "{}",
@@ -85,7 +70,7 @@ impl PostgresQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_drop_type_opt(&self, opt: &TypeDropOpt, sql: &mut SqlWriter) {
+    fn prepare_drop_type_opt(&self, opt: &TypeDropOpt, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "{}",
@@ -97,40 +82,35 @@ impl PostgresQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_alter_type_opt(
-        &self,
-        opt: &TypeAlterOpt,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_alter_type_opt(&self, opt: &TypeAlterOpt, sql: &mut dyn SqlWriter) {
         match opt {
             TypeAlterOpt::Add(value, placement) => {
                 write!(sql, " ADD VALUE ").unwrap();
                 match placement {
                     Some(add_option) => match add_option {
                         TypeAlterAddOpt::Before(before_value) => {
-                            self.prepare_value(&value.to_string().into(), sql, collector);
+                            self.prepare_value(&value.to_string().into(), sql);
                             write!(sql, " BEFORE ").unwrap();
-                            self.prepare_value(&before_value.to_string().into(), sql, collector);
+                            self.prepare_value(&before_value.to_string().into(), sql);
                         }
                         TypeAlterAddOpt::After(after_value) => {
-                            self.prepare_value(&value.to_string().into(), sql, collector);
+                            self.prepare_value(&value.to_string().into(), sql);
                             write!(sql, " AFTER ").unwrap();
-                            self.prepare_value(&after_value.to_string().into(), sql, collector);
+                            self.prepare_value(&after_value.to_string().into(), sql);
                         }
                     },
-                    None => self.prepare_value(&value.to_string().into(), sql, collector),
+                    None => self.prepare_value(&value.to_string().into(), sql),
                 }
             }
             TypeAlterOpt::Rename(new_name) => {
                 write!(sql, " RENAME TO ").unwrap();
-                self.prepare_value(&new_name.to_string().into(), sql, collector);
+                self.prepare_value(&new_name.to_string().into(), sql);
             }
             TypeAlterOpt::RenameValue(existing, new_name) => {
                 write!(sql, " RENAME VALUE ").unwrap();
-                self.prepare_value(&existing.to_string().into(), sql, collector);
+                self.prepare_value(&existing.to_string().into(), sql);
                 write!(sql, " TO ").unwrap();
-                self.prepare_value(&new_name.to_string().into(), sql, collector);
+                self.prepare_value(&new_name.to_string().into(), sql);
             }
         }
     }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -74,7 +74,6 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         write!(sql, "SELECT ").unwrap();
 
         if let Some(distinct) = &select.distinct {
-            write!(sql, " ").unwrap();
             self.prepare_select_distinct(distinct, sql);
             write!(sql, " ").unwrap();
         }
@@ -415,7 +414,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 write!(sql, " OVER ").unwrap();
                 write!(sql, "( ").unwrap();
                 self.prepare_window_statement(window, sql);
-                write!(sql, " ) ").unwrap();
+                write!(sql, " )").unwrap();
             }
             None => {}
         };
@@ -1233,17 +1232,17 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     /// Translate [`Frame`] into SQL statement.
     fn prepare_frame(&self, frame: &Frame, sql: &mut dyn SqlWriter) {
         match *frame {
-            Frame::UnboundedPreceding => write!(sql, " UNBOUNDED PRECEDING ").unwrap(),
+            Frame::UnboundedPreceding => write!(sql, "UNBOUNDED PRECEDING").unwrap(),
             Frame::Preceding(v) => {
                 self.prepare_value(&Some(v).into(), sql);
-                write!(sql, " PRECEDING ").unwrap();
+                write!(sql, "PRECEDING").unwrap();
             }
-            Frame::CurrentRow => write!(sql, " CURRENT ROW ").unwrap(),
+            Frame::CurrentRow => write!(sql, "CURRENT ROW").unwrap(),
             Frame::Following(v) => {
                 self.prepare_value(&Some(v).into(), sql);
-                write!(sql, " FOLLOWING ").unwrap();
+                write!(sql, "FOLLOWING").unwrap();
             }
-            Frame::UnboundedFollowing => write!(sql, " UNBOUNDED FOLLOWING ").unwrap(),
+            Frame::UnboundedFollowing => write!(sql, "UNBOUNDED FOLLOWING").unwrap(),
         }
     }
 
@@ -1251,7 +1250,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     /// Translate [`WindowStatement`] into SQL statement.
     fn prepare_window_statement(&self, window: &WindowStatement, sql: &mut dyn SqlWriter) {
         if !window.partition_by.is_empty() {
-            write!(sql, " PARTITION BY ").unwrap();
+            write!(sql, "PARTITION BY ").unwrap();
             window.partition_by.iter().fold(true, |first, expr| {
                 if !first {
                     write!(sql, ", ").unwrap()

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -13,17 +13,12 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`InsertStatement`] into SQL statement.
-    fn prepare_insert_statement(
-        &self,
-        insert: &InsertStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_insert_statement(&self, insert: &InsertStatement, sql: &mut dyn SqlWriter) {
         self.prepare_insert(insert.replace, sql);
 
         if let Some(table) = &insert.table {
             write!(sql, " INTO ").unwrap();
-            self.prepare_table_ref(table, sql, collector);
+            self.prepare_table_ref(table, sql);
             write!(sql, " ").unwrap();
         }
 
@@ -55,7 +50,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                                 if !first {
                                     write!(sql, ", ").unwrap()
                                 }
-                                self.prepare_simple_expr(col, sql, collector);
+                                self.prepare_simple_expr(col, sql);
                                 false
                             });
                             write!(sql, ")").unwrap();
@@ -63,29 +58,24 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                         });
                     }
                     InsertValueSource::Select(select_query) => {
-                        self.prepare_select_statement(select_query.deref(), sql, collector);
+                        self.prepare_select_statement(select_query.deref(), sql);
                     }
                 }
             }
         }
 
-        self.prepare_on_conflict(&insert.on_conflict, sql, collector);
+        self.prepare_on_conflict(&insert.on_conflict, sql);
 
-        self.prepare_returning(&insert.returning, sql, collector);
+        self.prepare_returning(&insert.returning, sql);
     }
 
     /// Translate [`SelectStatement`] into SQL statement.
-    fn prepare_select_statement(
-        &self,
-        select: &SelectStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_select_statement(&self, select: &SelectStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "SELECT ").unwrap();
 
         if let Some(distinct) = &select.distinct {
             write!(sql, " ").unwrap();
-            self.prepare_select_distinct(distinct, sql, collector);
+            self.prepare_select_distinct(distinct, sql);
             write!(sql, " ").unwrap();
         }
 
@@ -93,7 +83,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             if !first {
                 write!(sql, ", ").unwrap()
             }
-            self.prepare_select_expr(expr, sql, collector);
+            self.prepare_select_expr(expr, sql);
             false
         });
 
@@ -103,7 +93,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 if !first {
                     write!(sql, ", ").unwrap()
                 }
-                self.prepare_table_ref(table_ref, sql, collector);
+                self.prepare_table_ref(table_ref, sql);
                 false
             });
         }
@@ -111,11 +101,11 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         if !select.join.is_empty() {
             for expr in select.join.iter() {
                 write!(sql, " ").unwrap();
-                self.prepare_join_expr(expr, sql, collector);
+                self.prepare_join_expr(expr, sql);
             }
         }
 
-        self.prepare_condition(&select.r#where, "WHERE", sql, collector);
+        self.prepare_condition(&select.r#where, "WHERE", sql);
 
         if !select.groups.is_empty() {
             write!(sql, " GROUP BY ").unwrap();
@@ -123,12 +113,12 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 if !first {
                     write!(sql, ", ").unwrap()
                 }
-                self.prepare_simple_expr(expr, sql, collector);
+                self.prepare_simple_expr(expr, sql);
                 false
             });
         }
 
-        self.prepare_condition(&select.having, "HAVING", sql, collector);
+        self.prepare_condition(&select.having, "HAVING", sql);
 
         if !select.unions.is_empty() {
             select.unions.iter().for_each(|(union_type, query)| {
@@ -136,7 +126,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                     UnionType::Distinct => write!(sql, " UNION ").unwrap(),
                     UnionType::All => write!(sql, " UNION ALL ").unwrap(),
                 }
-                self.prepare_select_statement(query, sql, collector);
+                self.prepare_select_statement(query, sql);
             });
         }
 
@@ -146,45 +136,40 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 if !first {
                     write!(sql, ", ").unwrap()
                 }
-                self.prepare_order_expr(expr, sql, collector);
+                self.prepare_order_expr(expr, sql);
                 false
             });
         }
 
         if let Some(limit) = &select.limit {
             write!(sql, " LIMIT ").unwrap();
-            self.prepare_value(limit, sql, collector);
+            self.prepare_value(limit, sql);
         }
 
         if let Some(offset) = &select.offset {
             write!(sql, " OFFSET ").unwrap();
-            self.prepare_value(offset, sql, collector);
+            self.prepare_value(offset, sql);
         }
 
         if let Some(lock) = &select.lock {
             write!(sql, " ").unwrap();
-            self.prepare_select_lock(lock, sql, collector);
+            self.prepare_select_lock(lock, sql);
         }
 
         if let Some((name, query)) = &select.window {
             write!(sql, " WINDOW ").unwrap();
             name.prepare(sql, self.quote());
             write!(sql, " AS ").unwrap();
-            self.prepare_window_statement(query, sql, collector);
+            self.prepare_window_statement(query, sql);
         }
     }
 
     /// Translate [`UpdateStatement`] into SQL statement.
-    fn prepare_update_statement(
-        &self,
-        update: &UpdateStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_update_statement(&self, update: &UpdateStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "UPDATE ").unwrap();
 
         if let Some(table) = &update.table {
-            self.prepare_table_ref(table, sql, collector);
+            self.prepare_table_ref(table, sql);
         }
 
         write!(sql, " SET ").unwrap();
@@ -195,11 +180,11 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             }
             let (k, v) = row;
             write!(sql, "{}{}{} = ", self.quote(), k, self.quote()).unwrap();
-            self.prepare_simple_expr(v, sql, collector);
+            self.prepare_simple_expr(v, sql);
             false
         });
 
-        self.prepare_condition(&update.wherei, "WHERE", sql, collector);
+        self.prepare_condition(&update.wherei, "WHERE", sql);
 
         if !update.orders.is_empty() {
             write!(sql, " ORDER BY ").unwrap();
@@ -207,34 +192,29 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                self.prepare_order_expr(expr, sql, collector);
+                self.prepare_order_expr(expr, sql);
                 false
             });
         }
 
         if let Some(limit) = &update.limit {
             write!(sql, " LIMIT ").unwrap();
-            self.prepare_value(limit, sql, collector);
+            self.prepare_value(limit, sql);
         }
 
-        self.prepare_returning(&update.returning, sql, collector);
+        self.prepare_returning(&update.returning, sql);
     }
 
     /// Translate [`DeleteStatement`] into SQL statement.
-    fn prepare_delete_statement(
-        &self,
-        delete: &DeleteStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_delete_statement(&self, delete: &DeleteStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "DELETE ").unwrap();
 
         if let Some(table) = &delete.table {
             write!(sql, "FROM ").unwrap();
-            self.prepare_table_ref(table, sql, collector);
+            self.prepare_table_ref(table, sql);
         }
 
-        self.prepare_condition(&delete.wherei, "WHERE", sql, collector);
+        self.prepare_condition(&delete.wherei, "WHERE", sql);
 
         if !delete.orders.is_empty() {
             write!(sql, " ORDER BY ").unwrap();
@@ -242,50 +222,40 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                self.prepare_order_expr(expr, sql, collector);
+                self.prepare_order_expr(expr, sql);
                 false
             });
         }
 
         if let Some(limit) = &delete.limit {
             write!(sql, " LIMIT ").unwrap();
-            self.prepare_value(limit, sql, collector);
+            self.prepare_value(limit, sql);
         }
 
-        self.prepare_returning(&delete.returning, sql, collector);
+        self.prepare_returning(&delete.returning, sql);
     }
 
     /// Translate [`SimpleExpr`] into SQL statement.
-    fn prepare_simple_expr(
-        &self,
-        simple_expr: &SimpleExpr,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        self.prepare_simple_expr_common(simple_expr, sql, collector);
+    fn prepare_simple_expr(&self, simple_expr: &SimpleExpr, sql: &mut dyn SqlWriter) {
+        self.prepare_simple_expr_common(simple_expr, sql);
     }
 
-    fn prepare_simple_expr_common(
-        &self,
-        simple_expr: &SimpleExpr,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_simple_expr_common(&self, simple_expr: &SimpleExpr, sql: &mut dyn SqlWriter) {
         match simple_expr {
             SimpleExpr::Column(column_ref) => {
                 self.prepare_column_ref(column_ref, sql);
             }
             SimpleExpr::Tuple(exprs) => {
-                self.prepare_tuple(exprs, sql, collector);
+                self.prepare_tuple(exprs, sql);
             }
             SimpleExpr::Unary(op, expr) => {
-                self.prepare_un_oper(op, sql, collector);
+                self.prepare_un_oper(op, sql);
                 write!(sql, " ").unwrap();
-                self.prepare_simple_expr(expr, sql, collector);
+                self.prepare_simple_expr(expr, sql);
             }
             SimpleExpr::FunctionCall(func, exprs) => {
-                self.prepare_function(func, sql, collector);
-                self.prepare_tuple(exprs, sql, collector);
+                self.prepare_function(func, sql);
+                self.prepare_tuple(exprs, sql);
             }
             SimpleExpr::Binary(left, op, right) => {
                 if *op == BinOper::In && right.is_values() && right.get_values().is_empty() {
@@ -294,7 +264,6 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                         &BinOper::Equal,
                         &SimpleExpr::Value(2i32.into()),
                         sql,
-                        collector,
                     );
                 } else if *op == BinOper::NotIn
                     && right.is_values()
@@ -305,19 +274,18 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                         &BinOper::Equal,
                         &SimpleExpr::Value(1i32.into()),
                         sql,
-                        collector,
                     );
                 } else {
-                    self.binary_expr(left, op, right, sql, collector);
+                    self.binary_expr(left, op, right, sql);
                 }
             }
             SimpleExpr::SubQuery(sel) => {
                 write!(sql, "(").unwrap();
-                self.prepare_query_statement(sel.deref(), sql, collector);
+                self.prepare_query_statement(sel.deref(), sql);
                 write!(sql, ")").unwrap();
             }
             SimpleExpr::Value(val) => {
-                self.prepare_value(val, sql, collector);
+                self.prepare_value(val, sql);
             }
             SimpleExpr::Values(list) => {
                 write!(sql, "(").unwrap();
@@ -325,7 +293,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                     if !first {
                         write!(sql, ", ").unwrap();
                     }
-                    self.prepare_value(val, sql, collector);
+                    self.prepare_value(val, sql);
                     false
                 });
                 write!(sql, ")").unwrap();
@@ -346,12 +314,12 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                             }
                             Some(Token::Unquoted(tok)) if numbered => {
                                 if let Ok(num) = tok.parse::<usize>() {
-                                    self.prepare_value(&values[num - 1], sql, collector);
+                                    self.prepare_value(&values[num - 1], sql);
                                 }
                                 tokenizer.next();
                             }
                             _ => {
-                                self.prepare_value(&values[count], sql, collector);
+                                self.prepare_value(&values[count], sql);
                                 count += 1;
                             }
                         },
@@ -360,13 +328,13 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 }
             }
             SimpleExpr::Keyword(keyword) => {
-                self.prepare_keyword(keyword, sql, collector);
+                self.prepare_keyword(keyword, sql);
             }
             SimpleExpr::AsEnum(_, expr) => {
-                self.prepare_simple_expr(expr, sql, collector);
+                self.prepare_simple_expr(expr, sql);
             }
             SimpleExpr::Case(case_stmt) => {
-                self.prepare_case_statement(case_stmt, sql, collector);
+                self.prepare_case_statement(case_stmt, sql);
             }
             SimpleExpr::Constant(val) => {
                 self.prepare_constant(val, sql);
@@ -375,38 +343,28 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`CaseStatement`] into SQL statement.
-    fn prepare_case_statement(
-        &self,
-        stmts: &CaseStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_case_statement(&self, stmts: &CaseStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "(CASE").unwrap();
 
         let CaseStatement { when, r#else } = stmts;
 
         for case in when.iter() {
             write!(sql, " WHEN (").unwrap();
-            self.prepare_condition_where(&case.condition, sql, collector);
+            self.prepare_condition_where(&case.condition, sql);
             write!(sql, ") THEN ").unwrap();
 
-            self.prepare_simple_expr(&case.result.clone().into(), sql, collector);
+            self.prepare_simple_expr(&case.result.clone().into(), sql);
         }
         if let Some(r#else) = r#else.clone() {
             write!(sql, " ELSE ").unwrap();
-            self.prepare_simple_expr(&r#else.into(), sql, collector);
+            self.prepare_simple_expr(&r#else.into(), sql);
         }
 
         write!(sql, " END) ").unwrap();
     }
 
     /// Translate [`SelectDistinct`] into SQL statement.
-    fn prepare_select_distinct(
-        &self,
-        select_distinct: &SelectDistinct,
-        sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_select_distinct(&self, select_distinct: &SelectDistinct, sql: &mut dyn SqlWriter) {
         match select_distinct {
             SelectDistinct::All => write!(sql, "ALL").unwrap(),
             SelectDistinct::Distinct => write!(sql, "DISTINCT").unwrap(),
@@ -415,12 +373,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`LockType`] into SQL statement.
-    fn prepare_select_lock(
-        &self,
-        lock: &LockClause,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_select_lock(&self, lock: &LockClause, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "FOR {}",
@@ -438,7 +391,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                self.prepare_table_ref(table_ref, sql, collector);
+                self.prepare_table_ref(table_ref, sql);
                 false
             });
         }
@@ -451,13 +404,8 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`SelectExpr`] into SQL statement.
-    fn prepare_select_expr(
-        &self,
-        select_expr: &SelectExpr,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        self.prepare_simple_expr(&select_expr.expr, sql, collector);
+    fn prepare_select_expr(&self, select_expr: &SelectExpr, sql: &mut dyn SqlWriter) {
+        self.prepare_simple_expr(&select_expr.expr, sql);
         match &select_expr.window {
             Some(WindowSelectType::Name(name)) => {
                 write!(sql, " OVER ").unwrap();
@@ -466,7 +414,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             Some(WindowSelectType::Query(window)) => {
                 write!(sql, " OVER ").unwrap();
                 write!(sql, "( ").unwrap();
-                self.prepare_window_statement(window, sql, collector);
+                self.prepare_window_statement(window, sql);
                 write!(sql, " ) ").unwrap();
             }
             None => {}
@@ -482,51 +430,36 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`JoinExpr`] into SQL statement.
-    fn prepare_join_expr(
-        &self,
-        join_expr: &JoinExpr,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        self.prepare_join_type(&join_expr.join, sql, collector);
+    fn prepare_join_expr(&self, join_expr: &JoinExpr, sql: &mut dyn SqlWriter) {
+        self.prepare_join_type(&join_expr.join, sql);
         write!(sql, " ").unwrap();
-        self.prepare_join_table_ref(join_expr, sql, collector);
+        self.prepare_join_table_ref(join_expr, sql);
         if let Some(on) = &join_expr.on {
             write!(sql, " ").unwrap();
-            self.prepare_join_on(on, sql, collector);
+            self.prepare_join_on(on, sql);
         }
     }
 
-    fn prepare_join_table_ref(
-        &self,
-        join_expr: &JoinExpr,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_join_table_ref(&self, join_expr: &JoinExpr, sql: &mut dyn SqlWriter) {
         if join_expr.lateral {
             write!(sql, "LATERAL ").unwrap();
         }
-        self.prepare_table_ref(&join_expr.table, sql, collector);
+        self.prepare_table_ref(&join_expr.table, sql);
     }
 
     /// Translate [`TableRef`] into SQL statement.
-    fn prepare_table_ref(
-        &self,
-        table_ref: &TableRef,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_table_ref(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::SubQuery(query, alias) => {
                 write!(sql, "(").unwrap();
-                self.prepare_select_statement(query, sql, collector);
+                self.prepare_select_statement(query, sql);
                 write!(sql, ")").unwrap();
                 write!(sql, " AS ").unwrap();
                 alias.prepare(sql, self.quote());
             }
             TableRef::ValuesList(values, alias) => {
                 write!(sql, "(").unwrap();
-                self.prepare_values_list(values, sql, collector);
+                self.prepare_values_list(values, sql);
                 write!(sql, ")").unwrap();
                 write!(sql, " AS ").unwrap();
                 alias.prepare(sql, self.quote());
@@ -535,7 +468,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         }
     }
 
-    fn prepare_column_ref(&self, column_ref: &ColumnRef, sql: &mut SqlWriter) {
+    fn prepare_column_ref(&self, column_ref: &ColumnRef, sql: &mut dyn SqlWriter) {
         match column_ref {
             ColumnRef::Column(column) => column.prepare(sql, self.quote()),
             ColumnRef::TableColumn(table, column) => {
@@ -561,12 +494,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`UnOper`] into SQL statement.
-    fn prepare_un_oper(
-        &self,
-        un_oper: &UnOper,
-        sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_un_oper(&self, un_oper: &UnOper, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "{}",
@@ -577,12 +505,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         .unwrap();
     }
 
-    fn prepare_bin_oper_common(
-        &self,
-        bin_oper: &BinOper,
-        sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_bin_oper_common(&self, bin_oper: &BinOper, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "{}",
@@ -620,13 +543,8 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`BinOper`] into SQL statement.
-    fn prepare_bin_oper(
-        &self,
-        bin_oper: &BinOper,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        self.prepare_bin_oper_common(bin_oper, sql, collector);
+    fn prepare_bin_oper(&self, bin_oper: &BinOper, sql: &mut dyn SqlWriter) {
+        self.prepare_bin_oper_common(bin_oper, sql);
     }
 
     /// Translate [`LogicalChainOper`] into SQL statement.
@@ -635,8 +553,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         log_chain_oper: &LogicalChainOper,
         i: usize,
         length: usize,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) {
         let (simple_expr, oper) = match log_chain_oper {
             LogicalChainOper::And(simple_expr) => (simple_expr, "AND"),
@@ -655,19 +572,14 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         if need_parentheses {
             write!(sql, "(").unwrap();
         }
-        self.prepare_simple_expr(simple_expr, sql, collector);
+        self.prepare_simple_expr(simple_expr, sql);
         if need_parentheses {
             write!(sql, ")").unwrap();
         }
     }
 
     /// Translate [`Function`] into SQL statement.
-    fn prepare_function_common(
-        &self,
-        function: &Function,
-        sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_function_common(&self, function: &Function, sql: &mut dyn SqlWriter) {
         if let Function::Custom(iden) = function {
             iden.unquoted(sql);
         } else {
@@ -699,41 +611,25 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`QueryStatement`] into SQL statement.
-    fn prepare_query_statement(
-        &self,
-        query: &SubQueryStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    );
+    fn prepare_query_statement(&self, query: &SubQueryStatement, sql: &mut dyn SqlWriter);
 
-    fn prepare_with_query(
-        &self,
-        query: &WithQuery,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        self.prepare_with_clause(&query.with_clause, sql, collector);
-        self.prepare_query_statement(query.query.as_ref().unwrap().deref(), sql, collector);
+    fn prepare_with_query(&self, query: &WithQuery, sql: &mut dyn SqlWriter) {
+        self.prepare_with_clause(&query.with_clause, sql);
+        self.prepare_query_statement(query.query.as_ref().unwrap().deref(), sql);
     }
 
-    fn prepare_with_clause(
-        &self,
-        with_clause: &WithClause,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_with_clause(&self, with_clause: &WithClause, sql: &mut dyn SqlWriter) {
         self.prepare_with_clause_start(with_clause, sql);
-        self.prepare_with_clause_common_tables(with_clause, sql, collector);
+        self.prepare_with_clause_common_tables(with_clause, sql);
         if with_clause.recursive {
-            self.prepare_with_clause_recursive_options(with_clause, sql, collector);
+            self.prepare_with_clause_recursive_options(with_clause, sql);
         }
     }
 
     fn prepare_with_clause_recursive_options(
         &self,
         with_clause: &WithClause,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) {
         if with_clause.recursive {
             if let Some(search) = &with_clause.search {
@@ -747,7 +643,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 )
                 .unwrap();
 
-                self.prepare_simple_expr(&search.expr.as_ref().unwrap().expr, sql, collector);
+                self.prepare_simple_expr(&search.expr.as_ref().unwrap().expr, sql);
 
                 write!(sql, " SET ").unwrap();
 
@@ -764,7 +660,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             if let Some(cycle) = &with_clause.cycle {
                 write!(sql, "CYCLE ").unwrap();
 
-                self.prepare_simple_expr(cycle.expr.as_ref().unwrap(), sql, collector);
+                self.prepare_simple_expr(cycle.expr.as_ref().unwrap(), sql);
 
                 write!(sql, " SET ").unwrap();
 
@@ -776,12 +672,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         }
     }
 
-    fn prepare_with_clause_common_tables(
-        &self,
-        with_clause: &WithClause,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_with_clause_common_tables(&self, with_clause: &WithClause, sql: &mut dyn SqlWriter) {
         let mut cte_first = true;
         assert_ne!(
             with_clause.cte_expressions.len(),
@@ -804,15 +695,14 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             }
             cte_first = false;
 
-            self.prepare_with_query_clause_common_table(cte, sql, collector);
+            self.prepare_with_query_clause_common_table(cte, sql);
         }
     }
 
     fn prepare_with_query_clause_common_table(
         &self,
         cte: &CommonTableExpression,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) {
         cte.table_name.as_ref().unwrap().prepare(sql, self.quote());
 
@@ -839,7 +729,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
         write!(sql, "(").unwrap();
 
-        self.prepare_query_statement(cte.query.as_ref().unwrap().deref(), sql, collector);
+        self.prepare_query_statement(cte.query.as_ref().unwrap().deref(), sql);
 
         write!(sql, ") ").unwrap();
     }
@@ -847,7 +737,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     fn prepare_with_query_clause_materialization(
         &self,
         cte: &CommonTableExpression,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
     ) {
         if let Some(materialized) = cte.materialized {
             write!(
@@ -859,7 +749,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         }
     }
 
-    fn prepare_with_clause_start(&self, with_clause: &WithClause, sql: &mut SqlWriter) {
+    fn prepare_with_clause_start(&self, with_clause: &WithClause, sql: &mut dyn SqlWriter) {
         write!(sql, "WITH ").unwrap();
 
         if with_clause.recursive {
@@ -867,7 +757,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         }
     }
 
-    fn prepare_insert(&self, replace: bool, sql: &mut SqlWriter) {
+    fn prepare_insert(&self, replace: bool, sql: &mut dyn SqlWriter) {
         if replace {
             write!(sql, "REPLACE").unwrap();
         } else {
@@ -875,22 +765,12 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         }
     }
 
-    fn prepare_function(
-        &self,
-        function: &Function,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        self.prepare_function_common(function, sql, collector)
+    fn prepare_function(&self, function: &Function, sql: &mut dyn SqlWriter) {
+        self.prepare_function_common(function, sql)
     }
 
     /// Translate [`JoinType`] into SQL statement.
-    fn prepare_join_type(
-        &self,
-        join_type: &JoinType,
-        sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_join_type(&self, join_type: &JoinType, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "{}",
@@ -906,43 +786,28 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`OrderExpr`] into SQL statement.
-    fn prepare_order_expr(
-        &self,
-        order_expr: &OrderExpr,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_order_expr(&self, order_expr: &OrderExpr, sql: &mut dyn SqlWriter) {
         if !matches!(order_expr.order, Order::Field(_)) {
-            self.prepare_simple_expr(&order_expr.expr, sql, collector);
+            self.prepare_simple_expr(&order_expr.expr, sql);
         }
         write!(sql, " ").unwrap();
-        self.prepare_order(order_expr, sql, collector);
+        self.prepare_order(order_expr, sql);
     }
 
     /// Translate [`JoinOn`] into SQL statement.
-    fn prepare_join_on(
-        &self,
-        join_on: &JoinOn,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_join_on(&self, join_on: &JoinOn, sql: &mut dyn SqlWriter) {
         match join_on {
-            JoinOn::Condition(c) => self.prepare_condition(c, "ON", sql, collector),
+            JoinOn::Condition(c) => self.prepare_condition(c, "ON", sql),
             JoinOn::Columns(_c) => unimplemented!(),
         }
     }
 
     /// Translate [`Order`] into SQL statement.
-    fn prepare_order(
-        &self,
-        order_expr: &OrderExpr,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_order(&self, order_expr: &OrderExpr, sql: &mut dyn SqlWriter) {
         match &order_expr.order {
             Order::Asc => write!(sql, "ASC").unwrap(),
             Order::Desc => write!(sql, "DESC").unwrap(),
-            Order::Field(values) => self.prepare_field_order(order_expr, values, sql, collector),
+            Order::Field(values) => self.prepare_field_order(order_expr, values, sql),
         }
     }
 
@@ -951,14 +816,13 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         &self,
         order_expr: &OrderExpr,
         values: &Values,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) {
         write!(sql, "CASE ").unwrap();
         let mut i = 0;
         for value in &values.0 {
             write!(sql, " WHEN ").unwrap();
-            self.prepare_simple_expr(&order_expr.expr, sql, collector);
+            self.prepare_simple_expr(&order_expr.expr, sql);
             write!(sql, "=").unwrap();
             let value = self.value_to_string(value);
             write!(sql, "{}", value).unwrap();
@@ -969,25 +833,18 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Write [`Value`] into SQL statement as parameter.
-    fn prepare_value(&self, value: &Value, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value)) {
-        let (placeholder, numbered) = self.placeholder();
-        sql.push_param(placeholder, numbered);
-        collector(value.clone());
+    fn prepare_value(&self, value: &Value, sql: &mut dyn SqlWriter) {
+        sql.push_param(value.clone(), &self);
     }
 
     /// Write [`Value`] inline.
-    fn prepare_constant(&self, value: &Value, sql: &mut SqlWriter) {
+    fn prepare_constant(&self, value: &Value, sql: &mut dyn SqlWriter) {
         let string = self.value_to_string(value);
         write!(sql, "{}", string).unwrap();
     }
 
     /// Translate a `&[ValueTuple]` into a VALUES list.
-    fn prepare_values_list(
-        &self,
-        value_tuples: &[ValueTuple],
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_values_list(&self, value_tuples: &[ValueTuple], sql: &mut dyn SqlWriter) {
         let (placeholder, numbered) = self.placeholder();
         write!(sql, "VALUES ").unwrap();
         value_tuples.iter().fold(true, |first, value_tuple| {
@@ -1000,8 +857,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                sql.push_param(placeholder, numbered);
-                collector(value);
+                sql.push_param(value, &self);
                 false
             });
 
@@ -1011,30 +867,20 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`SimpleExpr::Tuple`] into SQL statement.
-    fn prepare_tuple(
-        &self,
-        exprs: &[SimpleExpr],
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_tuple(&self, exprs: &[SimpleExpr], sql: &mut dyn SqlWriter) {
         write!(sql, "(").unwrap();
         exprs.iter().fold(true, |first, expr| {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            self.prepare_simple_expr(expr, sql, collector);
+            self.prepare_simple_expr(expr, sql);
             false
         });
         write!(sql, ")").unwrap();
     }
 
     /// Translate [`Keyword`] into SQL statement.
-    fn prepare_keyword(
-        &self,
-        keyword: &Keyword,
-        sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_keyword(&self, keyword: &Keyword, sql: &mut dyn SqlWriter) {
         if let Keyword::Custom(iden) = keyword {
             iden.unquoted(sql);
         } else {
@@ -1190,16 +1036,11 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
     #[doc(hidden)]
     /// Write ON CONFLICT expression
-    fn prepare_on_conflict(
-        &self,
-        on_conflict: &Option<OnConflict>,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_on_conflict(&self, on_conflict: &Option<OnConflict>, sql: &mut dyn SqlWriter) {
         if let Some(on_conflict) = on_conflict {
-            self.prepare_on_conflict_keywords(sql, collector);
-            self.prepare_on_conflict_target(&on_conflict.target, sql, collector);
-            self.prepare_on_conflict_action(&on_conflict.action, sql, collector);
+            self.prepare_on_conflict_keywords(sql);
+            self.prepare_on_conflict_target(&on_conflict.target, sql);
+            self.prepare_on_conflict_action(&on_conflict.action, sql);
         }
     }
 
@@ -1208,8 +1049,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     fn prepare_on_conflict_target(
         &self,
         on_conflict_target: &Option<OnConflictTarget>,
-        sql: &mut SqlWriter,
-        _: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) {
         if let Some(target) = on_conflict_target {
             match target {
@@ -1233,8 +1073,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     fn prepare_on_conflict_action(
         &self,
         on_conflict_action: &Option<OnConflictAction>,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) {
         if let Some(action) = on_conflict_action {
             match action {
@@ -1242,26 +1081,26 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                     write!(sql, " DO NOTHING").unwrap();
                 }
                 OnConflictAction::UpdateColumns(columns) => {
-                    self.prepare_on_conflict_do_update_keywords(sql, collector);
+                    self.prepare_on_conflict_do_update_keywords(sql);
                     columns.iter().fold(true, |first, col| {
                         if !first {
                             write!(sql, ", ").unwrap()
                         }
                         col.prepare(sql, self.quote());
                         write!(sql, " = ").unwrap();
-                        self.prepare_on_conflict_excluded_table(col, sql, collector);
+                        self.prepare_on_conflict_excluded_table(col, sql);
                         false
                     });
                 }
                 OnConflictAction::UpdateExprs(column_exprs) => {
-                    self.prepare_on_conflict_do_update_keywords(sql, collector);
+                    self.prepare_on_conflict_do_update_keywords(sql);
                     column_exprs.iter().fold(true, |first, (col, expr)| {
                         if !first {
                             write!(sql, ", ").unwrap()
                         }
                         col.prepare(sql, self.quote());
                         write!(sql, " = ").unwrap();
-                        self.prepare_simple_expr(expr, sql, collector);
+                        self.prepare_simple_expr(expr, sql);
                         false
                     });
                 }
@@ -1271,28 +1110,19 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
     #[doc(hidden)]
     /// Write ON CONFLICT keywords
-    fn prepare_on_conflict_keywords(&self, sql: &mut SqlWriter, _: &mut dyn FnMut(Value)) {
+    fn prepare_on_conflict_keywords(&self, sql: &mut dyn SqlWriter) {
         write!(sql, " ON CONFLICT ").unwrap();
     }
 
     #[doc(hidden)]
     /// Write ON CONFLICT keywords
-    fn prepare_on_conflict_do_update_keywords(
-        &self,
-        sql: &mut SqlWriter,
-        _: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_on_conflict_do_update_keywords(&self, sql: &mut dyn SqlWriter) {
         write!(sql, " DO UPDATE SET ").unwrap();
     }
 
     #[doc(hidden)]
     /// Write ON CONFLICT update action by retrieving value from the excluded table
-    fn prepare_on_conflict_excluded_table(
-        &self,
-        col: &DynIden,
-        sql: &mut SqlWriter,
-        _: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_on_conflict_excluded_table(&self, col: &DynIden, sql: &mut dyn SqlWriter) {
         write!(sql, "{0}excluded{0}", self.quote()).unwrap();
         write!(sql, ".").unwrap();
         col.prepare(sql, self.quote());
@@ -1300,12 +1130,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
     #[doc(hidden)]
     /// Hook to insert "RETURNING" statements.
-    fn prepare_returning(
-        &self,
-        returning: &Option<ReturningClause>,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_returning(&self, returning: &Option<ReturningClause>, sql: &mut dyn SqlWriter) {
         if let Some(returning) = returning {
             write!(sql, " RETURNING ").unwrap();
             match &returning {
@@ -1324,7 +1149,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                         if !first {
                             write!(sql, ", ").unwrap()
                         }
-                        self.prepare_simple_expr(expr, sql, collector);
+                        self.prepare_simple_expr(expr, sql);
                         false
                     });
                 }
@@ -1338,8 +1163,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         &self,
         condition: &ConditionHolder,
         keyword: &str,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) {
         if !condition.is_empty() {
             write!(sql, " {} ", keyword).unwrap();
@@ -1348,29 +1172,18 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             ConditionHolderContents::Empty => (),
             ConditionHolderContents::Chain(conditions) => {
                 for (i, log_chain_oper) in conditions.iter().enumerate() {
-                    self.prepare_logical_chain_oper(
-                        log_chain_oper,
-                        i,
-                        conditions.len(),
-                        sql,
-                        collector,
-                    );
+                    self.prepare_logical_chain_oper(log_chain_oper, i, conditions.len(), sql);
                 }
             }
             ConditionHolderContents::Condition(c) => {
-                self.prepare_condition_where(c, sql, collector);
+                self.prepare_condition_where(c, sql);
             }
         }
     }
 
     #[doc(hidden)]
     /// Translate part of a condition to part of a "WHERE" clause.
-    fn prepare_condition_where(
-        &self,
-        condition: &Condition,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_condition_where(&self, condition: &Condition, sql: &mut dyn SqlWriter) {
         if condition.negate {
             write!(sql, "NOT (").unwrap();
         }
@@ -1389,7 +1202,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                     if condition.conditions.len() > 1 {
                         write!(sql, "(").unwrap();
                     }
-                    self.prepare_condition_where(c, sql, collector);
+                    self.prepare_condition_where(c, sql);
                     if condition.conditions.len() > 1 {
                         write!(sql, ")").unwrap();
                     }
@@ -1398,7 +1211,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                     if condition.conditions.len() > 1 && (e.is_logical() || e.is_between()) {
                         write!(sql, "(").unwrap();
                     }
-                    self.prepare_simple_expr(e, sql, collector);
+                    self.prepare_simple_expr(e, sql);
                     if condition.conditions.len() > 1 && (e.is_logical() || e.is_between()) {
                         write!(sql, ")").unwrap();
                     }
@@ -1412,16 +1225,16 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
     #[doc(hidden)]
     /// Translate [`Frame`] into SQL statement.
-    fn prepare_frame(&self, frame: &Frame, sql: &mut SqlWriter, collector: &mut dyn FnMut(Value)) {
+    fn prepare_frame(&self, frame: &Frame, sql: &mut dyn SqlWriter) {
         match *frame {
             Frame::UnboundedPreceding => write!(sql, " UNBOUNDED PRECEDING ").unwrap(),
             Frame::Preceding(v) => {
-                self.prepare_value(&Some(v).into(), sql, collector);
+                self.prepare_value(&Some(v).into(), sql);
                 write!(sql, " PRECEDING ").unwrap();
             }
             Frame::CurrentRow => write!(sql, " CURRENT ROW ").unwrap(),
             Frame::Following(v) => {
-                self.prepare_value(&Some(v).into(), sql, collector);
+                self.prepare_value(&Some(v).into(), sql);
                 write!(sql, " FOLLOWING ").unwrap();
             }
             Frame::UnboundedFollowing => write!(sql, " UNBOUNDED FOLLOWING ").unwrap(),
@@ -1430,19 +1243,14 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
     #[doc(hidden)]
     /// Translate [`WindowStatement`] into SQL statement.
-    fn prepare_window_statement(
-        &self,
-        window: &WindowStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_window_statement(&self, window: &WindowStatement, sql: &mut dyn SqlWriter) {
         if !window.partition_by.is_empty() {
             write!(sql, " PARTITION BY ").unwrap();
             window.partition_by.iter().fold(true, |first, expr| {
                 if !first {
                     write!(sql, ", ").unwrap()
                 }
-                self.prepare_simple_expr(expr, sql, collector);
+                self.prepare_simple_expr(expr, sql);
                 false
             });
         }
@@ -1453,7 +1261,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 if !first {
                     write!(sql, ", ").unwrap()
                 }
-                self.prepare_order_expr(expr, sql, collector);
+                self.prepare_order_expr(expr, sql);
                 false
             });
         }
@@ -1465,11 +1273,11 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             };
             if let Some(end) = &frame.end {
                 write!(sql, "BETWEEN ").unwrap();
-                self.prepare_frame(&frame.start, sql, collector);
+                self.prepare_frame(&frame.start, sql);
                 write!(sql, " AND ").unwrap();
-                self.prepare_frame(end, sql, collector);
+                self.prepare_frame(end, sql);
             } else {
-                self.prepare_frame(&frame.start, sql, collector);
+                self.prepare_frame(&frame.start, sql);
             }
         }
     }
@@ -1481,8 +1289,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         left: &SimpleExpr,
         op: &BinOper,
         right: &SimpleExpr,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) {
         let no_paren = matches!(op, BinOper::Equal | BinOper::NotEqual);
         let left_paren = left.need_parentheses()
@@ -1492,12 +1299,12 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         if left_paren {
             write!(sql, "(").unwrap();
         }
-        self.prepare_simple_expr(left, sql, collector);
+        self.prepare_simple_expr(left, sql);
         if left_paren {
             write!(sql, ")").unwrap();
         }
         write!(sql, " ").unwrap();
-        self.prepare_bin_oper(op, sql, collector);
+        self.prepare_bin_oper(op, sql);
         write!(sql, " ").unwrap();
         let no_right_paren = matches!(
             op,
@@ -1510,7 +1317,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         if right_paren {
             write!(sql, "(").unwrap();
         }
-        self.prepare_simple_expr(right, sql, collector);
+        self.prepare_simple_expr(right, sql);
         if right_paren {
             write!(sql, ")").unwrap();
         }
@@ -1547,7 +1354,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Write insert default rows expression.
-    fn insert_default_values(&self, num_rows: u32, sql: &mut SqlWriter) {
+    fn insert_default_values(&self, num_rows: u32, sql: &mut dyn SqlWriter) {
         write!(sql, "VALUES ").unwrap();
         (0..num_rows).fold(true, |first, _| {
             if !first {
@@ -1563,16 +1370,15 @@ impl SubQueryStatement {
     pub(crate) fn prepare_statement(
         &self,
         query_builder: &dyn QueryBuilder,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) {
         use SubQueryStatement::*;
         match self {
-            SelectStatement(stmt) => query_builder.prepare_select_statement(stmt, sql, collector),
-            InsertStatement(stmt) => query_builder.prepare_insert_statement(stmt, sql, collector),
-            UpdateStatement(stmt) => query_builder.prepare_update_statement(stmt, sql, collector),
-            DeleteStatement(stmt) => query_builder.prepare_delete_statement(stmt, sql, collector),
-            WithStatement(stmt) => query_builder.prepare_with_query(stmt, sql, collector),
+            SelectStatement(stmt) => query_builder.prepare_select_statement(stmt, sql),
+            InsertStatement(stmt) => query_builder.prepare_insert_statement(stmt, sql),
+            UpdateStatement(stmt) => query_builder.prepare_update_statement(stmt, sql),
+            DeleteStatement(stmt) => query_builder.prepare_delete_statement(stmt, sql),
+            WithStatement(stmt) => query_builder.prepare_with_query(stmt, sql),
         }
     }
 }
@@ -1580,13 +1386,8 @@ impl SubQueryStatement {
 pub(crate) struct CommonSqlQueryBuilder;
 
 impl QueryBuilder for CommonSqlQueryBuilder {
-    fn prepare_query_statement(
-        &self,
-        query: &SubQueryStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        query.prepare_statement(self, sql, collector);
+    fn prepare_query_statement(&self, query: &SubQueryStatement, sql: &mut dyn SqlWriter) {
+        query.prepare_statement(self, sql);
     }
 }
 

--- a/src/backend/sqlite/foreign_key.rs
+++ b/src/backend/sqlite/foreign_key.rs
@@ -4,7 +4,7 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
     fn prepare_foreign_key_drop_statement_internal(
         &self,
         drop: &ForeignKeyDropStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
         mode: Mode,
     ) {
         if mode != Mode::Creation {
@@ -20,7 +20,7 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
     fn prepare_foreign_key_create_statement_internal(
         &self,
         create: &ForeignKeyCreateStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
         mode: Mode,
     ) {
         if mode != Mode::Creation {
@@ -66,7 +66,7 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
         }
     }
 
-    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut SqlWriter) {
+    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
             _ => panic!("Not supported"),

--- a/src/backend/sqlite/foreign_key.rs
+++ b/src/backend/sqlite/foreign_key.rs
@@ -1,6 +1,13 @@
 use super::*;
 
 impl ForeignKeyBuilder for SqliteQueryBuilder {
+    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
+        match table_ref {
+            TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
+            _ => panic!("Not supported"),
+        }
+    }
+
     fn prepare_foreign_key_drop_statement_internal(
         &self,
         drop: &ForeignKeyDropStatement,
@@ -63,13 +70,6 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
         if let Some(foreign_key_action) = &create.foreign_key.on_update {
             write!(sql, " ON UPDATE ").unwrap();
             self.prepare_foreign_key_action(foreign_key_action, sql);
-        }
-    }
-
-    fn prepare_table_ref_fk_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
-        match table_ref {
-            TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
-            _ => panic!("Not supported"),
         }
     }
 }

--- a/src/backend/sqlite/foreign_key.rs
+++ b/src/backend/sqlite/foreign_key.rs
@@ -32,7 +32,7 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            col.prepare(sql, self.quote());
+            col.prepare(sql.as_writer(), self.quote());
             false
         });
         write!(sql, ")").unwrap();
@@ -50,7 +50,7 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                col.prepare(sql, self.quote());
+                col.prepare(sql.as_writer(), self.quote());
                 false
             });
         write!(sql, ")").unwrap();

--- a/src/backend/sqlite/index.rs
+++ b/src/backend/sqlite/index.rs
@@ -14,7 +14,9 @@ impl IndexBuilder for SqliteQueryBuilder {
             write!(sql, "IF NOT EXISTS ").unwrap();
         }
 
-        self.prepare_index_name(&create.index.name, sql);
+        if let Some(name) = &create.index.name {
+            write!(sql, "{}{}{}", self.quote(), name, self.quote()).unwrap();
+        }
 
         write!(sql, " ON ").unwrap();
         if let Some(table) = &create.table {

--- a/src/backend/sqlite/index.rs
+++ b/src/backend/sqlite/index.rs
@@ -1,7 +1,11 @@
 use super::*;
 
 impl IndexBuilder for SqliteQueryBuilder {
-    fn prepare_index_create_statement(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
+    fn prepare_index_create_statement(
+        &self,
+        create: &IndexCreateStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
         write!(sql, "CREATE ").unwrap();
         self.prepare_index_prefix(create, sql);
         write!(sql, "INDEX ").unwrap();
@@ -20,7 +24,7 @@ impl IndexBuilder for SqliteQueryBuilder {
         self.prepare_index_columns(&create.index.columns, sql);
     }
 
-    fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut SqlWriter) {
+    fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "DROP INDEX ").unwrap();
         if let Some(name) = &drop.index.name {
             let quote = self.quote();
@@ -33,9 +37,9 @@ impl IndexBuilder for SqliteQueryBuilder {
         }
     }
 
-    fn write_column_index_prefix(&self, _col_prefix: &Option<u32>, _sql: &mut SqlWriter) {}
+    fn write_column_index_prefix(&self, _col_prefix: &Option<u32>, _sql: &mut dyn SqlWriter) {}
 
-    fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut SqlWriter) {
+    fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut dyn SqlWriter) {
         if create.primary {
             write!(sql, "PRIMARY KEY ").unwrap();
         } else if create.unique {
@@ -43,7 +47,7 @@ impl IndexBuilder for SqliteQueryBuilder {
         }
     }
 
-    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut SqlWriter) {
+    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
             _ => panic!("Not supported"),

--- a/src/backend/sqlite/index.rs
+++ b/src/backend/sqlite/index.rs
@@ -21,7 +21,15 @@ impl IndexBuilder for SqliteQueryBuilder {
             self.prepare_table_ref_index_stmt(table, sql);
         }
 
+        write!(sql, " ").unwrap();
         self.prepare_index_columns(&create.index.columns, sql);
+    }
+
+    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
+        match table_ref {
+            TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
+            _ => panic!("Not supported"),
+        }
     }
 
     fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut dyn SqlWriter) {
@@ -37,8 +45,6 @@ impl IndexBuilder for SqliteQueryBuilder {
         }
     }
 
-    fn write_column_index_prefix(&self, _col_prefix: &Option<u32>, _sql: &mut dyn SqlWriter) {}
-
     fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut dyn SqlWriter) {
         if create.primary {
             write!(sql, "PRIMARY KEY ").unwrap();
@@ -47,10 +53,5 @@ impl IndexBuilder for SqliteQueryBuilder {
         }
     }
 
-    fn prepare_table_ref_index_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
-        match table_ref {
-            TableRef::Table(_) => self.prepare_table_ref_iden(table_ref, sql),
-            _ => panic!("Not supported"),
-        }
-    }
+    fn write_column_index_prefix(&self, _col_prefix: &Option<u32>, _sql: &mut dyn SqlWriter) {}
 }

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -5,26 +5,16 @@ impl QueryBuilder for SqliteQueryBuilder {
         "LENGTH"
     }
 
-    fn prepare_select_lock(
-        &self,
-        _select_lock: &LockClause,
-        _sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_select_lock(&self, _select_lock: &LockClause, _sql: &mut dyn SqlWriter) {
         // SQLite doesn't supports row locking
     }
 
-    fn prepare_order_expr(
-        &self,
-        order_expr: &OrderExpr,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_order_expr(&self, order_expr: &OrderExpr, sql: &mut dyn SqlWriter) {
         if !matches!(order_expr.order, Order::Field(_)) {
-            self.prepare_simple_expr(&order_expr.expr, sql, collector);
+            self.prepare_simple_expr(&order_expr.expr, sql);
         }
         write!(sql, " ").unwrap();
-        self.prepare_order(order_expr, sql, collector);
+        self.prepare_order(order_expr, sql);
         match order_expr.nulls {
             None => (),
             Some(NullOrdering::Last) => write!(sql, " NULLS LAST").unwrap(),
@@ -32,25 +22,15 @@ impl QueryBuilder for SqliteQueryBuilder {
         }
     }
 
-    fn prepare_query_statement(
-        &self,
-        query: &SubQueryStatement,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        query.prepare_statement(self, sql, collector);
+    fn prepare_query_statement(&self, query: &SubQueryStatement, sql: &mut dyn SqlWriter) {
+        query.prepare_statement(self, sql);
     }
 
-    fn prepare_with_clause_recursive_options(
-        &self,
-        _: &WithClause,
-        _: &mut SqlWriter,
-        _: &mut dyn FnMut(Value),
-    ) {
+    fn prepare_with_clause_recursive_options(&self, _: &WithClause, _: &mut dyn SqlWriter) {
         // Sqlite doesn't support sql recursive with query 'SEARCH' and 'CYCLE' options.
     }
 
-    fn insert_default_values(&self, _: u32, sql: &mut SqlWriter) {
+    fn insert_default_values(&self, _: u32, sql: &mut dyn SqlWriter) {
         // SQLite doesn't support inserting multiple rows with default values
         write!(sql, "DEFAULT VALUES").unwrap()
     }

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -34,4 +34,8 @@ impl QueryBuilder for SqliteQueryBuilder {
         // SQLite doesn't support inserting multiple rows with default values
         write!(sql, "DEFAULT VALUES").unwrap()
     }
+
+    fn prepare_value(&self, value: &Value, sql: &mut dyn SqlWriter) {
+        sql.push_param(value.clone(), self as _);
+    }
 }

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -1,25 +1,8 @@
 use super::*;
 
 impl QueryBuilder for SqliteQueryBuilder {
-    fn char_length_function(&self) -> &str {
-        "LENGTH"
-    }
-
     fn prepare_select_lock(&self, _select_lock: &LockClause, _sql: &mut dyn SqlWriter) {
         // SQLite doesn't supports row locking
-    }
-
-    fn prepare_order_expr(&self, order_expr: &OrderExpr, sql: &mut dyn SqlWriter) {
-        if !matches!(order_expr.order, Order::Field(_)) {
-            self.prepare_simple_expr(&order_expr.expr, sql);
-        }
-        write!(sql, " ").unwrap();
-        self.prepare_order(order_expr, sql);
-        match order_expr.nulls {
-            None => (),
-            Some(NullOrdering::Last) => write!(sql, " NULLS LAST").unwrap(),
-            Some(NullOrdering::First) => write!(sql, " NULLS FIRST").unwrap(),
-        }
     }
 
     fn prepare_query_statement(&self, query: &SubQueryStatement, sql: &mut dyn SqlWriter) {
@@ -30,12 +13,29 @@ impl QueryBuilder for SqliteQueryBuilder {
         // Sqlite doesn't support sql recursive with query 'SEARCH' and 'CYCLE' options.
     }
 
-    fn insert_default_values(&self, _: u32, sql: &mut dyn SqlWriter) {
-        // SQLite doesn't support inserting multiple rows with default values
-        write!(sql, "DEFAULT VALUES").unwrap()
+    fn prepare_order_expr(&self, order_expr: &OrderExpr, sql: &mut dyn SqlWriter) {
+        if !matches!(order_expr.order, Order::Field(_)) {
+            self.prepare_simple_expr(&order_expr.expr, sql);
+            write!(sql, " ").unwrap();
+        }
+        self.prepare_order(order_expr, sql);
+        match order_expr.nulls {
+            None => (),
+            Some(NullOrdering::Last) => write!(sql, " NULLS LAST").unwrap(),
+            Some(NullOrdering::First) => write!(sql, " NULLS FIRST").unwrap(),
+        }
     }
 
     fn prepare_value(&self, value: &Value, sql: &mut dyn SqlWriter) {
         sql.push_param(value.clone(), self as _);
+    }
+
+    fn char_length_function(&self) -> &str {
+        "LENGTH"
+    }
+
+    fn insert_default_values(&self, _: u32, sql: &mut dyn SqlWriter) {
+        // SQLite doesn't support inserting multiple rows with default values
+        write!(sql, "DEFAULT VALUES").unwrap()
     }
 }

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -121,17 +121,8 @@ impl TableBuilder for SqliteQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut dyn SqlWriter) {
-        match column_spec {
-            ColumnSpec::Null => write!(sql, "NULL"),
-            ColumnSpec::NotNull => write!(sql, "NOT NULL"),
-            ColumnSpec::Default(value) => write!(sql, "DEFAULT {}", self.value_to_string(value)),
-            ColumnSpec::AutoIncrement => write!(sql, "AUTOINCREMENT"),
-            ColumnSpec::UniqueKey => write!(sql, "UNIQUE"),
-            ColumnSpec::PrimaryKey => write!(sql, "PRIMARY KEY"),
-            ColumnSpec::Extra(string) => write!(sql, "{}", string),
-        }
-        .unwrap()
+    fn column_spec_auto_increment_keyword(&self) -> &str {
+        "AUTOINCREMENT"
     }
 
     fn prepare_table_drop_opt(&self, _drop_opt: &TableDropOpt, _sql: &mut dyn SqlWriter) {

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl TableBuilder for SqliteQueryBuilder {
-    fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut SqlWriter) {
+    fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter) {
         column_def.name.prepare(sql, self.quote());
 
         if let Some(column_type) = &column_def.types {
@@ -35,7 +35,7 @@ impl TableBuilder for SqliteQueryBuilder {
         }
     }
 
-    fn prepare_column_type(&self, column_type: &ColumnType, sql: &mut SqlWriter) {
+    fn prepare_column_type(&self, column_type: &ColumnType, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "{}",
@@ -121,7 +121,7 @@ impl TableBuilder for SqliteQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut SqlWriter) {
+    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut dyn SqlWriter) {
         match column_spec {
             ColumnSpec::Null => write!(sql, "NULL"),
             ColumnSpec::NotNull => write!(sql, "NOT NULL"),
@@ -134,11 +134,11 @@ impl TableBuilder for SqliteQueryBuilder {
         .unwrap()
     }
 
-    fn prepare_table_drop_opt(&self, _drop_opt: &TableDropOpt, _sql: &mut dyn std::fmt::Write) {
+    fn prepare_table_drop_opt(&self, _drop_opt: &TableDropOpt, _sql: &mut dyn SqlWriter) {
         // SQLite does not support table drop options
     }
 
-    fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut SqlWriter) {
+    fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut dyn SqlWriter) {
         if alter.options.is_empty() {
             panic!("No alter option found")
         };
@@ -176,7 +176,11 @@ impl TableBuilder for SqliteQueryBuilder {
         }
     }
 
-    fn prepare_table_rename_statement(&self, rename: &TableRenameStatement, sql: &mut SqlWriter) {
+    fn prepare_table_rename_statement(
+        &self,
+        rename: &TableRenameStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
         write!(sql, "ALTER TABLE ").unwrap();
         if let Some(from_name) = &rename.from_name {
             self.prepare_table_ref_table_stmt(from_name, sql);

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl TableBuilder for SqliteQueryBuilder {
     fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter) {
-        column_def.name.prepare(sql, self.quote());
+        column_def.name.prepare(sql.as_writer(), self.quote());
 
         if let Some(column_type) = &column_def.types {
             write!(sql, " ").unwrap();
@@ -160,9 +160,9 @@ impl TableBuilder for SqliteQueryBuilder {
             }
             TableAlterOption::RenameColumn(from_name, to_name) => {
                 write!(sql, "RENAME COLUMN ").unwrap();
-                from_name.prepare(sql, self.quote());
+                from_name.prepare(sql.as_writer(), self.quote());
                 write!(sql, " TO ").unwrap();
-                to_name.prepare(sql, self.quote());
+                to_name.prepare(sql.as_writer(), self.quote());
             }
             TableAlterOption::DropColumn(_) => {
                 panic!("Sqlite not support dropping table column")

--- a/src/backend/table_builder.rs
+++ b/src/backend/table_builder.rs
@@ -2,7 +2,11 @@ use crate::*;
 
 pub trait TableBuilder: IndexBuilder + ForeignKeyBuilder + QuotedBuilder + TableRefBuilder {
     /// Translate [`TableCreateStatement`] into SQL statement.
-    fn prepare_table_create_statement(&self, create: &TableCreateStatement, sql: &mut SqlWriter) {
+    fn prepare_table_create_statement(
+        &self,
+        create: &TableCreateStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
         write!(sql, "CREATE TABLE ").unwrap();
 
         if create.if_not_exists {
@@ -49,7 +53,7 @@ pub trait TableBuilder: IndexBuilder + ForeignKeyBuilder + QuotedBuilder + Table
     }
 
     /// Translate [`TableRef`] into SQL statement.
-    fn prepare_table_ref_table_stmt(&self, table_ref: &TableRef, sql: &mut SqlWriter) {
+    fn prepare_table_ref_table_stmt(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(_)
             | TableRef::SchemaTable(_, _)
@@ -59,16 +63,16 @@ pub trait TableBuilder: IndexBuilder + ForeignKeyBuilder + QuotedBuilder + Table
     }
 
     /// Translate [`ColumnDef`] into SQL statement.
-    fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut SqlWriter);
+    fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter);
 
     /// Translate [`ColumnType`] into SQL statement.
-    fn prepare_column_type(&self, column_type: &ColumnType, sql: &mut SqlWriter);
+    fn prepare_column_type(&self, column_type: &ColumnType, sql: &mut dyn SqlWriter);
 
     /// Translate [`ColumnSpec`] into SQL statement.
-    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut SqlWriter);
+    fn prepare_column_spec(&self, column_spec: &ColumnSpec, sql: &mut dyn SqlWriter);
 
     /// Translate [`TableOpt`] into SQL statement.
-    fn prepare_table_opt(&self, table_opt: &TableOpt, sql: &mut SqlWriter) {
+    fn prepare_table_opt(&self, table_opt: &TableOpt, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "{}",
@@ -82,10 +86,11 @@ pub trait TableBuilder: IndexBuilder + ForeignKeyBuilder + QuotedBuilder + Table
     }
 
     /// Translate [`TablePartition`] into SQL statement.
-    fn prepare_table_partition(&self, _table_partition: &TablePartition, _sql: &mut SqlWriter) {}
+    fn prepare_table_partition(&self, _table_partition: &TablePartition, _sql: &mut dyn SqlWriter) {
+    }
 
     /// Translate [`TableDropStatement`] into SQL statement.
-    fn prepare_table_drop_statement(&self, drop: &TableDropStatement, sql: &mut SqlWriter) {
+    fn prepare_table_drop_statement(&self, drop: &TableDropStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "DROP TABLE ").unwrap();
 
         if drop.if_exists {
@@ -100,16 +105,14 @@ pub trait TableBuilder: IndexBuilder + ForeignKeyBuilder + QuotedBuilder + Table
             false
         });
 
-        let mut table_drop_opt = String::new();
         for drop_opt in drop.options.iter() {
-            write!(&mut table_drop_opt, " ").unwrap();
-            self.prepare_table_drop_opt(drop_opt, &mut table_drop_opt);
+            write!(sql, " ").unwrap();
+            self.prepare_table_drop_opt(drop_opt, sql);
         }
-        write!(sql, "{}", table_drop_opt.trim_end()).unwrap();
     }
 
     /// Translate [`TableDropOpt`] into SQL statement.
-    fn prepare_table_drop_opt(&self, drop_opt: &TableDropOpt, sql: &mut dyn std::fmt::Write) {
+    fn prepare_table_drop_opt(&self, drop_opt: &TableDropOpt, sql: &mut dyn SqlWriter) {
         write!(
             sql,
             "{}",
@@ -125,7 +128,7 @@ pub trait TableBuilder: IndexBuilder + ForeignKeyBuilder + QuotedBuilder + Table
     fn prepare_table_truncate_statement(
         &self,
         truncate: &TableTruncateStatement,
-        sql: &mut SqlWriter,
+        sql: &mut dyn SqlWriter,
     ) {
         write!(sql, "TRUNCATE TABLE ").unwrap();
 
@@ -135,8 +138,12 @@ pub trait TableBuilder: IndexBuilder + ForeignKeyBuilder + QuotedBuilder + Table
     }
 
     /// Translate [`TableAlterStatement`] into SQL statement.
-    fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut SqlWriter);
+    fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut dyn SqlWriter);
 
     /// Translate [`TableRenameStatement`] into SQL statement.
-    fn prepare_table_rename_statement(&self, rename: &TableRenameStatement, sql: &mut SqlWriter);
+    fn prepare_table_rename_statement(
+        &self,
+        rename: &TableRenameStatement,
+        sql: &mut dyn SqlWriter,
+    );
 }

--- a/src/backend/table_ref_builder.rs
+++ b/src/backend/table_ref_builder.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 pub trait TableRefBuilder: QuotedBuilder {
     /// Translate [`TableRef`] that without values into SQL statement.
-    fn prepare_table_ref_iden(&self, table_ref: &TableRef, sql: &mut SqlWriter) {
+    fn prepare_table_ref_iden(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(iden) => {
                 iden.prepare(sql, self.quote());

--- a/src/backend/table_ref_builder.rs
+++ b/src/backend/table_ref_builder.rs
@@ -5,40 +5,40 @@ pub trait TableRefBuilder: QuotedBuilder {
     fn prepare_table_ref_iden(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(iden) => {
-                iden.prepare(sql, self.quote());
+                iden.prepare(sql.as_writer(), self.quote());
             }
             TableRef::SchemaTable(schema, table) => {
-                schema.prepare(sql, self.quote());
+                schema.prepare(sql.as_writer(), self.quote());
                 write!(sql, ".").unwrap();
-                table.prepare(sql, self.quote());
+                table.prepare(sql.as_writer(), self.quote());
             }
             TableRef::DatabaseSchemaTable(database, schema, table) => {
-                database.prepare(sql, self.quote());
+                database.prepare(sql.as_writer(), self.quote());
                 write!(sql, ".").unwrap();
-                schema.prepare(sql, self.quote());
+                schema.prepare(sql.as_writer(), self.quote());
                 write!(sql, ".").unwrap();
-                table.prepare(sql, self.quote());
+                table.prepare(sql.as_writer(), self.quote());
             }
             TableRef::TableAlias(iden, alias) => {
-                iden.prepare(sql, self.quote());
+                iden.prepare(sql.as_writer(), self.quote());
                 write!(sql, " AS ").unwrap();
-                alias.prepare(sql, self.quote());
+                alias.prepare(sql.as_writer(), self.quote());
             }
             TableRef::SchemaTableAlias(schema, table, alias) => {
-                schema.prepare(sql, self.quote());
+                schema.prepare(sql.as_writer(), self.quote());
                 write!(sql, ".").unwrap();
-                table.prepare(sql, self.quote());
+                table.prepare(sql.as_writer(), self.quote());
                 write!(sql, " AS ").unwrap();
-                alias.prepare(sql, self.quote());
+                alias.prepare(sql.as_writer(), self.quote());
             }
             TableRef::DatabaseSchemaTableAlias(database, schema, table, alias) => {
-                database.prepare(sql, self.quote());
+                database.prepare(sql.as_writer(), self.quote());
                 write!(sql, ".").unwrap();
-                schema.prepare(sql, self.quote());
+                schema.prepare(sql.as_writer(), self.quote());
                 write!(sql, ".").unwrap();
-                table.prepare(sql, self.quote());
+                table.prepare(sql.as_writer(), self.quote());
                 write!(sql, " AS ").unwrap();
-                alias.prepare(sql, self.quote());
+                alias.prepare(sql.as_writer(), self.quote());
             }
             TableRef::SubQuery(_, _) | TableRef::ValuesList(_, _) => {
                 panic!("TableRef with values is not support")

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2149,6 +2149,15 @@ impl From<Expr> for SelectExpr {
     }
 }
 
+impl<T> From<T> for SimpleExpr
+where
+    T: Into<Value>,
+{
+    fn from(v: T) -> Self {
+        SimpleExpr::Value(v.into())
+    }
+}
+
 impl SimpleExpr {
     /// Express a logical `AND` operation.
     ///

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -113,19 +113,19 @@ pub trait TypeBuilder: QuotedBuilder {
     fn prepare_type_ref(&self, type_ref: &TypeRef, sql: &mut dyn SqlWriter) {
         match type_ref {
             TypeRef::Type(name) => {
-                name.prepare(sql, self.quote());
+                name.prepare(sql.as_writer(), self.quote());
             }
             TypeRef::SchemaType(schema, name) => {
-                schema.prepare(sql, self.quote());
+                schema.prepare(sql.as_writer(), self.quote());
                 write!(sql, ".").unwrap();
-                name.prepare(sql, self.quote());
+                name.prepare(sql.as_writer(), self.quote());
             }
             TypeRef::DatabaseSchemaType(database, schema, name) => {
-                database.prepare(sql, self.quote());
+                database.prepare(sql.as_writer(), self.quote());
                 write!(sql, ".").unwrap();
-                schema.prepare(sql, self.quote());
+                schema.prepare(sql.as_writer(), self.quote());
                 write!(sql, ".").unwrap();
-                name.prepare(sql, self.quote());
+                name.prepare(sql.as_writer(), self.quote());
             }
         }
     }
@@ -137,7 +137,7 @@ pub trait TypeStatementBuilder {
     }
 
     fn build_ref<T: TypeBuilder>(&self, type_builder: &T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         self.build_collect_ref(type_builder, &mut sql)
     }
 
@@ -250,7 +250,7 @@ impl TypeStatementBuilder for TypeCreateStatement {
         sql: &mut dyn SqlWriter,
     ) -> String {
         type_builder.prepare_type_create_statement(self, sql);
-        sql.result()
+        sql.to_string()
     }
 }
 
@@ -326,7 +326,7 @@ impl TypeStatementBuilder for TypeDropStatement {
         sql: &mut dyn SqlWriter,
     ) -> String {
         type_builder.prepare_type_drop_statement(self, sql);
-        sql.result()
+        sql.to_string()
     }
 }
 
@@ -464,7 +464,7 @@ impl TypeStatementBuilder for TypeAlterStatement {
         sql: &mut dyn SqlWriter,
     ) -> String {
         type_builder.prepare_type_alter_statement(self, sql);
-        sql.result()
+        sql.to_string()
     }
 }
 

--- a/src/foreign_key/create.rs
+++ b/src/foreign_key/create.rs
@@ -1,6 +1,5 @@
 use crate::{
-    backend::SchemaBuilder, prepare::*, types::*, ForeignKeyAction, SchemaStatementBuilder,
-    TableForeignKey,
+    backend::SchemaBuilder, types::*, ForeignKeyAction, SchemaStatementBuilder, TableForeignKey,
 };
 
 /// Create a foreign key constraint for an existing table. Unsupported by Sqlite
@@ -183,14 +182,14 @@ impl ForeignKeyCreateStatement {
 
 impl SchemaStatementBuilder for ForeignKeyCreateStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_foreign_key_create_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_foreign_key_create_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 }

--- a/src/foreign_key/create.rs
+++ b/src/foreign_key/create.rs
@@ -183,13 +183,13 @@ impl ForeignKeyCreateStatement {
 
 impl SchemaStatementBuilder for ForeignKeyCreateStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_foreign_key_create_statement(self, &mut sql);
         sql.result()
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_foreign_key_create_statement(self, &mut sql);
         sql.result()
     }

--- a/src/foreign_key/drop.rs
+++ b/src/foreign_key/drop.rs
@@ -1,6 +1,4 @@
-use crate::{
-    backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder, TableForeignKey,
-};
+use crate::{backend::SchemaBuilder, types::*, SchemaStatementBuilder, TableForeignKey};
 
 /// Drop a foreign key constraint for an existing table
 ///
@@ -63,14 +61,14 @@ impl ForeignKeyDropStatement {
 
 impl SchemaStatementBuilder for ForeignKeyDropStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_foreign_key_drop_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_foreign_key_drop_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 }

--- a/src/foreign_key/drop.rs
+++ b/src/foreign_key/drop.rs
@@ -63,13 +63,13 @@ impl ForeignKeyDropStatement {
 
 impl SchemaStatementBuilder for ForeignKeyDropStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_foreign_key_drop_statement(self, &mut sql);
         sql.result()
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_foreign_key_drop_statement(self, &mut sql);
         sql.result()
     }

--- a/src/func.rs
+++ b/src/func.rs
@@ -42,7 +42,7 @@ impl Func {
     /// struct MyFunction;
     ///
     /// impl Iden for MyFunction {
-    ///     fn unquoted(&self, s: &mut dyn FmtWrite) {
+    ///     fn unquoted(&self, s: &mut dyn Write) {
     ///         write!(s, "MY_FUNCTION").unwrap();
     ///     }
     /// }

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -1,5 +1,5 @@
 use super::common::*;
-use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder};
+use crate::{backend::SchemaBuilder, types::*, SchemaStatementBuilder};
 
 /// Create an index for an existing table
 ///
@@ -239,14 +239,14 @@ impl IndexCreateStatement {
 
 impl SchemaStatementBuilder for IndexCreateStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_index_create_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_index_create_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 }

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -239,13 +239,13 @@ impl IndexCreateStatement {
 
 impl SchemaStatementBuilder for IndexCreateStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_index_create_statement(self, &mut sql);
         sql.result()
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_index_create_statement(self, &mut sql);
         sql.result()
     }

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -1,4 +1,4 @@
-use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder, TableIndex};
+use crate::{backend::SchemaBuilder, types::*, SchemaStatementBuilder, TableIndex};
 
 /// Drop an index for an existing table
 ///
@@ -64,14 +64,14 @@ impl IndexDropStatement {
 
 impl SchemaStatementBuilder for IndexDropStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_index_drop_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_index_drop_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 }

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -64,13 +64,13 @@ impl IndexDropStatement {
 
 impl SchemaStatementBuilder for IndexDropStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_index_drop_statement(self, &mut sql);
         sql.result()
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_index_drop_statement(self, &mut sql);
         sql.result()
     }

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -6,14 +6,16 @@ pub use std::fmt::Write;
 pub trait SqlWriter: Write + ToString {
     fn push_param(&mut self, value: Value, query_builder: &dyn QueryBuilder);
 
-    fn as_writer(&mut self) -> &mut dyn Write {
-        &mut self as _
-    }
+    fn as_writer(&mut self) -> &mut dyn Write;
 }
 
 impl SqlWriter for String {
     fn push_param(&mut self, value: Value, query_builder: &dyn QueryBuilder) {
         self.push_str(&query_builder.value_to_string(&value))
+    }
+
+    fn as_writer(&mut self) -> &mut dyn Write {
+        self as _
     }
 }
 
@@ -60,11 +62,15 @@ impl SqlWriter for SqlWriterValues {
         self.counter += 1;
         if self.numbered {
             let counter = self.counter;
-            write!(self, "{}{}", self.placeholder, counter).unwrap();
+            write!(self.string, "{}{}", self.placeholder, counter).unwrap();
         } else {
-            write!(self, "{}", self.placeholder).unwrap();
+            write!(self.string, "{}", self.placeholder).unwrap();
         }
         self.values.push(value)
+    }
+
+    fn as_writer(&mut self) -> &mut dyn Write {
+        self as _
     }
 }
 

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -3,10 +3,75 @@
 use crate::*;
 pub use std::fmt::Write;
 
-#[derive(Debug, Default)]
-pub struct SqlWriter {
-    pub(crate) counter: usize,
+pub trait SqlWriter: Write {
+    fn push_param(&mut self, value: Value, query_builder: &dyn QueryBuilder);
+    fn result(self) -> String;
+}
+
+pub struct SqlStringWriter {
     pub(crate) string: String,
+}
+
+impl SqlStringWriter {
+    pub fn new() -> Self {
+        Self {
+            string: String::with_capacity(256),
+        }
+    }
+}
+
+impl Write for SqlStringWriter {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        write!(self.string, "{}", s)
+    }
+}
+
+impl SqlWriter for SqlStringWriter {
+    fn push_param(&mut self, value: Value, query_builder: &dyn QueryBuilder) {
+        self.string.push_str(&query_builder.value_to_string(&value));
+    }
+
+    fn result(self) -> String {
+        self.string
+    }
+}
+
+pub struct SqlWriterObj {
+    counter: usize,
+    placeholder: String,
+    numbered: bool,
+    string: String,
+    values: Vec<Value>,
+}
+
+impl SqlWriterObj {
+    pub fn new(placeholder: &str, numbered: bool) -> Self {
+        Self {
+            counter: 0,
+            placeholder: placeholder.to_owned(),
+            numbered,
+            string: String::with_capacity(256),
+            values: Vec::new(),
+        }
+    }
+
+    pub fn into_parts(self) -> (String, Values) {
+        (self.string, Values(self.values))
+    }
+}
+
+impl Write for SqlWriterObj {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        write!(self.string, "{}", s)
+    }
+}
+
+impl SqlWriter for SqlWriterObj {
+    fn push_param(&mut self, value: Value, query_builder: &dyn QueryBuilder) {}
+
+    fn result(self) -> String {
+        self.string
+    }
 }
 
 pub fn inject_parameters<I>(sql: &str, params: I, query_builder: &dyn QueryBuilder) -> String
@@ -46,51 +111,6 @@ where
         i += 1;
     }
     output.into_iter().collect()
-}
-
-impl SqlWriter {
-    pub fn new() -> Self {
-        Self {
-            counter: 0,
-            string: String::with_capacity(256),
-        }
-    }
-
-    pub fn push_param(&mut self, sign: &str, numbered: bool) {
-        self.counter += 1;
-        if numbered {
-            let counter = self.counter;
-            write!(self, "{}{}", sign, counter).unwrap();
-        } else {
-            write!(self, "{}", sign).unwrap();
-        }
-    }
-
-    pub fn result(self) -> String {
-        self.string
-    }
-
-    fn skip_str(s: &str, n: usize) -> &str {
-        let mut it = s.chars();
-        for _ in 0..n {
-            it.next();
-        }
-        it.as_str()
-    }
-}
-
-impl std::fmt::Write for SqlWriter {
-    fn write_str(&mut self, s: &str) -> std::result::Result<(), std::fmt::Error> {
-        write!(
-            self.string,
-            "{}",
-            if self.string.ends_with(' ') && s.starts_with(' ') {
-                Self::skip_str(s, 1)
-            } else {
-                s
-            }
-        )
-    }
 }
 
 #[cfg(test)]

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -461,20 +461,24 @@ pub trait ConditionalStatement {
     ///
     /// assert_eq!(
     ///     Query::select()
+    ///         .column(Glyph::Id)
+    ///         .from(Glyph::Table)
     ///         .cond_where(Expr::col(Glyph::Id).eq(1))
     ///         .cond_where(any![Expr::col(Glyph::Id).eq(2), Expr::col(Glyph::Id).eq(3)])
     ///         .to_owned()
     ///         .to_string(PostgresQueryBuilder),
-    ///     r#"SELECT WHERE "id" = 1 AND ("id" = 2 OR "id" = 3)"#
+    ///     r#"SELECT "id" FROM "glyph" WHERE "id" = 1 AND ("id" = 2 OR "id" = 3)"#
     /// );
     ///
     /// assert_eq!(
     ///     Query::select()
+    ///         .column(Glyph::Id)
+    ///         .from(Glyph::Table)
     ///         .cond_where(any![Expr::col(Glyph::Id).eq(2), Expr::col(Glyph::Id).eq(3)])
     ///         .cond_where(Expr::col(Glyph::Id).eq(1))
     ///         .to_owned()
     ///         .to_string(PostgresQueryBuilder),
-    ///     r#"SELECT WHERE ("id" = 2 OR "id" = 3) AND "id" = 1"#
+    ///     r#"SELECT "id" FROM "glyph" WHERE ("id" = 2 OR "id" = 3) AND "id" = 1"#
     /// );
     /// ```
     ///
@@ -485,20 +489,24 @@ pub trait ConditionalStatement {
     ///
     /// assert_eq!(
     ///     Query::select()
+    ///         .column(Glyph::Id)
+    ///         .from(Glyph::Table)
     ///         .cond_where(any![Expr::col(Glyph::Id).eq(1), Expr::col(Glyph::Id).eq(2)])
     ///         .cond_where(any![Expr::col(Glyph::Id).eq(3), Expr::col(Glyph::Id).eq(4)])
     ///         .to_owned()
     ///         .to_string(PostgresQueryBuilder),
-    ///     r#"SELECT WHERE ("id" = 1 OR "id" = 2) AND ("id" = 3 OR "id" = 4)"#
+    ///     r#"SELECT "id" FROM "glyph" WHERE ("id" = 1 OR "id" = 2) AND ("id" = 3 OR "id" = 4)"#
     /// );
     ///
     /// assert_eq!(
     ///     Query::select()
+    ///         .column(Glyph::Id)
+    ///         .from(Glyph::Table)
     ///         .cond_where(all![Expr::col(Glyph::Id).eq(1), Expr::col(Glyph::Id).eq(2)])
     ///         .cond_where(all![Expr::col(Glyph::Id).eq(3), Expr::col(Glyph::Id).eq(4)])
     ///         .to_owned()
     ///         .to_string(PostgresQueryBuilder),
-    ///     r#"SELECT WHERE "id" = 1 AND "id" = 2 AND "id" = 3 AND "id" = 4"#
+    ///     r#"SELECT "id" FROM "glyph" WHERE "id" = 1 AND "id" = 2 AND "id" = 3 AND "id" = 4"#
     /// );
     /// ```
     ///
@@ -509,6 +517,8 @@ pub trait ConditionalStatement {
     ///
     /// assert_eq!(
     ///     Query::select()
+    ///         .column(Glyph::Id)
+    ///         .from(Glyph::Table)
     ///         .cond_where(
     ///             Cond::all()
     ///                 .not()
@@ -522,11 +532,13 @@ pub trait ConditionalStatement {
     ///         )
     ///         .to_owned()
     ///         .to_string(PostgresQueryBuilder),
-    ///     r#"SELECT WHERE (NOT ("id" = 1 AND "id" = 2)) AND ("id" = 3 AND "id" = 4)"#
+    ///     r#"SELECT "id" FROM "glyph" WHERE (NOT ("id" = 1 AND "id" = 2)) AND ("id" = 3 AND "id" = 4)"#
     /// );
     ///
     /// assert_eq!(
     ///     Query::select()
+    ///         .column(Glyph::Id)
+    ///         .from(Glyph::Table)
     ///         .cond_where(
     ///             Cond::all()
     ///                 .add(Expr::col(Glyph::Id).eq(3))
@@ -540,7 +552,7 @@ pub trait ConditionalStatement {
     ///         )
     ///         .to_owned()
     ///         .to_string(PostgresQueryBuilder),
-    ///     r#"SELECT WHERE "id" = 3 AND "id" = 4 AND (NOT ("id" = 1 AND "id" = 2))"#
+    ///     r#"SELECT "id" FROM "glyph" WHERE "id" = 3 AND "id" = 4 AND (NOT ("id" = 1 AND "id" = 2))"#
     /// );
     /// ```
     fn cond_where<C>(&mut self, condition: C) -> &mut Self

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -241,13 +241,8 @@ impl DeleteStatement {
 }
 
 impl QueryStatementBuilder for DeleteStatement {
-    fn build_collect_any_into(
-        &self,
-        query_builder: &dyn QueryBuilder,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        query_builder.prepare_delete_statement(self, sql, collector);
+    fn build_collect_any_into(&self, query_builder: &dyn QueryBuilder, sql: &mut dyn SqlWriter) {
+        query_builder.prepare_delete_statement(self, sql);
     }
 
     fn into_sub_query_statement(self) -> SubQueryStatement {
@@ -256,40 +251,8 @@ impl QueryStatementBuilder for DeleteStatement {
 }
 
 impl QueryStatementWriter for DeleteStatement {
-    /// Build corresponding SQL statement for certain database backend and collect query parameters
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::delete()
-    ///     .from_table(Glyph::Table)
-    ///     .and_where(Expr::col(Glyph::Id).eq(1))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"DELETE FROM `glyph` WHERE `id` = 1"#
-    /// );
-    ///
-    /// let mut params = Vec::new();
-    /// let mut collector = |v| params.push(v);
-    ///
-    /// assert_eq!(
-    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
-    ///     r#"DELETE FROM `glyph` WHERE `id` = ?"#
-    /// );
-    /// assert_eq!(params, vec![Value::Int(Some(1)),]);
-    /// ```
-    fn build_collect<T: QueryBuilder>(
-        &self,
-        query_builder: T,
-        collector: &mut dyn FnMut(Value),
-    ) -> String {
-        let mut sql = SqlWriter::new();
-        query_builder.prepare_delete_statement(self, &mut sql, collector);
-        sql.result()
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter) {
+        query_builder.prepare_delete_statement(self, sql);
     }
 }
 

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -557,13 +557,8 @@ impl InsertStatement {
 }
 
 impl QueryStatementBuilder for InsertStatement {
-    fn build_collect_any_into(
-        &self,
-        query_builder: &dyn QueryBuilder,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        query_builder.prepare_insert_statement(self, sql, collector);
+    fn build_collect_any_into(&self, query_builder: &dyn QueryBuilder, sql: &mut dyn SqlWriter) {
+        query_builder.prepare_insert_statement(self, sql);
     }
 
     fn into_sub_query_statement(self) -> SubQueryStatement {
@@ -572,46 +567,7 @@ impl QueryStatementBuilder for InsertStatement {
 }
 
 impl QueryStatementWriter for InsertStatement {
-    /// Build corresponding SQL statement for certain database backend and collect query parameters
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::insert()
-    ///     .into_table(Glyph::Table)
-    ///     .columns([Glyph::Aspect, Glyph::Image])
-    ///     .values_panic(vec![3.1415.into(), "041080".into()])
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (3.1415, '041080')"#
-    /// );
-    ///
-    /// let mut params = Vec::new();
-    /// let mut collector = |v| params.push(v);
-    ///
-    /// assert_eq!(
-    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
-    ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (?, ?)"#
-    /// );
-    /// assert_eq!(
-    ///     params,
-    ///     vec![
-    ///         Value::Double(Some(3.1415)),
-    ///         Value::String(Some(Box::new(String::from("041080")))),
-    ///     ]
-    /// );
-    /// ```
-    fn build_collect<T: QueryBuilder>(
-        &self,
-        query_builder: T,
-        collector: &mut dyn FnMut(Value),
-    ) -> String {
-        let mut sql = SqlWriter::new();
-        query_builder.prepare_insert_statement(self, &mut sql, collector);
-        sql.result()
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter) {
+        query_builder.prepare_insert_statement(self, sql);
     }
 }

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -2195,13 +2195,8 @@ impl SelectStatement {
 }
 
 impl QueryStatementBuilder for SelectStatement {
-    fn build_collect_any_into(
-        &self,
-        query_builder: &dyn QueryBuilder,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        query_builder.prepare_select_statement(self, sql, collector);
+    fn build_collect_any_into(&self, query_builder: &dyn QueryBuilder, sql: &mut dyn SqlWriter) {
+        query_builder.prepare_select_statement(self, sql);
     }
 
     fn into_sub_query_statement(self) -> SubQueryStatement {
@@ -2210,46 +2205,8 @@ impl QueryStatementBuilder for SelectStatement {
 }
 
 impl QueryStatementWriter for SelectStatement {
-    /// Build corresponding SQL statement for certain database backend and collect query parameters
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .column(Glyph::Aspect)
-    ///     .from(Glyph::Table)
-    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-    ///     .order_by(Glyph::Image, Order::Desc)
-    ///     .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
-    /// );
-    ///
-    /// let mut params = Vec::new();
-    /// let mut collector = |v| params.push(v);
-    ///
-    /// assert_eq!(
-    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
-    ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, ?) > ? ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
-    /// );
-    /// assert_eq!(
-    ///     params,
-    ///     vec![Value::Int(Some(0)), Value::Int(Some(2))]
-    /// );
-    /// ```
-    fn build_collect<T: QueryBuilder>(
-        &self,
-        query_builder: T,
-        collector: &mut dyn FnMut(Value),
-    ) -> String {
-        let mut sql = SqlWriter::new();
-        query_builder.prepare_select_statement(self, &mut sql, collector);
-        sql.result()
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter) {
+        query_builder.prepare_select_statement(self, sql);
     }
 }
 

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -1,15 +1,12 @@
 use std::fmt::Debug;
 
-use crate::{
-    backend::QueryBuilder, value::Values, SqlStringWriter, SqlWriter, SqlWriterObj,
-    SubQueryStatement,
-};
+use crate::{backend::QueryBuilder, value::Values, SqlWriter, SqlWriterValues, SubQueryStatement};
 
 pub trait QueryStatementBuilder: Debug {
     /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
     fn build_any(&self, query_builder: &dyn QueryBuilder) -> (String, Values) {
         let (placeholder, numbered) = query_builder.placeholder();
-        let mut sql = SqlWriterObj::new(placeholder, numbered);
+        let mut sql = SqlWriterValues::new(placeholder, numbered);
         self.build_collect_any_into(query_builder, &mut sql);
         sql.into_parts()
     }
@@ -21,7 +18,7 @@ pub trait QueryStatementBuilder: Debug {
         sql: &mut dyn SqlWriter,
     ) -> String {
         self.build_collect_any_into(query_builder, sql);
-        sql.result()
+        sql.to_string()
     }
 
     /// Build corresponding SQL statement into the SqlWriter for certain database backend and collect query parameters
@@ -52,9 +49,9 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     /// );
     /// ```
     fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         self.build_collect_any_into(&query_builder, &mut sql);
-        sql.result()
+        sql
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
@@ -83,7 +80,7 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     /// ```
     fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
         let (placeholder, numbered) = query_builder.placeholder();
-        let mut sql = SqlWriterObj::new(placeholder, numbered);
+        let mut sql = SqlWriterValues::new(placeholder, numbered);
         self.build_collect_into(query_builder, &mut sql);
         sql.into_parts()
     }
@@ -122,9 +119,9 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     /// ```
     fn build_collect<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter) -> String {
         let (placeholder, numbered) = query_builder.placeholder();
-        let mut sql = SqlWriterObj::new(placeholder, numbered);
+        let mut sql = SqlWriterValues::new(placeholder, numbered);
         self.build_collect_into(query_builder, &mut sql);
-        sql.result()
+        sql.to_string()
     }
 
     fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter);

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -105,16 +105,18 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2 ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
     ///
-    /// let mut params = Vec::new();
-    /// let mut collector = |v| params.push(v);
+    /// let (placeholder, numbered) = MysqlQueryBuilder.placeholder();
+    /// let mut sql = SqlWriterValues::new(placeholder, numbered);
     ///
     /// assert_eq!(
-    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
+    ///     query.build_collect(MysqlQueryBuilder, &mut sql),
     ///     r#"SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, ?) > ? ORDER BY `image` DESC, `glyph`.`aspect` ASC"#
     /// );
+    ///
+    /// let (sql, values) = sql.into_parts();
     /// assert_eq!(
-    ///     params,
-    ///     vec![Value::Int(Some(0)), Value::Int(Some(2))]
+    ///     values,
+    ///     Values(vec![Value::Int(Some(0)), Value::Int(Some(2))])
     /// );
     /// ```
     fn build_collect<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter) -> String {

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -118,9 +118,7 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     /// );
     /// ```
     fn build_collect<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter) -> String {
-        let (placeholder, numbered) = query_builder.placeholder();
-        let mut sql = SqlWriterValues::new(placeholder, numbered);
-        self.build_collect_into(query_builder, &mut sql);
+        self.build_collect_into(query_builder, sql);
         sql.to_string()
     }
 

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -1,38 +1,31 @@
-use crate::{
-    backend::QueryBuilder,
-    prepare::inject_parameters,
-    value::{Value, Values},
-    SqlWriter, SubQueryStatement,
-};
 use std::fmt::Debug;
+
+use crate::{
+    backend::QueryBuilder, value::Values, SqlStringWriter, SqlWriter, SqlWriterObj,
+    SubQueryStatement,
+};
 
 pub trait QueryStatementBuilder: Debug {
     /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
     fn build_any(&self, query_builder: &dyn QueryBuilder) -> (String, Values) {
-        let mut values = Vec::new();
-        let mut collector = |v| values.push(v);
-        let sql = self.build_collect_any(query_builder, &mut collector);
-        (sql, Values(values))
+        let (placeholder, numbered) = query_builder.placeholder();
+        let mut sql = SqlWriterObj::new(placeholder, numbered);
+        self.build_collect_any_into(query_builder, &mut sql);
+        sql.into_parts()
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters
     fn build_collect_any(
         &self,
         query_builder: &dyn QueryBuilder,
-        collector: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) -> String {
-        let mut sql = SqlWriter::new();
-        self.build_collect_any_into(query_builder, &mut sql, collector);
+        self.build_collect_any_into(query_builder, sql);
         sql.result()
     }
 
     /// Build corresponding SQL statement into the SqlWriter for certain database backend and collect query parameters
-    fn build_collect_any_into(
-        &self,
-        query_builder: &dyn QueryBuilder,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    );
+    fn build_collect_any_into(&self, query_builder: &dyn QueryBuilder, sql: &mut dyn SqlWriter);
 
     fn into_sub_query_statement(self) -> SubQueryStatement;
 }
@@ -59,8 +52,9 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     /// );
     /// ```
     fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
-        let (sql, values) = self.build_any(&query_builder);
-        inject_parameters(&sql, values.0, &query_builder)
+        let mut sql = SqlStringWriter::new();
+        self.build_collect_any_into(&query_builder, &mut sql);
+        sql.result()
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters into a vector
@@ -88,10 +82,10 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     /// );
     /// ```
     fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
-        let mut values = Vec::new();
-        let mut collector = |v| values.push(v);
-        let sql = self.build_collect(query_builder, &mut collector);
-        (sql, Values(values))
+        let (placeholder, numbered) = query_builder.placeholder();
+        let mut sql = SqlWriterObj::new(placeholder, numbered);
+        self.build_collect_into(query_builder, &mut sql);
+        sql.into_parts()
     }
 
     /// Build corresponding SQL statement for certain database backend and collect query parameters
@@ -126,9 +120,12 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     ///     vec![Value::Int(Some(0)), Value::Int(Some(2))]
     /// );
     /// ```
-    fn build_collect<T: QueryBuilder>(
-        &self,
-        query_builder: T,
-        collector: &mut dyn FnMut(Value),
-    ) -> String;
+    fn build_collect<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter) -> String {
+        let (placeholder, numbered) = query_builder.placeholder();
+        let mut sql = SqlWriterObj::new(placeholder, numbered);
+        self.build_collect_into(query_builder, &mut sql);
+        sql.result()
+    }
+
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter);
 }

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -356,13 +356,8 @@ impl UpdateStatement {
 }
 
 impl QueryStatementBuilder for UpdateStatement {
-    fn build_collect_any_into(
-        &self,
-        query_builder: &dyn QueryBuilder,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        query_builder.prepare_update_statement(self, sql, collector);
+    fn build_collect_any_into(&self, query_builder: &dyn QueryBuilder, sql: &mut dyn SqlWriter) {
+        query_builder.prepare_update_statement(self, sql);
     }
 
     fn into_sub_query_statement(self) -> SubQueryStatement {
@@ -371,51 +366,8 @@ impl QueryStatementBuilder for UpdateStatement {
 }
 
 impl QueryStatementWriter for UpdateStatement {
-    /// Build corresponding SQL statement for certain database backend and collect query parameters
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::update()
-    ///     .table(Glyph::Table)
-    ///     .values(vec![
-    ///         (Glyph::Aspect, 2.1345.into()),
-    ///         (Glyph::Image, "235m".into()),
-    ///     ])
-    ///     .and_where(Expr::col(Glyph::Id).eq(1))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"UPDATE `glyph` SET `aspect` = 2.1345, `image` = '235m' WHERE `id` = 1"#
-    /// );
-    ///
-    /// let mut params = Vec::new();
-    /// let mut collector = |v| params.push(v);
-    ///
-    /// assert_eq!(
-    ///     query.build_collect(MysqlQueryBuilder, &mut collector),
-    ///     r#"UPDATE `glyph` SET `aspect` = ?, `image` = ? WHERE `id` = ?"#
-    /// );
-    /// assert_eq!(
-    ///     params,
-    ///     vec![
-    ///         Value::Double(Some(2.1345)),
-    ///         Value::String(Some(Box::new(String::from("235m")))),
-    ///         Value::Int(Some(1)),
-    ///     ]
-    /// );
-    /// ```
-    fn build_collect<T: QueryBuilder>(
-        &self,
-        query_builder: T,
-        collector: &mut dyn FnMut(Value),
-    ) -> String {
-        let mut sql = SqlWriter::new();
-        query_builder.prepare_update_statement(self, &mut sql, collector);
-        sql.result()
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter) {
+        query_builder.prepare_update_statement(self, sql);
     }
 }
 

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -9,7 +9,6 @@ use crate::SimpleExpr;
 use crate::SqlWriter;
 use crate::SubQueryStatement;
 use crate::TableRef;
-use crate::Value;
 use crate::{Alias, QueryBuilder};
 use std::ops::Deref;
 
@@ -591,13 +590,8 @@ impl WithQuery {
 }
 
 impl QueryStatementBuilder for WithQuery {
-    fn build_collect_any_into(
-        &self,
-        query_builder: &dyn QueryBuilder,
-        sql: &mut SqlWriter,
-        collector: &mut dyn FnMut(Value),
-    ) {
-        query_builder.prepare_with_query(self, sql, collector);
+    fn build_collect_any_into(&self, query_builder: &dyn QueryBuilder, sql: &mut dyn SqlWriter) {
+        query_builder.prepare_with_query(self, sql);
     }
 
     fn into_sub_query_statement(self) -> SubQueryStatement {
@@ -606,13 +600,7 @@ impl QueryStatementBuilder for WithQuery {
 }
 
 impl QueryStatementWriter for WithQuery {
-    fn build_collect<T: crate::QueryBuilder>(
-        &self,
-        query_builder: T,
-        collector: &mut dyn FnMut(Value),
-    ) -> String {
-        let mut sql = SqlWriter::new();
-        query_builder.prepare_with_query(self, &mut sql, collector);
-        sql.result()
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut dyn SqlWriter) {
+        query_builder.prepare_with_query(self, sql);
     }
 }

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -385,13 +385,13 @@ impl TableAlterStatement {
 
 impl SchemaStatementBuilder for TableAlterStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_table_alter_statement(self, &mut sql);
         sql.result()
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_table_alter_statement(self, &mut sql);
         sql.result()
     }

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -1,7 +1,4 @@
-use crate::{
-    backend::SchemaBuilder, prepare::*, types::*, ColumnDef, SchemaStatementBuilder,
-    TableForeignKey,
-};
+use crate::{backend::SchemaBuilder, types::*, ColumnDef, SchemaStatementBuilder, TableForeignKey};
 
 /// Alter a table
 ///
@@ -385,14 +382,14 @@ impl TableAlterStatement {
 
 impl SchemaStatementBuilder for TableAlterStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_alter_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_alter_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 }

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -1,4 +1,4 @@
-use crate::{types::*, value::*};
+use crate::{expr::*, types::*};
 
 /// Specification of a table column
 #[derive(Debug, Clone)]
@@ -53,7 +53,7 @@ pub enum ColumnType {
 pub enum ColumnSpec {
     Null,
     NotNull,
-    Default(Value),
+    Default(SimpleExpr),
     AutoIncrement,
     UniqueKey,
     PrimaryKey,
@@ -151,7 +151,7 @@ impl ColumnDef {
     /// Set default value of a column
     pub fn default<T>(&mut self, value: T) -> &mut Self
     where
-        T: Into<Value>,
+        T: Into<SimpleExpr>,
     {
         self.spec.push(ColumnSpec::Default(value.into()));
         self

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -289,13 +289,13 @@ impl TableCreateStatement {
 
 impl SchemaStatementBuilder for TableCreateStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_table_create_statement(self, &mut sql);
         sql.result()
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_table_create_statement(self, &mut sql);
         sql.result()
     }

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -1,6 +1,5 @@
 use crate::{
-    backend::SchemaBuilder, foreign_key::*, index::*, prepare::*, types::*, ColumnDef,
-    SchemaStatementBuilder,
+    backend::SchemaBuilder, foreign_key::*, index::*, types::*, ColumnDef, SchemaStatementBuilder,
 };
 
 /// Create a table
@@ -289,14 +288,14 @@ impl TableCreateStatement {
 
 impl SchemaStatementBuilder for TableCreateStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_create_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_create_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 }

--- a/src/table/drop.rs
+++ b/src/table/drop.rs
@@ -93,13 +93,13 @@ impl TableDropStatement {
 
 impl SchemaStatementBuilder for TableDropStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_table_drop_statement(self, &mut sql);
         sql.result()
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_table_drop_statement(self, &mut sql);
         sql.result()
     }

--- a/src/table/drop.rs
+++ b/src/table/drop.rs
@@ -1,4 +1,4 @@
-use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder};
+use crate::{backend::SchemaBuilder, types::*, SchemaStatementBuilder};
 
 /// Drop a table
 ///
@@ -93,14 +93,14 @@ impl TableDropStatement {
 
 impl SchemaStatementBuilder for TableDropStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_drop_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_drop_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 }

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -66,13 +66,13 @@ impl TableRenameStatement {
 
 impl SchemaStatementBuilder for TableRenameStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_table_rename_statement(self, &mut sql);
         sql.result()
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_table_rename_statement(self, &mut sql);
         sql.result()
     }

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -1,4 +1,4 @@
-use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder};
+use crate::{backend::SchemaBuilder, types::*, SchemaStatementBuilder};
 
 /// Rename a table
 ///
@@ -66,14 +66,14 @@ impl TableRenameStatement {
 
 impl SchemaStatementBuilder for TableRenameStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_rename_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_rename_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 }

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -1,4 +1,4 @@
-use crate::{backend::SchemaBuilder, prepare::*, types::*, SchemaStatementBuilder};
+use crate::{backend::SchemaBuilder, types::*, SchemaStatementBuilder};
 
 /// Drop a table
 ///
@@ -57,14 +57,14 @@ impl TableTruncateStatement {
 
 impl SchemaStatementBuilder for TableTruncateStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_truncate_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlStringWriter::new();
+        let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_truncate_statement(self, &mut sql);
-        sql.result()
+        sql
     }
 }

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -57,13 +57,13 @@ impl TableTruncateStatement {
 
 impl SchemaStatementBuilder for TableTruncateStatement {
     fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_table_truncate_statement(self, &mut sql);
         sql.result()
     }
 
     fn build_any(&self, schema_builder: &dyn SchemaBuilder) -> String {
-        let mut sql = SqlWriter::new();
+        let mut sql = SqlStringWriter::new();
         schema_builder.prepare_table_truncate_statement(self, &mut sql);
         sql.result()
     }

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -1,10 +1,11 @@
 //! Configurations for test cases and examples. Not intended for actual use.
 
+use std::fmt;
+
 #[cfg(feature = "with-json")]
 pub use serde_json::json;
 
 use crate::Iden;
-use crate::SqlWriter;
 
 /// Representation of a database table named `Character`.
 ///
@@ -28,7 +29,7 @@ pub enum Character {
 pub type Char = Character;
 
 impl Iden for Character {
-    fn unquoted(&self, s: &mut dyn SqlWriter) {
+    fn unquoted(&self, s: &mut dyn fmt::Write) {
         write!(
             s,
             "{}",
@@ -63,7 +64,7 @@ pub enum Font {
 }
 
 impl Iden for Font {
-    fn unquoted(&self, s: &mut dyn SqlWriter) {
+    fn unquoted(&self, s: &mut dyn fmt::Write) {
         write!(
             s,
             "{}",
@@ -93,7 +94,7 @@ pub enum Glyph {
 }
 
 impl Iden for Glyph {
-    fn unquoted(&self, s: &mut dyn SqlWriter) {
+    fn unquoted(&self, s: &mut dyn fmt::Write) {
         write!(
             s,
             "{}",

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -1,11 +1,10 @@
 //! Configurations for test cases and examples. Not intended for actual use.
 
-pub use std::fmt::Write as FmtWrite;
-
 #[cfg(feature = "with-json")]
 pub use serde_json::json;
 
 use crate::Iden;
+use crate::SqlWriter;
 
 /// Representation of a database table named `Character`.
 ///
@@ -29,7 +28,7 @@ pub enum Character {
 pub type Char = Character;
 
 impl Iden for Character {
-    fn unquoted(&self, s: &mut dyn FmtWrite) {
+    fn unquoted(&self, s: &mut dyn SqlWriter) {
         write!(
             s,
             "{}",
@@ -64,7 +63,7 @@ pub enum Font {
 }
 
 impl Iden for Font {
-    fn unquoted(&self, s: &mut dyn FmtWrite) {
+    fn unquoted(&self, s: &mut dyn SqlWriter) {
         write!(
             s,
             "{}",
@@ -94,7 +93,7 @@ pub enum Glyph {
 }
 
 impl Iden for Glyph {
-    fn unquoted(&self, s: &mut dyn FmtWrite) {
+    fn unquoted(&self, s: &mut dyn SqlWriter) {
         write!(
             s,
             "{}",

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Base types used throughout sea-query.
 
-use crate::{expr::*, prepare::SqlWriter, query::*, ValueTuple, Values};
+use crate::{expr::*, query::*, ValueTuple, Values};
 use std::fmt;
 
 #[cfg(not(feature = "thread-safe"))]
@@ -12,7 +12,7 @@ macro_rules! iden_trait {
     ($($bounds:ident),*) => {
         /// Identifier
         pub trait Iden where $(Self: $bounds),* {
-            fn prepare(&self, s: &mut dyn SqlWriter, q: char) {
+            fn prepare(&self, s: &mut dyn fmt::Write, q: char) {
                 write!(s, "{}{}{}", q, self.quoted(q), q).unwrap();
             }
 
@@ -28,7 +28,7 @@ macro_rules! iden_trait {
                 s.to_owned()
             }
 
-            fn unquoted(&self, s: &mut dyn SqlWriter);
+            fn unquoted(&self, s: &mut dyn fmt::Write);
         }
     };
 }
@@ -373,7 +373,7 @@ impl Alias {
 }
 
 impl Iden for Alias {
-    fn unquoted(&self, s: &mut dyn SqlWriter) {
+    fn unquoted(&self, s: &mut dyn fmt::Write) {
         write!(s, "{}", self.0).unwrap();
     }
 }
@@ -391,7 +391,7 @@ impl Default for NullAlias {
 }
 
 impl Iden for NullAlias {
-    fn unquoted(&self, _s: &mut dyn SqlWriter) {}
+    fn unquoted(&self, _s: &mut dyn fmt::Write) {}
 }
 
 impl LikeExpr {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Base types used throughout sea-query.
 
-use crate::{expr::*, query::*, ValueTuple, Values};
+use crate::{expr::*, prepare::SqlWriter, query::*, ValueTuple, Values};
 use std::fmt;
 
 #[cfg(not(feature = "thread-safe"))]
@@ -12,7 +12,7 @@ macro_rules! iden_trait {
     ($($bounds:ident),*) => {
         /// Identifier
         pub trait Iden where $(Self: $bounds),* {
-            fn prepare(&self, s: &mut dyn fmt::Write, q: char) {
+            fn prepare(&self, s: &mut dyn SqlWriter, q: char) {
                 write!(s, "{}{}{}", q, self.quoted(q), q).unwrap();
             }
 
@@ -28,7 +28,7 @@ macro_rules! iden_trait {
                 s.to_owned()
             }
 
-            fn unquoted(&self, s: &mut dyn fmt::Write);
+            fn unquoted(&self, s: &mut dyn SqlWriter);
         }
     };
 }
@@ -373,7 +373,7 @@ impl Alias {
 }
 
 impl Iden for Alias {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
+    fn unquoted(&self, s: &mut dyn SqlWriter) {
         write!(s, "{}", self.0).unwrap();
     }
 }
@@ -391,7 +391,7 @@ impl Default for NullAlias {
 }
 
 impl Iden for NullAlias {
-    fn unquoted(&self, _s: &mut dyn fmt::Write) {}
+    fn unquoted(&self, _s: &mut dyn SqlWriter) {}
 }
 
 impl LikeExpr {

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -6,7 +6,7 @@ mod index;
 mod interval;
 mod query;
 mod table;
-// mod types;
+mod types;
 
 #[path = "../common.rs"]
 mod common;

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -6,7 +6,7 @@ mod index;
 mod interval;
 mod query;
 mod table;
-mod types;
+// mod types;
 
 #[path = "../common.rs"]
 mod common;

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1029,7 +1029,7 @@ fn select_60() {
         .build(PostgresQueryBuilder);
 
     let (statement, values) = Query::select()
-        .expr(Expr::cust_with_values(&cust_query[6..], cust_values.0))
+        .expr(Expr::cust_with_values(&cust_query[7..], cust_values.0))
         .limit(5)
         .build(PostgresQueryBuilder);
 


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-query/issues/347

## Adds

- [x] new trait `SqlWriter`
- [x] `impl SqlWriter for String` - write sql to String with inline `Value`
- [x] `impl SqlWriter for SqlWriterValues` - write sql to String with store `Value` into `Vec`

## Breaking Changes

- [x] Remove `struct SqlWriter`
- [x] Remove `collector` from QueryBuilder and other backend traits
- [x] backend traits instead `SqlWriter` parameter get `&mut dyn SqlWriter`

## Context: https://github.com/SeaQL/sea-query/pull/428#issuecomment-1239542662

 ```rust
pub trait SqlWriter: Write + ToString {
    fn push_param(&mut self, value: Value, query_builder: &dyn QueryBuilder);

    fn as_writer(&mut self) -> &mut dyn Write;
}
```