### PR TITLE
query(union): add intersect and except types

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -133,7 +133,9 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         if !select.unions.is_empty() {
             select.unions.iter().for_each(|(union_type, query)| {
                 match union_type {
+                    UnionType::Intersect => write!(sql, " INTERSECT ").unwrap(),
                     UnionType::Distinct => write!(sql, " UNION ").unwrap(),
+                    UnionType::Except => write!(sql, " EXCEPT ").unwrap(),
                     UnionType::All => write!(sql, " UNION ALL ").unwrap(),
                 }
                 self.prepare_select_statement(query, sql, collector);

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -118,7 +118,9 @@ pub struct LockClause {
 /// List of union types that can be used in union clause
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnionType {
+    Intersect,
     Distinct,
+    Except,
     All,
 }
 


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-query/issues/427

## Changes

- [x] add the INTERSECT and EXCEPT operators