### PR TITLE
issues-440 Add new keywords for work

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -688,7 +688,6 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                     Function::Lower => "LOWER",
                     Function::Upper => "UPPER",
                     Function::Custom(_) => "",
-                    Function::CurrentTimestamp => "CURRENT_TIMESTAMP",
                     Function::Random => self.random_function(),
                     #[cfg(feature = "backend-postgres")]
                     Function::PgFunction(_) => unimplemented!(),
@@ -1035,18 +1034,12 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         sql: &mut SqlWriter,
         _collector: &mut dyn FnMut(Value),
     ) {
-        if let Keyword::Custom(iden) = keyword {
-            iden.unquoted(sql);
-        } else {
-            write!(
-                sql,
-                "{}",
-                match keyword {
-                    Keyword::Null => "NULL",
-                    Keyword::Custom(_) => "",
-                }
-            )
-            .unwrap();
+        match keyword {
+            Keyword::Null => write!(sql, "NULL").unwrap(),
+            Keyword::CurrentDate => write!(sql, "CURRENT_DATE").unwrap(),
+            Keyword::CurrentTime => write!(sql, "CURRENT_TIME").unwrap(),
+            Keyword::CurrentTimestamp => write!(sql, "CURRENT_TIMESTAMP").unwrap(),
+            Keyword::Custom(iden) => iden.unquoted(sql),
         }
     }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2120,6 +2120,84 @@ impl Expr {
     {
         CaseStatement::new().case(cond, then)
     }
+
+    /// Keyword `CURRENT_TIMESTAMP`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{Query, Expr, PostgresQueryBuilder, MysqlQueryBuilder, SqliteQueryBuilder};
+    ///
+    /// let query = Query::select().expr(Expr::current_date()).to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT CURRENT_DATE"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT CURRENT_DATE"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT CURRENT_DATE"#
+    /// );
+    /// ```
+    pub fn current_date() -> SimpleExpr {
+        SimpleExpr::Keyword(Keyword::CurrentDate)
+    }
+
+    /// Keyword `CURRENT_TIMESTAMP`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{Query, Expr, PostgresQueryBuilder, MysqlQueryBuilder, SqliteQueryBuilder};
+    ///
+    /// let query = Query::select().expr(Expr::current_time()).to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT CURRENT_TIME"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT CURRENT_TIME"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT CURRENT_TIME"#
+    /// );
+    /// ```
+    pub fn current_time() -> SimpleExpr {
+        SimpleExpr::Keyword(Keyword::CurrentTime)
+    }
+
+    /// Keyword `CURRENT_TIMESTAMP`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{Query, Expr, PostgresQueryBuilder, MysqlQueryBuilder, SqliteQueryBuilder};
+    ///
+    /// let query = Query::select().expr(Expr::current_timestamp()).to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT CURRENT_TIMESTAMP"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT CURRENT_TIMESTAMP"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT CURRENT_TIMESTAMP"#
+    /// );
+    /// ```
+    pub fn current_timestamp() -> SimpleExpr {
+        SimpleExpr::Keyword(Keyword::CurrentTimestamp)
+    }
 }
 
 impl From<Expr> for SimpleExpr {

--- a/src/func.rs
+++ b/src/func.rs
@@ -21,7 +21,6 @@ pub enum Function {
     Coalesce,
     Lower,
     Upper,
-    CurrentTimestamp,
     Random,
     #[cfg(feature = "backend-postgres")]
     PgFunction(PgFunction),
@@ -467,33 +466,6 @@ impl Func {
         T: Into<SimpleExpr>,
     {
         Expr::func(Function::Upper).arg(expr)
-    }
-
-    /// Call `CURRENT_TIMESTAMP` function.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::tests_cfg::Character::Character;
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select().expr(Func::current_timestamp()).to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT CURRENT_TIMESTAMP()"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT CURRENT_TIMESTAMP()"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT CURRENT_TIMESTAMP()"#
-    /// );
-    /// ```
-    pub fn current_timestamp() -> SimpleExpr {
-        Expr::func(Function::CurrentTimestamp).into()
     }
 
     /// Call `RANDOM` function.

--- a/src/types.rs
+++ b/src/types.rs
@@ -200,6 +200,9 @@ pub struct NullAlias;
 #[derive(Debug, Clone)]
 pub enum Keyword {
     Null,
+    CurrentDate,
+    CurrentTime,
+    CurrentTimestamp,
     Custom(DynIden),
 }
 


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <https://github.com/SeaQL/sea-query/issues/440>

## Adds

- Add new Keywords: `CURRENT_DATE`, `CURRENT_TIME`, `CURRENT_TIMESTAMP` (all this keywords support by Mysql, Sqlite, Postgresql)