### PR TITLE
fix: provide error hint for unsupported column type

### DIFF
--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -236,7 +236,7 @@ impl PostgresQueryBuilder {
                     ColumnType::SmallInteger(_) => write!(sql, "smallserial").unwrap(),
                     ColumnType::Integer(_) => write!(sql, "serial").unwrap(),
                     ColumnType::BigInteger(_) => write!(sql, "bigserial").unwrap(),
-                    _ => unimplemented!(),
+                    _ => unimplemented!("{:?} doesn't support auto increment", column_type),
                 }
             } else {
                 self.prepare_column_type(column_type, sql);


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->
## Changes

When using `auto_increment` with random column types the current error message doesn't describe the actual reason when running migrations:

```
`migration up`
Applying 1 pending migrations
Applying migration 'm20220915_153744_create_links_table'
thread 'main' panicked at 'not implemented', sea-query-0.26.3/src/backend/postgres/table.rs:239:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```