### PR TITLE
Small improvments

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ assert_eq!(
         .column(Glyph::Image)
         .from(Glyph::Table)
         .and_where(Expr::col(Glyph::Image).like("A"))
-        .and_where(Expr::col(Glyph::Id).is_in(vec![1, 2, 3]))
+        .and_where(Expr::col(Glyph::Id).is_in([1, 2, 3]))
         .build(PostgresQueryBuilder),
     (
         r#"SELECT "image" FROM "glyph" WHERE "image" LIKE $1 AND "id" IN ($2, $3, $4)"#
             .to_owned(),
-        Values(vec![
+        Values([
             Value::String(Some(Box::new("A".to_owned()))),
             Value::Int(Some(1)),
             Value::Int(Some(2)),
@@ -231,7 +231,7 @@ assert_eq!(
         .and_where(
             Expr::col(Char::SizeW).in_subquery(
                 Query::select()
-                    .expr(Expr::cust_with_values("ln($1 ^ $2)", vec![2.4, 1.2]))
+                    .expr(Expr::cust_with_values("ln($1 ^ $2)", [2.4, 1.2]))
                     .take()
             )
         )
@@ -270,7 +270,7 @@ assert_eq!(
                 )
                 .add(
                     Cond::all()
-                        .add(Expr::col(Glyph::Aspect).is_in(vec![3, 4]))
+                        .add(Expr::col(Glyph::Aspect).is_in([3, 4]))
                         .add(Expr::col(Glyph::Image).like("A%"))
                 )
         )
@@ -290,7 +290,7 @@ There is also the [`any!`] and [`all!`] macro at your convenience:
 
 ```rust
 Query::select().cond_where(any![
-    Expr::col(Glyph::Aspect).is_in(vec![3, 4]),
+    Expr::col(Glyph::Aspect).is_in([3, 4]),
     all![
         Expr::col(Glyph::Aspect).is_null(),
         Expr::col(Glyph::Image).like("A%")

--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -91,7 +91,7 @@ fn main() {
             Document::Decimal,
             Document::Array,
         ])
-        .values_panic(vec![
+        .values_panic([
             document_chrono.uuid.into(),
             serde_json::to_value(document_chrono.json_field)
                 .unwrap()
@@ -101,7 +101,7 @@ fn main() {
             document_chrono.decimal.into(),
             document_chrono.array.into(),
         ])
-        .values_panic(vec![
+        .values_panic([
             document_time.uuid.into(),
             serde_json::to_value(document_time.json_field)
                 .unwrap()

--- a/examples/sqlx_any/src/main.rs
+++ b/examples/sqlx_any/src/main.rs
@@ -72,12 +72,12 @@ async fn main() {
 
     let (sql, values) = Query::insert()
         .into_table(Character::Table)
-        .columns(vec![
+        .columns([
             Character::FontSize,
             Character::Character,
             Character::Created,
         ])
-        .values_panic(vec![
+        .values_panic([
             12.into(),
             "A".into(),
             NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
@@ -95,7 +95,7 @@ async fn main() {
     // Read
 
     let (sql, values) = Query::select()
-        .columns(vec![
+        .columns([
             Character::Id,
             Character::Character,
             Character::FontSize,
@@ -120,7 +120,7 @@ async fn main() {
 
     let (sql, values) = Query::update()
         .table(Character::Table)
-        .values(vec![(Character::FontSize, 24.into())])
+        .values([(Character::FontSize, 24.into())])
         .and_where(Expr::col(Character::Id).eq(id))
         .build_any_sqlx(query_builder);
 

--- a/examples/sqlx_mysql/src/main.rs
+++ b/examples/sqlx_mysql/src/main.rs
@@ -56,7 +56,7 @@ async fn main() {
             Character::BigDecimal,
             Character::Created,
         ])
-        .values_panic(vec![
+        .values_panic([
             Uuid::new_v4().into(),
             12.into(),
             "A".into(),
@@ -71,7 +71,7 @@ async fn main() {
                 .into(),
             NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
         ])
-        .values_panic(vec![
+        .values_panic([
             Uuid::new_v4().into(),
             12.into(),
             "A".into(),
@@ -134,7 +134,7 @@ async fn main() {
 
     let (sql, values) = Query::update()
         .table(Character::Table)
-        .values(vec![(Character::FontSize, 24.into())])
+        .values([(Character::FontSize, 24.into())])
         .and_where(Expr::col(Character::Id).eq(id))
         .build_sqlx(MysqlQueryBuilder);
 
@@ -184,8 +184,8 @@ async fn main() {
     let (sql, values) = Query::insert()
         .into_table(Character::Table)
         .columns([Character::Id, Character::FontSize, Character::Character])
-        .values_panic(vec![1.into(), 16.into(), "B".into()])
-        .values_panic(vec![2.into(), 24.into(), "C".into()])
+        .values_panic([1.into(), 16.into(), "B".into()])
+        .values_panic([2.into(), 24.into(), "C".into()])
         .on_conflict(
             OnConflict::new()
                 .update_columns([Character::FontSize, Character::Character])

--- a/examples/sqlx_postgres/src/main.rs
+++ b/examples/sqlx_postgres/src/main.rs
@@ -65,7 +65,7 @@ async fn main() {
             Character::Inet,
             Character::MacAddress,
         ])
-        .values_panic(vec![
+        .values_panic([
             Uuid::new_v4().into(),
             12.into(),
             "A".into(),
@@ -84,7 +84,7 @@ async fn main() {
                 .into(),
             get_mac_address().unwrap().unwrap().into(),
         ])
-        .values_panic(vec![
+        .values_panic([
             Uuid::new_v4().into(),
             12.into(),
             "A".into(),
@@ -157,7 +157,7 @@ async fn main() {
 
     let (sql, values) = Query::update()
         .table(Character::Table)
-        .values(vec![(Character::FontSize, 24.into())])
+        .values([(Character::FontSize, 24.into())])
         .and_where(Expr::col(Character::Id).eq(id))
         .build_sqlx(PostgresQueryBuilder);
 
@@ -225,8 +225,8 @@ async fn main() {
     let (sql, values) = Query::insert()
         .into_table(Character::Table)
         .columns([Character::Id, Character::FontSize, Character::Character])
-        .values_panic(vec![1.into(), 16.into(), "B".into()])
-        .values_panic(vec![2.into(), 24.into(), "C".into()])
+        .values_panic([1.into(), 16.into(), "B".into()])
+        .values_panic([2.into(), 24.into(), "C".into()])
         .on_conflict(
             OnConflict::column(Character::Id)
                 .update_columns([Character::FontSize, Character::Character])

--- a/examples/sqlx_sqlite/src/main.rs
+++ b/examples/sqlx_sqlite/src/main.rs
@@ -46,7 +46,7 @@ async fn main() {
             Character::Meta,
             Character::Created,
         ])
-        .values_panic(vec![
+        .values_panic([
             Uuid::new_v4().into(),
             12.into(),
             "A".into(),
@@ -56,7 +56,7 @@ async fn main() {
             .into(),
             NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
         ])
-        .values_panic(vec![
+        .values_panic([
             Uuid::new_v4().into(),
             12.into(),
             "A".into(),
@@ -113,7 +113,7 @@ async fn main() {
     // Update
     let (sql, values) = Query::update()
         .table(Character::Table)
-        .values(vec![(Character::FontSize, 24.into())])
+        .values([(Character::FontSize, 24.into())])
         .and_where(Expr::col(Character::Id).eq(id))
         .build_sqlx(SqliteQueryBuilder);
 
@@ -173,8 +173,8 @@ async fn main() {
     let (sql, values) = Query::insert()
         .into_table(Character::Table)
         .columns([Character::Id, Character::FontSize, Character::Character])
-        .values_panic(vec![1.into(), 16.into(), "B".into()])
-        .values_panic(vec![2.into(), 24.into(), "C".into()])
+        .values_panic([1.into(), 16.into(), "B".into()])
+        .values_panic([2.into(), 24.into(), "C".into()])
         .on_conflict(
             OnConflict::column(Character::Id)
                 .update_columns([Character::FontSize, Character::Character])

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -76,6 +76,7 @@ impl QueryBuilder for MysqlQueryBuilder {
     fn random_function(&self) -> &str {
         "RAND"
     }
+
     fn insert_default_keyword(&self) -> &str {
         "()"
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -432,7 +432,7 @@ impl Expr {
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
     ///     .and_where(Expr::col(Char::Id).eq(1))
-    ///     .and_where(Expr::cust_with_values("6 = ? * ?", vec![2, 3]))
+    ///     .and_where(Expr::cust_with_values("6 = ? * ?", [2, 3]))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -451,7 +451,7 @@ impl Expr {
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
     ///     .and_where(Expr::col(Char::Id).eq(1))
-    ///     .and_where(Expr::cust_with_values("6 = $2 * $1", vec![3, 2]))
+    ///     .and_where(Expr::cust_with_values("6 = $2 * $1", [3, 2]))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -463,7 +463,7 @@ impl Expr {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Expr::cust_with_values("6 = ? * ?", vec![2, 3]))
+    ///     .expr(Expr::cust_with_values("6 = ? * ?", [2, 3]))
     ///     .to_owned();
     ///
     /// assert_eq!(query.to_string(MysqlQueryBuilder), r#"SELECT 6 = 2 * 3"#);
@@ -474,7 +474,7 @@ impl Expr {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Expr::cust_with_values("$1 $$ $2", vec!["a", "b"]))
+    ///     .expr(Expr::cust_with_values("$1 $$ $2", ["a", "b"]))
     ///     .to_owned();
     ///
     /// assert_eq!(query.to_string(PostgresQueryBuilder), r#"SELECT 'a' $ 'b'"#);
@@ -485,7 +485,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .expr(Expr::cust_with_values(
     ///         "data @? ($1::JSONPATH)",
-    ///         vec!["hello"],
+    ///         ["hello"],
     ///     ))
     ///     .to_owned();
     ///
@@ -1233,7 +1233,7 @@ impl Expr {
     /// use sea_query::{*, tests_cfg::*};
     ///
     /// let query = Query::select()
-    ///     .columns(vec![Char::Character, Char::SizeW, Char::SizeH])
+    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
     ///     .and_where(Expr::tbl(Char::Table, Char::Character).like(LikeExpr::str(r"|_Our|_").escape('|')))
     ///     .to_owned();
@@ -1633,7 +1633,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Id])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::tbl(Char::Table, Char::SizeW).is_in(vec![1, 2, 3]))
+    ///     .and_where(Expr::tbl(Char::Table, Char::SizeW).is_in([1, 2, 3]))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1744,7 +1744,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Id])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::tbl(Char::Table, Char::SizeW).is_not_in(vec![1, 2, 3]))
+    ///     .and_where(Expr::tbl(Char::Table, Char::SizeW).is_not_in([1, 2, 3]))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -2156,7 +2156,7 @@ impl Expr {
     /// let query = Query::insert()
     ///     .into_table(Char::Table)
     ///     .columns([Char::FontSize])
-    ///     .exprs_panic(vec![Expr::val("large").as_enum(Alias::new("FontSizeEnum"))])
+    ///     .exprs_panic([Expr::val("large").as_enum(Alias::new("FontSizeEnum"))])
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -2212,7 +2212,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .expr_as(
     ///         Expr::case(
-    ///                 Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![2, 4]),
+    ///                 Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([2, 4]),
     ///                 Expr::val(true)
     ///              )
     ///             .finally(Expr::val(false)),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -366,9 +366,9 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::value(1).into())
-    ///     .and_where(Expr::value(2.5).into())
-    ///     .and_where(Expr::value("3").into())
+    ///     .and_where(Expr::value(1))
+    ///     .and_where(Expr::value(2.5))
+    ///     .and_where(Expr::value("3"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -401,7 +401,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::cust("1 = 1").into())
+    ///     .and_where(Expr::cust("1 = 1"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -432,7 +432,7 @@ impl Expr {
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
     ///     .and_where(Expr::col(Char::Id).eq(1))
-    ///     .and_where(Expr::cust_with_values("6 = ? * ?", vec![2, 3]).into())
+    ///     .and_where(Expr::cust_with_values("6 = ? * ?", vec![2, 3]))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -451,7 +451,7 @@ impl Expr {
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
     ///     .and_where(Expr::col(Char::Id).eq(1))
-    ///     .and_where(Expr::cust_with_values("6 = $2 * $1", vec![3, 2]).into())
+    ///     .and_where(Expr::cust_with_values("6 = $2 * $1", vec![3, 2]))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -242,7 +242,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::any(Expr::val([0, 1])))
+    ///     .expr(PgFunc::any(Expr::val(vec![0, 1])))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -266,7 +266,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::some(Expr::val([0, 1])))
+    ///     .expr(PgFunc::some(Expr::val(vec![0, 1])))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -290,7 +290,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::all(Expr::val([0, 1])))
+    ///     .expr(PgFunc::all(Expr::val(vec![0, 1])))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -242,7 +242,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::any(Expr::val(vec![0, 1])))
+    ///     .expr(PgFunc::any(Expr::val([0, 1])))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -266,7 +266,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::some(Expr::val(vec![0, 1])))
+    ///     .expr(PgFunc::some(Expr::val([0, 1])))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -290,7 +290,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::all(Expr::val(vec![0, 1])))
+    ///     .expr(PgFunc::all(Expr::val([0, 1])))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -51,8 +51,7 @@ impl PgFunc {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Expr::func(Function::PgFunction(PgFunction::ToTsquery))
-                    .args(vec![config, expr.into()])
+                Expr::func(Function::PgFunction(PgFunction::ToTsquery)).args([config, expr.into()])
             }
             None => Expr::func(Function::PgFunction(PgFunction::ToTsquery)).arg(expr),
         }
@@ -84,8 +83,7 @@ impl PgFunc {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Expr::func(Function::PgFunction(PgFunction::ToTsvector))
-                    .args(vec![config, expr.into()])
+                Expr::func(Function::PgFunction(PgFunction::ToTsvector)).args([config, expr.into()])
             }
             None => Expr::func(Function::PgFunction(PgFunction::ToTsvector)).arg(expr),
         }
@@ -118,7 +116,7 @@ impl PgFunc {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
                 Expr::func(Function::PgFunction(PgFunction::PhrasetoTsquery))
-                    .args(vec![config, expr.into()])
+                    .args([config, expr.into()])
             }
             None => Expr::func(Function::PgFunction(PgFunction::PhrasetoTsquery)).arg(expr),
         }
@@ -151,7 +149,7 @@ impl PgFunc {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
                 Expr::func(Function::PgFunction(PgFunction::PlaintoTsquery))
-                    .args(vec![config, expr.into()])
+                    .args([config, expr.into()])
             }
             None => Expr::func(Function::PgFunction(PgFunction::PlaintoTsquery)).arg(expr),
         }
@@ -184,7 +182,7 @@ impl PgFunc {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
                 Expr::func(Function::PgFunction(PgFunction::WebsearchToTsquery))
-                    .args(vec![config, expr.into()])
+                    .args([config, expr.into()])
             }
             None => Expr::func(Function::PgFunction(PgFunction::WebsearchToTsquery)).arg(expr),
         }
@@ -210,7 +208,7 @@ impl PgFunc {
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::PgFunction(PgFunction::TsRank)).args(vec![vector, query])
+        Expr::func(Function::PgFunction(PgFunction::TsRank)).args([vector, query])
     }
 
     /// Call `TS_RANK_CD` function. Postgres only.
@@ -233,7 +231,7 @@ impl PgFunc {
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::PgFunction(PgFunction::TsRankCd)).args(vec![vector, query])
+        Expr::func(Function::PgFunction(PgFunction::TsRankCd)).args([vector, query])
     }
 
     /// Call `ANY` function. Postgres only.

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -184,7 +184,7 @@ impl TypeCreateStatement {
     /// assert_eq!(
     ///     Type::create()
     ///         .as_enum(FontFamily::Type)
-    ///         .values(vec![
+    ///         .values([
     ///             FontFamily::Serif,
     ///             FontFamily::Sans,
     ///             FontFamily::Monospace

--- a/src/foreign_key/create.rs
+++ b/src/foreign_key/create.rs
@@ -19,7 +19,7 @@ use crate::{
 ///
 /// assert_eq!(
 ///     foreign_key.to_string(MysqlQueryBuilder),
-///     vec![
+///     [
 ///         r#"ALTER TABLE `character`"#,
 ///         r#"ADD CONSTRAINT `FK_character_font`"#,
 ///         r#"FOREIGN KEY (`font_id`) REFERENCES `font` (`id`)"#,
@@ -29,7 +29,7 @@ use crate::{
 /// );
 /// assert_eq!(
 ///     foreign_key.to_string(PostgresQueryBuilder),
-///     vec![
+///     [
 ///         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_font""#,
 ///         r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
 ///         r#"ON DELETE CASCADE ON UPDATE CASCADE"#,
@@ -52,7 +52,7 @@ use crate::{
 ///
 /// assert_eq!(
 ///     foreign_key.to_string(MysqlQueryBuilder),
-///     vec![
+///     [
 ///         r#"ALTER TABLE `character`"#,
 ///         r#"ADD CONSTRAINT `FK_character_glyph`"#,
 ///         r#"FOREIGN KEY (`font_id`, `id`) REFERENCES `glyph` (`font_id`, `id`)"#,
@@ -62,7 +62,7 @@ use crate::{
 /// );
 /// assert_eq!(
 ///     foreign_key.to_string(PostgresQueryBuilder),
-///     vec![
+///     [
 ///         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_glyph""#,
 ///         r#"FOREIGN KEY ("font_id", "id") REFERENCES "glyph" ("font_id", "id")"#,
 ///         r#"ON DELETE CASCADE ON UPDATE CASCADE"#,

--- a/src/func.rs
+++ b/src/func.rs
@@ -327,7 +327,7 @@ impl Func {
         A: Into<SimpleExpr>,
         B: Into<SimpleExpr>,
     {
-        Expr::func(Function::IfNull).args(vec![a.into(), b.into()])
+        Expr::func(Function::IfNull).args([a.into(), b.into()])
     }
 
     /// Call `CAST` function with a custom type.

--- a/src/func.rs
+++ b/src/func.rs
@@ -47,7 +47,7 @@ impl Func {
     /// }
     ///
     /// let query = Query::select()
-    ///     .expr(Func::cust(MyFunction).args(vec![Expr::val("hello")]))
+    ///     .expr(Func::cust(MyFunction).args([Expr::val("hello")]))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //!         .column(Glyph::Image)
 //!         .from(Glyph::Table)
 //!         .and_where(Expr::col(Glyph::Image).like("A"))
-//!         .and_where(Expr::col(Glyph::Id).is_in(vec![1, 2, 3]))
+//!         .and_where(Expr::col(Glyph::Id).is_in([1, 2, 3]))
 //!         .build(PostgresQueryBuilder),
 //!     (
 //!         r#"SELECT "image" FROM "glyph" WHERE "image" LIKE $1 AND "id" IN ($2, $3, $4)"#
@@ -243,7 +243,7 @@
 //!         .and_where(
 //!             Expr::col(Char::SizeW).in_subquery(
 //!                 Query::select()
-//!                     .expr(Expr::cust_with_values("ln($1 ^ $2)", vec![2.4, 1.2]))
+//!                     .expr(Expr::cust_with_values("ln($1 ^ $2)", [2.4, 1.2]))
 //!                     .take()
 //!             )
 //!         )
@@ -283,7 +283,7 @@
 //!                 )
 //!                 .add(
 //!                     Cond::all()
-//!                         .add(Expr::col(Glyph::Aspect).is_in(vec![3, 4]))
+//!                         .add(Expr::col(Glyph::Aspect).is_in([3, 4]))
 //!                         .add(Expr::col(Glyph::Image).like("A%"))
 //!                 )
 //!         )
@@ -304,7 +304,7 @@
 //! ```
 //! # use sea_query::{*, tests_cfg::*};
 //! Query::select().cond_where(any![
-//!     Expr::col(Glyph::Aspect).is_in(vec![3, 4]),
+//!     Expr::col(Glyph::Aspect).is_in([3, 4]),
 //!     all![
 //!         Expr::col(Glyph::Aspect).is_null(),
 //!         Expr::col(Glyph::Image).like("A%")
@@ -352,7 +352,7 @@
 //!     .column((Font::Table, Font::Name))
 //!     .from(Char::Table)
 //!     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
-//!     .and_where(Expr::col(Char::SizeW).is_in(vec![3, 4]))
+//!     .and_where(Expr::col(Char::SizeW).is_in([3, 4]))
 //!     .and_where(Expr::col(Char::Character).like("A%"))
 //!     .to_owned();
 //!
@@ -377,8 +377,8 @@
 //! let query = Query::insert()
 //!     .into_table(Glyph::Table)
 //!     .columns([Glyph::Aspect, Glyph::Image])
-//!     .values_panic(vec![5.15.into(), "12A".into()])
-//!     .values_panic(vec![4.21.into(), "123".into()])
+//!     .values_panic([5.15.into(), "12A".into()])
+//!     .values_panic([4.21.into(), "123".into()])
 //!     .to_owned();
 //!
 //! assert_eq!(
@@ -401,7 +401,7 @@
 //! # use sea_query::{*, tests_cfg::*};
 //! let query = Query::update()
 //!     .table(Glyph::Table)
-//!     .values(vec![
+//!     .values([
 //!         (Glyph::Aspect, 1.23.into()),
 //!         (Glyph::Image, "123".into()),
 //!     ])
@@ -474,7 +474,7 @@
 //!
 //! assert_eq!(
 //!     table.to_string(MysqlQueryBuilder),
-//!     vec![
+//!     [
 //!         r#"CREATE TABLE IF NOT EXISTS `character` ("#,
 //!             r#"`id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,"#,
 //!             r#"`font_size` int NOT NULL,"#,
@@ -490,7 +490,7 @@
 //! );
 //! assert_eq!(
 //!     table.to_string(PostgresQueryBuilder),
-//!     vec![
+//!     [
 //!         r#"CREATE TABLE IF NOT EXISTS "character" ("#,
 //!             r#""id" serial NOT NULL PRIMARY KEY,"#,
 //!             r#""font_size" integer NOT NULL,"#,
@@ -506,7 +506,7 @@
 //! );
 //! assert_eq!(
 //!     table.to_string(SqliteQueryBuilder),
-//!     vec![
+//!     [
 //!        r#"CREATE TABLE IF NOT EXISTS "character" ("#,
 //!            r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
 //!            r#""font_size" integer NOT NULL,"#,
@@ -627,7 +627,7 @@
 //!
 //! assert_eq!(
 //!     foreign_key.to_string(MysqlQueryBuilder),
-//!     vec![
+//!     [
 //!         r#"ALTER TABLE `character`"#,
 //!         r#"ADD CONSTRAINT `FK_character_font`"#,
 //!         r#"FOREIGN KEY (`font_id`) REFERENCES `font` (`id`)"#,
@@ -637,7 +637,7 @@
 //! );
 //! assert_eq!(
 //!     foreign_key.to_string(PostgresQueryBuilder),
-//!     vec![
+//!     [
 //!         r#"ALTER TABLE "character" ADD CONSTRAINT "FK_character_font""#,
 //!         r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
 //!         r#"ON DELETE CASCADE ON UPDATE CASCADE"#,

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -129,11 +129,7 @@ mod tests {
     #[test]
     fn inject_parameters_2() {
         assert_eq!(
-            inject_parameters(
-                "WHERE A = '?' AND B = ?",
-                vec!["C".into()],
-                &MysqlQueryBuilder
-            ),
+            inject_parameters("WHERE A = '?' AND B = ?", ["C".into()], &MysqlQueryBuilder),
             "WHERE A = '?' AND B = 'C'"
         );
     }
@@ -143,7 +139,7 @@ mod tests {
         assert_eq!(
             inject_parameters(
                 "WHERE A = ? AND C = ?",
-                vec!["B".into(), "D".into()],
+                ["B".into(), "D".into()],
                 &MysqlQueryBuilder
             ),
             "WHERE A = 'B' AND C = 'D'"
@@ -155,7 +151,7 @@ mod tests {
         assert_eq!(
             inject_parameters(
                 "WHERE A = $1 AND C = $2",
-                vec!["B".into(), "D".into()],
+                ["B".into(), "D".into()],
                 &PostgresQueryBuilder
             ),
             "WHERE A = 'B' AND C = 'D'"
@@ -167,7 +163,7 @@ mod tests {
         assert_eq!(
             inject_parameters(
                 "WHERE A = $2 AND C = $1",
-                vec!["B".into(), "D".into()],
+                ["B".into(), "D".into()],
                 &PostgresQueryBuilder
             ),
             "WHERE A = 'D' AND C = 'B'"
@@ -177,7 +173,7 @@ mod tests {
     #[test]
     fn inject_parameters_6() {
         assert_eq!(
-            inject_parameters("WHERE A = $1", vec!["B'C".into()], &PostgresQueryBuilder),
+            inject_parameters("WHERE A = $1", ["B'C".into()], &PostgresQueryBuilder),
             "WHERE A = E'B\\'C'"
         );
     }
@@ -185,11 +181,7 @@ mod tests {
     #[test]
     fn inject_parameters_7() {
         assert_eq!(
-            inject_parameters(
-                "?",
-                vec![vec![0xABu8, 0xCD, 0xEF].into()],
-                &MysqlQueryBuilder
-            ),
+            inject_parameters("?", [vec![0xABu8, 0xCD, 0xEF].into()], &MysqlQueryBuilder),
             "x'ABCDEF'"
         );
     }

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn inject_parameters_1() {
         assert_eq!(
-            inject_parameters("WHERE A = ?", vec!["B".into()], &MysqlQueryBuilder),
+            inject_parameters("WHERE A = ?", ["B".into()], &MysqlQueryBuilder),
             "WHERE A = 'B'"
         );
     }

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -23,7 +23,7 @@ impl CaseStatement {
     /// let query = Query::select()
     ///     .expr_as(
     ///         CaseStatement::new()
-    ///             .case(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![2, 4]), Expr::val(true))
+    ///             .case(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([2, 4]), Expr::val(true))
     ///             .finally(Expr::val(false)),
     ///          Alias::new("is_even")
     ///     )

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -132,7 +132,7 @@ impl Condition {
     ///     .from(Glyph::Table)
     ///     .cond_where(
     ///         Cond::any()
-    ///             .add(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
+    ///             .add(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]))
     ///             .add(Expr::tbl(Glyph::Table, Glyph::Image).like("A%"))
     ///     )
     ///     .to_owned();
@@ -162,7 +162,7 @@ impl Condition {
     ///     .from(Glyph::Table)
     ///     .cond_where(
     ///         Cond::all()
-    ///             .add(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
+    ///             .add(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]))
     ///             .add(Expr::tbl(Glyph::Table, Glyph::Image).like("A%"))
     ///     )
     ///     .to_owned();
@@ -193,7 +193,7 @@ impl Condition {
     ///     .cond_where(
     ///         Cond::all()
     ///             .not()
-    ///             .add(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
+    ///             .add(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]))
     ///             .add(Expr::tbl(Glyph::Table, Glyph::Image).like("A%"))
     ///     )
     ///     .to_owned();
@@ -289,7 +289,7 @@ impl From<SimpleExpr> for ConditionExpression {
 ///     .from(Glyph::Table)
 ///     .cond_where(
 ///         any![
-///             Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]),
+///             Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]),
 ///             Expr::tbl(Glyph::Table, Glyph::Image).like("A%")
 ///         ]
 ///     )
@@ -325,7 +325,7 @@ macro_rules! any {
 ///     .from(Glyph::Table)
 ///     .cond_where(
 ///         all![
-///             Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]),
+///             Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]),
 ///             Expr::tbl(Glyph::Table, Glyph::Image).like("A%")
 ///         ]
 ///     )
@@ -360,7 +360,7 @@ pub trait ConditionalStatement {
     /// let query = Query::select()
     ///     .column(Glyph::Image)
     ///     .from(Glyph::Table)
-    ///     .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
+    ///     .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]))
     ///     .and_where(Expr::tbl(Glyph::Table, Glyph::Image).like("A%"))
     ///     .to_owned();
     ///
@@ -381,7 +381,7 @@ pub trait ConditionalStatement {
     /// let query = Query::select()
     ///     .column(Glyph::Image)
     ///     .from(Glyph::Table)
-    ///     .and_where(Expr::col(Glyph::Aspect).is_in(vec![3, 4]))
+    ///     .and_where(Expr::col(Glyph::Aspect).is_in([3, 4]))
     ///     .and_where_option(Some(Expr::col(Glyph::Image).like("A%")))
     ///     .and_where_option(None)
     ///     .to_owned();
@@ -416,7 +416,7 @@ pub trait ConditionalStatement {
     ///     .from(Glyph::Table)
     ///     .cond_where(
     ///         Cond::all()
-    ///             .add(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
+    ///             .add(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]))
     ///             .add(Cond::any()
     ///                 .add(Expr::tbl(Glyph::Table, Glyph::Image).like("A%"))
     ///                 .add(Expr::tbl(Glyph::Table, Glyph::Image).like("B%"))
@@ -440,7 +440,7 @@ pub trait ConditionalStatement {
     ///     .from(Glyph::Table)
     ///     .cond_where(
     ///         all![
-    ///             Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]),
+    ///             Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]),
     ///             any![
     ///                 Expr::tbl(Glyph::Table, Glyph::Image).like("A%"),
     ///                 Expr::tbl(Glyph::Table, Glyph::Image).like("B%"),

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -50,7 +50,7 @@ impl Condition {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let statement = sea_query::Query::select()
+    /// let statement = Query::select()
     ///     .column(Glyph::Id)
     ///     .from(Glyph::Table)
     ///     .cond_where(
@@ -265,13 +265,13 @@ impl Condition {
     }
 }
 
-impl std::convert::From<Condition> for ConditionExpression {
+impl From<Condition> for ConditionExpression {
     fn from(condition: Condition) -> Self {
         ConditionExpression::Condition(condition)
     }
 }
 
-impl std::convert::From<SimpleExpr> for ConditionExpression {
+impl From<SimpleExpr> for ConditionExpression {
     fn from(condition: SimpleExpr) -> Self {
         ConditionExpression::SimpleExpr(condition)
     }

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -177,7 +177,7 @@ impl DeleteStatement {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Image])
-    ///     .values_panic(vec!["12A".into()])
+    ///     .values_panic(["12A".into()])
     ///     .returning_all()
     ///     .to_owned();
     ///

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -24,8 +24,8 @@ pub(crate) enum InsertValueSource {
 /// let query = Query::insert()
 ///     .into_table(Glyph::Table)
 ///     .columns([Glyph::Aspect, Glyph::Image])
-///     .values_panic(vec![5.15.into(), "12A".into()])
-///     .values_panic(vec![4.21.into(), "123".into()])
+///     .values_panic([5.15.into(), "12A".into()])
+///     .values_panic([4.21.into(), "123".into()])
 ///     .to_owned();
 ///
 /// assert_eq!(
@@ -69,7 +69,7 @@ impl InsertStatement {
     ///     .replace()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Aspect, Glyph::Image])
-    ///     .values_panic(vec![5.15.into(), "12A".into()])
+    ///     .values_panic([5.15.into(), "12A".into()])
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -124,9 +124,9 @@ impl InsertStatement {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Aspect, Glyph::Image])
-    ///     .values(vec![2.1345.into(), "24B".into()])
+    ///     .values([2.1345.into(), "24B".into()])
     ///     .unwrap()
-    ///     .values_panic(vec![5.15.into(), "12A".into()])
+    ///     .values_panic([5.15.into(), "12A".into()])
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -231,7 +231,7 @@ impl InsertStatement {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Aspect, Glyph::Image])
-    ///     .exprs(vec![
+    ///     .exprs([
     ///         Expr::val(2).into(),
     ///         Func::cast_as("2020-02-02 00:00:00", Alias::new("DATE")),
     ///     ])
@@ -316,7 +316,7 @@ impl InsertStatement {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Image])
-    ///     .values_panic(vec!["12A".into()])
+    ///     .values_panic(["12A".into()])
     ///     .returning(Query::returning().columns([Glyph::Id]))
     ///     .to_owned();
     ///
@@ -348,7 +348,7 @@ impl InsertStatement {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Image])
-    ///     .values_panic(vec!["12A".into()])
+    ///     .values_panic(["12A".into()])
     ///     .returning_col(Glyph::Id)
     ///     .to_owned();
     ///
@@ -382,7 +382,7 @@ impl InsertStatement {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Image])
-    ///     .values_panic(vec!["12A".into()])
+    ///     .values_panic(["12A".into()])
     ///     .returning_all()
     ///     .to_owned();
     ///
@@ -482,7 +482,7 @@ impl InsertStatement {
     ///     .into_table(Glyph::Table)
     ///     .or_default_values()
     ///     .columns([Glyph::Image])
-    ///     .values_panic(vec!["ABC".into()])
+    ///     .values_panic(["ABC".into()])
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -534,7 +534,7 @@ impl InsertStatement {
     ///     .into_table(Glyph::Table)
     ///     .or_default_values_many(3)
     ///     .columns([Glyph::Image])
-    ///     .values_panic(vec!["ABC".into()])
+    ///     .values_panic(["ABC".into()])
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -1,4 +1,4 @@
-use crate::{ConditionHolder, DynIden, Expr, IntoCondition, IntoIden, SimpleExpr, Value};
+use crate::{ConditionHolder, DynIden, IntoCondition, IntoIden, SimpleExpr, Value};
 
 #[derive(Debug, Clone, Default)]
 pub struct OnConflict {

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -1,4 +1,4 @@
-use crate::{DynIden, Expr, IntoIden, SimpleExpr, Value};
+use crate::{DynIden, IntoIden, SimpleExpr, Value};
 
 #[derive(Debug, Clone, Default)]
 pub struct OnConflict {
@@ -36,7 +36,7 @@ impl OnConflict {
     where
         C: IntoIden,
     {
-        Self::columns(vec![column])
+        Self::columns([column])
     }
 
     /// Set ON CONFLICT target columns
@@ -63,7 +63,7 @@ impl OnConflict {
     where
         C: IntoIden,
     {
-        self.update_columns(vec![column])
+        self.update_columns([column])
     }
 
     /// Set ON CONFLICT update columns
@@ -112,11 +112,12 @@ impl OnConflict {
     }
 
     /// Set ON CONFLICT update value
+    #[deprecated(since = "0.27", note = "Please use the [`OnConflict::update_expr`]")]
     pub fn update_value<C>(&mut self, column_value: (C, Value)) -> &mut Self
     where
         C: IntoIden,
     {
-        self.update_values(vec![column_value])
+        self.update_exprs([(column_value.0, column_value.1.into())])
     }
 
     /// Set ON CONFLICT update values
@@ -135,7 +136,7 @@ impl OnConflict {
     ///     ])
     ///     .on_conflict(
     ///         OnConflict::column(Glyph::Id)
-    ///             .update_values([
+    ///             .update_exprs([
     ///                 (Glyph::Aspect, "04108048005887010020060000204E0180400400".into()),
     ///                 (Glyph::Image, 3.1415.into()),
     ///             ])
@@ -156,26 +157,22 @@ impl OnConflict {
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2, 3) ON CONFLICT ("id") DO UPDATE SET "aspect" = '04108048005887010020060000204E0180400400', "image" = 3.1415"#
     /// );
     /// ```
+    #[deprecated(since = "0.27", note = "Please use the [`OnConflict::update_exprs`]")]
     pub fn update_values<C, I>(&mut self, column_values: I) -> &mut Self
     where
         C: IntoIden,
         I: IntoIterator<Item = (C, Value)>,
     {
-        self.action = Some(OnConflictAction::UpdateExprs(
-            column_values
-                .into_iter()
-                .map(|(c, v)| (c.into_iden(), Expr::val(v).into()))
-                .collect(),
-        ));
-        self
+        self.update_exprs(column_values.into_iter().map(|(c, v)| (c, v.into())))
     }
 
     /// Set ON CONFLICT update expr
-    pub fn update_expr<C>(&mut self, column_expr: (C, SimpleExpr)) -> &mut Self
+    pub fn update_expr<C, E>(&mut self, column_expr: (C, E)) -> &mut Self
     where
         C: IntoIden,
+        E: Into<SimpleExpr>,
     {
-        self.update_exprs(vec![column_expr])
+        self.update_exprs([(column_expr.0, column_expr.1.into())])
     }
 
     /// Set ON CONFLICT update exprs

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -76,7 +76,7 @@ impl OnConflict {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Aspect, Glyph::Image])
-    ///     .values_panic(vec![
+    ///     .values_panic([
     ///         2.into(),
     ///         3.into(),
     ///     ])
@@ -130,7 +130,7 @@ impl OnConflict {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Aspect, Glyph::Image])
-    ///     .values_panic(vec![
+    ///     .values_panic([
     ///         2.into(),
     ///         3.into(),
     ///     ])
@@ -185,7 +185,7 @@ impl OnConflict {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Aspect, Glyph::Image])
-    ///     .values_panic(vec![
+    ///     .values_panic([
     ///         2.into(),
     ///         3.into(),
     ///     ])

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -112,7 +112,7 @@ impl OnConflict {
     }
 
     /// Set ON CONFLICT update value
-    #[deprecated(since = "0.27", note = "Please use the [`OnConflict::update_expr`]")]
+    #[deprecated(since = "0.27.0", note = "Please use the [`OnConflict::update_expr`]")]
     pub fn update_value<C>(&mut self, column_value: (C, Value)) -> &mut Self
     where
         C: IntoIden,
@@ -157,7 +157,7 @@ impl OnConflict {
     ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2, 3) ON CONFLICT ("id") DO UPDATE SET "aspect" = '04108048005887010020060000204E0180400400', "image" = 3.1415"#
     /// );
     /// ```
-    #[deprecated(since = "0.27", note = "Please use the [`OnConflict::update_exprs`]")]
+    #[deprecated(since = "0.27.0", note = "Please use the [`OnConflict::update_exprs`]")]
     pub fn update_values<C, I>(&mut self, column_values: I) -> &mut Self
     where
         C: IntoIden,

--- a/src/query/ordered.rs
+++ b/src/query/ordered.rs
@@ -109,9 +109,10 @@ pub trait OrderedStatement {
     }
 
     /// Order by custom string.
-    fn order_by_customs<T>(&mut self, cols: Vec<(T, Order)>) -> &mut Self
+    fn order_by_customs<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: ToString,
+        I: IntoIterator<Item = (T, Order)>,
     {
         cols.into_iter().for_each(|(c, order)| {
             self.add_order_by(OrderExpr {
@@ -124,9 +125,10 @@ pub trait OrderedStatement {
     }
 
     /// Order by vector of columns.
-    fn order_by_columns<T>(&mut self, cols: Vec<(T, Order)>) -> &mut Self
+    fn order_by_columns<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
+        I: IntoIterator<Item = (T, Order)>,
     {
         cols.into_iter().for_each(|(c, order)| {
             self.add_order_by(OrderExpr {
@@ -187,9 +189,10 @@ pub trait OrderedStatement {
     }
 
     /// Order by custom string with nulls order option.
-    fn order_by_customs_with_nulls<T>(&mut self, cols: Vec<(T, Order, NullOrdering)>) -> &mut Self
+    fn order_by_customs_with_nulls<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: ToString,
+        I: IntoIterator<Item = (T, Order, NullOrdering)>,
     {
         cols.into_iter().for_each(|(c, order, nulls)| {
             self.add_order_by(OrderExpr {
@@ -202,9 +205,10 @@ pub trait OrderedStatement {
     }
 
     /// Order by vector of columns with nulls order option.
-    fn order_by_columns_with_nulls<T>(&mut self, cols: Vec<(T, Order, NullOrdering)>) -> &mut Self
+    fn order_by_columns_with_nulls<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
+        I: IntoIterator<Item = (T, Order, NullOrdering)>,
     {
         cols.into_iter().for_each(|(c, order, nulls)| {
             self.add_order_by(OrderExpr {

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -21,7 +21,7 @@ use crate::{
 ///     .column((Font::Table, Font::Name))
 ///     .from(Char::Table)
 ///     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
-///     .and_where(Expr::col(Char::SizeW).is_in(vec![3, 4]))
+///     .and_where(Expr::col(Char::SizeW).is_in([3, 4]))
 ///     .and_where(Expr::col(Char::Character).like("A%"))
 ///     .to_owned();
 ///
@@ -277,7 +277,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .exprs(vec![
+    ///     .exprs([
     ///         Expr::col(Char::Id).max(),
     ///         (1..10_i32).fold(Expr::value(0), |expr, i| expr.add(Expr::value(i))),
     ///     ])
@@ -328,7 +328,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .distinct_on(vec![Char::Character])
+    ///     .distinct_on([Char::Character])
     ///     .column(Char::Character)
     ///     .column(Char::SizeW)
     ///     .column(Char::SizeH)
@@ -831,7 +831,7 @@ impl SelectStatement {
     ///
     /// let query = sea_query::Query::select()
     ///     .expr(Expr::asterisk())
-    ///     .from_values(vec![(1, "hello"), (2, "world")], Alias::new("x"))
+    ///     .from_values([(1, "hello"), (2, "world")], Alias::new("x"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1518,7 +1518,7 @@ impl SelectStatement {
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
     ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
-    ///     .group_by_columns(vec![
+    ///     .group_by_columns([
     ///         Char::Character,
     ///     ])
     ///     .to_owned();
@@ -1545,7 +1545,7 @@ impl SelectStatement {
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
     ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
-    ///     .group_by_columns(vec![
+    ///     .group_by_columns([
     ///         (Char::Table, Char::Character),
     ///     ])
     ///     .to_owned();
@@ -1605,7 +1605,7 @@ impl SelectStatement {
     where
         T: IntoColumnRef,
     {
-        self.group_by_columns(vec![col])
+        self.group_by_columns([col])
     }
 
     /// Add group by expressions from vector of [`SelectExpr`].
@@ -1618,7 +1618,7 @@ impl SelectStatement {
     /// let query = Query::select()
     ///     .from(Char::Table)
     ///     .column(Char::Character)
-    ///     .add_group_by(vec![
+    ///     .add_group_by([
     ///         Expr::col(Char::SizeW).into(),
     ///         Expr::col(Char::SizeH).into(),
     ///     ])
@@ -1656,12 +1656,12 @@ impl SelectStatement {
     ///     .column(Glyph::Aspect)
     ///     .expr(Expr::col(Glyph::Image).max())
     ///     .from(Glyph::Table)
-    ///     .group_by_columns(vec![
+    ///     .group_by_columns([
     ///         Glyph::Aspect,
     ///     ])
     ///     .cond_having(
     ///         all![
-    ///             Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]),
+    ///             Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]),
     ///             any![
     ///                 Expr::tbl(Glyph::Table, Glyph::Image).like("A%"),
     ///                 Expr::tbl(Glyph::Table, Glyph::Image).like("B%")
@@ -1694,7 +1694,7 @@ impl SelectStatement {
     ///     .column(Glyph::Aspect)
     ///     .expr(Expr::col(Glyph::Image).max())
     ///     .from(Glyph::Table)
-    ///     .group_by_columns(vec![
+    ///     .group_by_columns([
     ///         Glyph::Aspect,
     ///     ])
     ///     .and_having(Expr::col(Glyph::Aspect).gt(2))
@@ -1840,7 +1840,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .from(Char::Table)
     ///     .and_where(Expr::col(Char::FontId).eq(5))
-    ///     .lock_with_tables(LockType::Update, vec![Glyph::Table])
+    ///     .lock_with_tables(LockType::Update, [Glyph::Table])
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1916,7 +1916,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .from(Char::Table)
     ///     .and_where(Expr::col(Char::FontId).eq(5))
-    ///     .lock_with_tables_behavior(LockType::Update, vec![Glyph::Table], LockBehavior::Nowait)
+    ///     .lock_with_tables_behavior(LockType::Update, [Glyph::Table], LockBehavior::Nowait)
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -2060,7 +2060,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .from(Char::Table)
     ///     .and_where(Expr::col(Char::FontId).eq(5))
-    ///     .unions(vec![
+    ///     .unions([
     ///         (UnionType::All, Query::select()
     ///             .column(Char::Character)
     ///             .from(Char::Table)

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// let query = Query::update()
 ///     .table(Glyph::Table)
-///     .values(vec![
+///     .values([
 ///         (Glyph::Aspect, 1.23.into()),
 ///         (Glyph::Image, "123".into()),
 ///     ])
@@ -91,7 +91,7 @@ impl UpdateStatement {
     /// let query = Query::update()
     ///     .table(Glyph::Table)
     ///     .col_expr(Glyph::Aspect, Expr::cust("60 * 24 * 24"))
-    ///     .values(vec![
+    ///     .values([
     ///         (Glyph::Image, "24B0E11951B03B07F8300FD003983F03F0780060".into()),
     ///     ])
     ///     .and_where(Expr::col(Glyph::Id).eq(1))
@@ -135,7 +135,7 @@ impl UpdateStatement {
     ///
     /// let query = Query::update()
     ///     .table(Glyph::Table)
-    ///     .values(vec![
+    ///     .values([
     ///         (Glyph::Aspect, 2.1345.into()),
     ///         (Glyph::Image, "235m".into()),
     ///     ])
@@ -291,7 +291,7 @@ impl UpdateStatement {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Image])
-    ///     .values_panic(vec!["12A".into()])
+    ///     .values_panic(["12A".into()])
     ///     .returning_all()
     ///     .to_owned();
     ///

--- a/src/query/window.rs
+++ b/src/query/window.rs
@@ -14,9 +14,10 @@ pub trait OverStatement {
     }
 
     /// Partition by custom string.
-    fn partition_by_customs<T>(&mut self, cols: Vec<T>) -> &mut Self
+    fn partition_by_customs<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: ToString,
+        I: IntoIterator<Item = T>,
     {
         cols.into_iter().for_each(|c| {
             self.add_partition_by(SimpleExpr::Custom(c.to_string()));
@@ -25,9 +26,10 @@ pub trait OverStatement {
     }
 
     /// Partition by vector of columns.
-    fn partition_by_columns<T>(&mut self, cols: Vec<T>) -> &mut Self
+    fn partition_by_columns<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
+        I: IntoIterator<Item = T>,
     {
         cols.into_iter().for_each(|c| {
             self.add_partition_by(SimpleExpr::Column(c.into_column_ref()));

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -94,16 +94,18 @@ macro_rules! impl_ordered_statement {
                     <Self as OrderedStatement>::order_by_expr(self, expr, order)
                 }
 
-                pub fn order_by_customs<T>(&mut self, cols: Vec<(T, Order)>) -> &mut Self
+                pub fn order_by_customs<I, T>(&mut self, cols: I) -> &mut Self
                 where
                     T: ToString,
+                    I: IntoIterator<Item = (T, Order)>,
                 {
                     <Self as OrderedStatement>::order_by_customs(self, cols)
                 }
 
-                pub fn order_by_columns<T>(&mut self, cols: Vec<(T, Order)>) -> &mut Self
+                pub fn order_by_columns<I, T>(&mut self, cols: I) -> &mut Self
                 where
                     T: IntoColumnRef,
+                    I: IntoIterator<Item = (T, Order)>,
                 {
                     <Self as OrderedStatement>::order_by_columns(self, cols)
                 }

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -178,7 +178,7 @@ impl TableAlterStatement {
     /// );
     /// assert_eq!(
     ///     table.to_string(PostgresQueryBuilder),
-    ///     vec![
+    ///     [
     ///         r#"ALTER TABLE "font""#,
     ///         r#"ALTER COLUMN "new_col" TYPE bigint,"#,
     ///         r#"ALTER COLUMN "new_col" SET DEFAULT 999"#,
@@ -293,7 +293,7 @@ impl TableAlterStatement {
     ///
     /// assert_eq!(
     ///     table.to_string(MysqlQueryBuilder),
-    ///     vec![
+    ///     [
     ///         r#"ALTER TABLE `character`"#,
     ///         r#"ADD CONSTRAINT `FK_character_glyph`"#,
     ///         r#"FOREIGN KEY (`font_id`, `id`) REFERENCES `glyph` (`font_id`, `id`)"#,
@@ -307,7 +307,7 @@ impl TableAlterStatement {
     ///
     /// assert_eq!(
     ///     table.to_string(PostgresQueryBuilder),
-    ///     vec![
+    ///     [
     ///         r#"ALTER TABLE "character""#,
     ///         r#"ADD CONSTRAINT "FK_character_glyph""#,
     ///         r#"FOREIGN KEY ("font_id", "id") REFERENCES "glyph" ("font_id", "id")"#,
@@ -340,7 +340,7 @@ impl TableAlterStatement {
     ///
     /// assert_eq!(
     ///     table.to_string(MysqlQueryBuilder),
-    ///     vec![
+    ///     [
     ///         r#"ALTER TABLE `character`"#,
     ///         r#"DROP FOREIGN KEY `FK_character_glyph`,"#,
     ///         r#"DROP FOREIGN KEY `FK_character_font`"#,
@@ -350,7 +350,7 @@ impl TableAlterStatement {
     ///
     /// assert_eq!(
     ///     table.to_string(PostgresQueryBuilder),
-    ///     vec![
+    ///     [
     ///         r#"ALTER TABLE "character""#,
     ///         r#"DROP CONSTRAINT "FK_character_glyph","#,
     ///         r#"DROP CONSTRAINT "FK_character_font""#,

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -377,7 +377,7 @@ impl ColumnDef {
     ///                 .not_null()
     ///         )
     ///         .to_string(PostgresQueryBuilder),
-    ///     vec![
+    ///     [
     ///         r#"CREATE TABLE "glyph" ("#,
     ///         r#""I1" interval NOT NULL,"#,
     ///         r#""I2" interval YEAR TO MONTH NOT NULL,"#,

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -30,7 +30,7 @@ use crate::{
 ///
 /// assert_eq!(
 ///     table.to_string(MysqlQueryBuilder),
-///     vec![
+///     [
 ///         r#"CREATE TABLE IF NOT EXISTS `character` ("#,
 ///             r#"`id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,"#,
 ///             r#"`font_size` int NOT NULL,"#,
@@ -46,7 +46,7 @@ use crate::{
 /// );
 /// assert_eq!(
 ///     table.to_string(PostgresQueryBuilder),
-///     vec![
+///     [
 ///         r#"CREATE TABLE IF NOT EXISTS "character" ("#,
 ///             r#""id" serial NOT NULL PRIMARY KEY,"#,
 ///             r#""font_size" integer NOT NULL,"#,
@@ -62,7 +62,7 @@ use crate::{
 /// );
 /// assert_eq!(
 ///     table.to_string(SqliteQueryBuilder),
-///     vec![
+///     [
 ///        r#"CREATE TABLE IF NOT EXISTS "character" ("#,
 ///            r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
 ///            r#""font_size" integer NOT NULL,"#,
@@ -154,7 +154,7 @@ impl TableCreateStatement {
     ///         .col(ColumnDef::new(Glyph::Id).integer().not_null())
     ///         .index(Index::create().unique().name("idx-glyph-id").col(Glyph::Id))
     ///         .to_string(MysqlQueryBuilder),
-    ///     vec![
+    ///     [
     ///         "CREATE TABLE `glyph` (",
     ///         "`id` int NOT NULL,",
     ///         "UNIQUE KEY `idx-glyph-id` (`id`)",
@@ -183,7 +183,7 @@ impl TableCreateStatement {
     ///     .primary_key(Index::create().col(Glyph::Id).col(Glyph::Image));
     /// assert_eq!(
     ///     statement.to_string(MysqlQueryBuilder),
-    ///     vec![
+    ///     [
     ///         "CREATE TABLE `glyph` (",
     ///         "`id` int NOT NULL,",
     ///         "`image` varchar(255) NOT NULL,",
@@ -194,7 +194,7 @@ impl TableCreateStatement {
     /// );
     /// assert_eq!(
     ///     statement.to_string(PostgresQueryBuilder),
-    ///     vec![
+    ///     [
     ///         "CREATE TABLE \"glyph\" (",
     ///         "\"id\" integer NOT NULL,",
     ///         "\"image\" varchar NOT NULL,",
@@ -205,7 +205,7 @@ impl TableCreateStatement {
     /// );
     /// assert_eq!(
     ///     statement.to_string(SqliteQueryBuilder),
-    ///     vec![
+    ///     [
     ///         r#"CREATE TABLE "glyph" ("#,
     ///         r#""id" integer NOT NULL,"#,
     ///         r#""image" text NOT NULL,"#,

--- a/src/types.rs
+++ b/src/types.rs
@@ -259,10 +259,10 @@ where
     A: IntoIden,
     B: IntoIden,
 {
-    type IntoIter = std::vec::IntoIter<DynIden>;
+    type IntoIter = std::array::IntoIter<DynIden, 2>;
 
     fn into_iter(self) -> Self::IntoIter {
-        vec![self.0.into_iden(), self.1.into_iden()].into_iter()
+        [self.0.into_iden(), self.1.into_iden()].into_iter()
     }
 }
 
@@ -272,10 +272,10 @@ where
     B: IntoIden,
     C: IntoIden,
 {
-    type IntoIter = std::vec::IntoIter<DynIden>;
+    type IntoIter = std::array::IntoIter<DynIden, 3>;
 
     fn into_iter(self) -> Self::IntoIter {
-        vec![self.0.into_iden(), self.1.into_iden(), self.2.into_iden()].into_iter()
+        [self.0.into_iden(), self.1.into_iden(), self.2.into_iden()].into_iter()
     }
 }
 

--- a/tests/error/mod.rs
+++ b/tests/error/mod.rs
@@ -6,7 +6,7 @@ fn insert_values_1() {
     let result = insert
         .into_table(Glyph::Table)
         .columns([Glyph::Image, Glyph::Aspect])
-        .values(vec![String::from("").into()]);
+        .values([String::from("").into()]);
 
     assert!(result.is_err());
     assert_eq!(

--- a/tests/mysql/foreign_key.rs
+++ b/tests/mysql/foreign_key.rs
@@ -10,7 +10,7 @@ fn create_1() {
             .on_delete(ForeignKeyAction::Cascade)
             .on_update(ForeignKeyAction::Cascade)
             .to_string(MysqlQueryBuilder),
-        vec![
+        [
             "ALTER TABLE `character`",
             "ADD CONSTRAINT `FK_2e303c3a712662f1fc2a4d0aad6`",
             "FOREIGN KEY (`font_id`) REFERENCES `font` (`id`)",

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1218,7 +1218,7 @@ fn insert_on_conflict_3() {
             ])
             .on_conflict(
                 OnConflict::columns([Glyph::Id, Glyph::Aspect])
-                    .update_values([
+                    .update_exprs([
                         (Glyph::Aspect, "04108048005887010020060000204E0180400400".into()),
                         (Glyph::Image, 3.1415.into()),
                     ])

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -64,7 +64,7 @@ fn select_5() {
         Query::select()
             .column((Glyph::Table, Glyph::Image))
             .from(Glyph::Table)
-            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
+            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]))
             .to_string(MysqlQueryBuilder),
         "SELECT `glyph`.`image` FROM `glyph` WHERE `glyph`.`aspect` IN (3, 4)"
     );
@@ -75,9 +75,9 @@ fn select_6() {
     assert_eq!(
         Query::select()
             .columns([Glyph::Aspect,])
-            .exprs(vec![Expr::col(Glyph::Image).max(),])
+            .exprs([Expr::col(Glyph::Image).max(),])
             .from(Glyph::Table)
-            .group_by_columns(vec![Glyph::Aspect,])
+            .group_by_columns([Glyph::Aspect,])
             .and_having(Expr::col(Glyph::Aspect).gt(2))
             .to_string(MysqlQueryBuilder),
         "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `aspect` > 2"

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -18,7 +18,7 @@ fn create_1() {
             .character_set("utf8mb4")
             .collate("utf8mb4_unicode_ci")
             .to_string(MysqlQueryBuilder),
-        vec![
+        [
             "CREATE TABLE `glyph` (",
             "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
             "`aspect` double NOT NULL,",
@@ -48,7 +48,7 @@ fn create_2() {
             .character_set("utf8mb4")
             .collate("utf8mb4_unicode_ci")
             .to_string(MysqlQueryBuilder),
-        vec![
+        [
             "CREATE TABLE `font` (",
             "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
             "`name` varchar(255) NOT NULL,",
@@ -94,7 +94,7 @@ fn create_3() {
             .character_set("utf8mb4")
             .collate("utf8mb4_unicode_ci")
             .to_string(MysqlQueryBuilder),
-        vec![
+        [
             "CREATE TABLE IF NOT EXISTS `character` (",
             "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
             "`font_size` int(11) NOT NULL,",
@@ -123,7 +123,7 @@ fn create_4() {
                     .extra("ANYTHING I WANT TO SAY".to_owned())
             )
             .to_string(MysqlQueryBuilder),
-        vec![
+        [
             "CREATE TABLE `glyph` (",
             "`id` int NOT NULL ANYTHING I WANT TO SAY",
             ")",
@@ -140,7 +140,7 @@ fn create_5() {
             .col(ColumnDef::new(Glyph::Id).integer().not_null())
             .index(Index::create().unique().name("idx-glyph-id").col(Glyph::Id))
             .to_string(MysqlQueryBuilder),
-        vec![
+        [
             "CREATE TABLE `glyph` (",
             "`id` int NOT NULL,",
             "UNIQUE KEY `idx-glyph-id` (`id`)",
@@ -163,7 +163,7 @@ fn create_6() {
             .col(ColumnDef::new(BinaryType::MediumBlob).blob(BlobSize::Medium))
             .col(ColumnDef::new(BinaryType::LongBlob).blob(BlobSize::Long))
             .to_string(MysqlQueryBuilder),
-        vec![
+        [
             "CREATE TABLE `binary_type` (",
             "`binlen` binary(32),",
             "`bin` blob, `defb` binary(32),",
@@ -186,7 +186,7 @@ fn create_7() {
             .col(ColumnDef::new(Char::FontSize).binary_len(10))
             .col(ColumnDef::new(Char::SizeW).var_binary(10))
             .to_string(MysqlQueryBuilder),
-        vec![
+        [
             "CREATE TABLE `character` (",
             "`character` blob,",
             "`font_size` binary(10),",

--- a/tests/postgres/foreign_key.rs
+++ b/tests/postgres/foreign_key.rs
@@ -10,7 +10,7 @@ fn create_1() {
             .on_delete(ForeignKeyAction::Cascade)
             .on_update(ForeignKeyAction::Cascade)
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"ALTER TABLE "character" ADD CONSTRAINT "FK_2e303c3a712662f1fc2a4d0aad6""#,
             r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
             r#"ON DELETE CASCADE ON UPDATE CASCADE"#,
@@ -29,7 +29,7 @@ fn create_2() {
             .on_delete(ForeignKeyAction::Cascade)
             .on_update(ForeignKeyAction::Cascade)
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"ALTER TABLE "schema"."character" ADD CONSTRAINT "FK_2e303c3a712662f1fc2a4d0aad6""#,
             r#"FOREIGN KEY ("font_id") REFERENCES "font" ("id")"#,
             r#"ON DELETE CASCADE ON UPDATE CASCADE"#,

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1310,7 +1310,7 @@ fn insert_on_conflict_3() {
             ])
             .on_conflict(
                 OnConflict::columns([Glyph::Id, Glyph::Aspect])
-                    .update_values([
+                    .update_exprs([
                         (Glyph::Aspect, "04108048005887010020060000204E0180400400".into()),
                         (Glyph::Image, 3.1415.into()),
                     ])

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -62,7 +62,7 @@ fn select_5() {
         Query::select()
             .column((Glyph::Table, Glyph::Image))
             .from(Glyph::Table)
-            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
+            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]))
             .to_string(PostgresQueryBuilder),
         r#"SELECT "glyph"."image" FROM "glyph" WHERE "glyph"."aspect" IN (3, 4)"#
     );
@@ -73,9 +73,9 @@ fn select_6() {
     assert_eq!(
         Query::select()
             .columns([Glyph::Aspect,])
-            .exprs(vec![Expr::col(Glyph::Image).max(),])
+            .exprs([Expr::col(Glyph::Image).max(),])
             .from(Glyph::Table)
-            .group_by_columns(vec![Glyph::Aspect,])
+            .group_by_columns([Glyph::Aspect,])
             .and_having(Expr::col(Glyph::Aspect).gt(2))
             .to_string(PostgresQueryBuilder),
         r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2"#
@@ -166,7 +166,7 @@ fn select_12() {
             .columns([Glyph::Aspect,])
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .order_by_columns(vec![(Glyph::Id, Order::Asc), (Glyph::Aspect, Order::Desc),])
+            .order_by_columns([(Glyph::Id, Order::Asc), (Glyph::Aspect, Order::Desc),])
             .to_string(PostgresQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2 ORDER BY "id" ASC, "aspect" DESC"#
     );
@@ -179,7 +179,7 @@ fn select_13() {
             .columns([Glyph::Aspect,])
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .order_by_columns(vec![
+            .order_by_columns([
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
             ])

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -15,7 +15,7 @@ fn create_1() {
             .col(ColumnDef::new(Glyph::Aspect).double().not_null())
             .col(ColumnDef::new(Glyph::Image).text())
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "glyph" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
             r#""aspect" double precision NOT NULL,"#,
@@ -42,7 +42,7 @@ fn create_2() {
             .col(ColumnDef::new(Font::Variant).string_len(255).not_null())
             .col(ColumnDef::new(Font::Language).string_len(255).not_null())
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "font" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
             r#""name" varchar NOT NULL,"#,
@@ -85,7 +85,7 @@ fn create_3() {
                     .on_update(ForeignKeyAction::Cascade)
             )
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" serial NOT NULL PRIMARY KEY,"#,
             r#""font_size" integer NOT NULL,"#,
@@ -109,7 +109,7 @@ fn create_4() {
             .table(Glyph::Table)
             .col(ColumnDef::new(Glyph::Image).custom(Glyph::Aspect))
             .to_string(PostgresQueryBuilder),
-        vec![r#"CREATE TABLE "glyph" ("#, r#""image" aspect"#, r#")"#,].join(" ")
+        [r#"CREATE TABLE "glyph" ("#, r#""image" aspect"#, r#")"#,].join(" ")
     );
 }
 
@@ -121,7 +121,7 @@ fn create_5() {
             .col(ColumnDef::new(Glyph::Image).json())
             .col(ColumnDef::new(Glyph::Aspect).json_binary())
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "glyph" ("#,
             r#""image" json,"#,
             r#""aspect" jsonb"#,
@@ -143,7 +143,7 @@ fn create_6() {
                     .extra("ANYTHING I WANT TO SAY".to_owned())
             )
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "glyph" ("#,
             r#""id" integer NOT NULL ANYTHING I WANT TO SAY"#,
             r#")"#,
@@ -163,7 +163,7 @@ fn create_7() {
                     .not_null()
             )
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "glyph" ("#,
             r#""aspect" interval NOT NULL"#,
             r#")"#,
@@ -183,7 +183,7 @@ fn create_8() {
                     .not_null()
             )
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "glyph" ("#,
             r#""aspect" interval YEAR TO MONTH NOT NULL"#,
             r#")"#,
@@ -203,7 +203,7 @@ fn create_9() {
                     .not_null()
             )
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "glyph" ("#,
             r#""aspect" interval(42) NOT NULL"#,
             r#")"#,
@@ -223,7 +223,7 @@ fn create_10() {
                     .not_null()
             )
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "glyph" ("#,
             r#""aspect" interval HOUR(43) NOT NULL"#,
             r#")"#,
@@ -243,7 +243,7 @@ fn create_11() {
                     .not_null()
             )
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "character" ("#,
             r#""created_at" timestamp(0) with time zone NOT NULL"#,
             r#")"#,
@@ -265,7 +265,7 @@ fn create_12() {
             .col(ColumnDef::new(BinaryType::MediumBlob).blob(BlobSize::Medium))
             .col(ColumnDef::new(BinaryType::LongBlob).blob(BlobSize::Long))
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "binary_type" ("#,
             r#""binlen" bytea,"#,
             r#""bin" bytea,"#,
@@ -289,7 +289,7 @@ fn create_13() {
             .col(ColumnDef::new(Char::FontSize).binary_len(10))
             .col(ColumnDef::new(Char::SizeW).var_binary(10))
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "character" ("#,
             r#""character" bytea,"#,
             r#""font_size" bytea,"#,
@@ -307,7 +307,7 @@ fn create_14() {
             .table((Alias::new("schema"), Glyph::Table))
             .col(ColumnDef::new(Glyph::Image).custom(Glyph::Aspect))
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "schema"."glyph" ("#,
             r#""image" aspect"#,
             r#")"#,
@@ -387,7 +387,7 @@ fn alter_2() {
                     .default(999)
             )
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"ALTER TABLE "font""#,
             r#"ALTER COLUMN "new_col" TYPE bigint,"#,
             r#"ALTER COLUMN "new_col" SET DEFAULT 999"#,
@@ -454,7 +454,7 @@ fn alter_8() {
             .table(Font::Table)
             .modify_column(ColumnDef::new(Font::Language).null())
             .to_string(PostgresQueryBuilder),
-        vec![
+        [
             r#"ALTER TABLE "font""#,
             r#"ALTER COLUMN "language" DROP NOT NULL"#,
         ]

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -7,7 +7,7 @@ fn create_1() {
     assert_eq!(
         Type::create()
             .as_enum(Font::Table)
-            .values(vec![Font::Name, Font::Variant, Font::Language])
+            .values([Font::Name, Font::Variant, Font::Language])
             .to_string(PostgresQueryBuilder),
         r#"CREATE TYPE "font" AS ENUM ('name', 'variant', 'language')"#
     );
@@ -18,7 +18,7 @@ fn create_2() {
     assert_eq!(
         Type::create()
             .as_enum((Alias::new("schema"), Font::Table))
-            .values(vec![Font::Name, Font::Variant, Font::Language])
+            .values([Font::Name, Font::Variant, Font::Language])
             .to_string(PostgresQueryBuilder),
         r#"CREATE TYPE "schema"."font" AS ENUM ('name', 'variant', 'language')"#
     );

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1198,7 +1198,7 @@ fn insert_on_conflict_3() {
             ])
             .on_conflict(
                 OnConflict::columns([Glyph::Id, Glyph::Aspect])
-                    .update_values([
+                    .update_exprs([
                         (Glyph::Aspect, "04108048005887010020060000204E0180400400".into()),
                         (Glyph::Image, 3.1415.into()),
                     ])

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -62,7 +62,7 @@ fn select_5() {
         Query::select()
             .column((Glyph::Table, Glyph::Image))
             .from(Glyph::Table)
-            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in(vec![3, 4]))
+            .and_where(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([3, 4]))
             .to_string(SqliteQueryBuilder),
         r#"SELECT "glyph"."image" FROM "glyph" WHERE "glyph"."aspect" IN (3, 4)"#
     );
@@ -73,9 +73,9 @@ fn select_6() {
     assert_eq!(
         Query::select()
             .columns([Glyph::Aspect,])
-            .exprs(vec![Expr::col(Glyph::Image).max(),])
+            .exprs([Expr::col(Glyph::Image).max(),])
             .from(Glyph::Table)
-            .group_by_columns(vec![Glyph::Aspect,])
+            .group_by_columns([Glyph::Aspect,])
             .and_having(Expr::col(Glyph::Aspect).gt(2))
             .to_string(SqliteQueryBuilder),
         r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect" HAVING "aspect" > 2"#
@@ -166,7 +166,7 @@ fn select_12() {
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .order_by_columns(vec![(Glyph::Id, Order::Asc), (Glyph::Aspect, Order::Desc)])
+            .order_by_columns([(Glyph::Id, Order::Asc), (Glyph::Aspect, Order::Desc)])
             .to_string(SqliteQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE IFNULL("aspect", 0) > 2 ORDER BY "id" ASC, "aspect" DESC"#
     );
@@ -179,7 +179,7 @@ fn select_13() {
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
             .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
-            .order_by_columns(vec![
+            .order_by_columns([
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
             ])
@@ -195,10 +195,7 @@ fn select_14() {
             .columns([Glyph::Id, Glyph::Aspect])
             .expr(Expr::col(Glyph::Image).max())
             .from(Glyph::Table)
-            .group_by_columns(vec![
-                (Glyph::Table, Glyph::Id),
-                (Glyph::Table, Glyph::Aspect),
-            ])
+            .group_by_columns([(Glyph::Table, Glyph::Id), (Glyph::Table, Glyph::Aspect),])
             .and_having(Expr::col(Glyph::Aspect).gt(2))
             .to_string(SqliteQueryBuilder),
         r#"SELECT "id", "aspect", MAX("image") FROM "glyph" GROUP BY "glyph"."id", "glyph"."aspect" HAVING "aspect" > 2"#

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -15,7 +15,7 @@ fn create_1() {
             .col(ColumnDef::new(Glyph::Aspect).double().not_null())
             .col(ColumnDef::new(Glyph::Image).text())
             .to_string(SqliteQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "glyph" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
             r#""aspect" real NOT NULL,"#,
@@ -42,7 +42,7 @@ fn create_2() {
             .col(ColumnDef::new(Font::Variant).string().not_null())
             .col(ColumnDef::new(Font::Language).string().not_null())
             .to_string(SqliteQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "font" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
             r#""name" text NOT NULL,"#,
@@ -84,7 +84,7 @@ fn create_3() {
                     .on_update(ForeignKeyAction::Cascade)
             )
             .to_string(SqliteQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
             r#""font_size" integer NOT NULL,"#,
@@ -112,7 +112,7 @@ fn create_4() {
             .col(ColumnDef::new(BinaryType::MediumBlob).blob(BlobSize::Medium))
             .col(ColumnDef::new(BinaryType::LongBlob).blob(BlobSize::Long))
             .to_string(SqliteQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "binary_type" ("#,
             r#""binlen" binary(32),"#,
             r#""bin" blob,"#,
@@ -136,7 +136,7 @@ fn create_5() {
             .col(ColumnDef::new(Char::FontSize).binary_len(10))
             .col(ColumnDef::new(Char::SizeW).var_binary(10))
             .to_string(SqliteQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "character" ("#,
             r#""character" blob,"#,
             r#""font_size" binary(10),"#,
@@ -161,7 +161,7 @@ fn create_6() {
             )
             .col(ColumnDef::new(Task::IsDone).boolean().not_null())
             .to_string(SqliteQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE "task" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
             r#""is_done" boolean NOT NULL"#,
@@ -202,7 +202,7 @@ fn create_with_unique_index() {
             )
             .index(Index::create().unique().col(Char::SizeH).col(Char::SizeW))
             .to_string(SqliteQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
             r#""font_size" integer NOT NULL,"#,
@@ -247,7 +247,7 @@ fn create_with_primary_unique_index() {
             )
             .index(Index::create().unique().primary().col(Char::SizeH).col(Char::SizeW))
             .to_string(SqliteQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" integer NOT NULL,"#,
             r#""font_size" integer NOT NULL,"#,
@@ -301,7 +301,7 @@ fn create_with_unique_index_constraint() {
                     .unique(),
             )
             .to_string(SqliteQueryBuilder),
-        vec![
+        [
             r#"CREATE TABLE IF NOT EXISTS "character" ("#,
             r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
             r#""font_size" integer NOT NULL,"#,


### PR DESCRIPTION
## PR Info

## Changes

- deprecated: `OnConflict::update_value`, we can now use `OnConflict::update_expr`
- deprecated: `OnConflict::update_values`, we can now use `OnConflict::update_exprs`
- Remove unneeded `vec!`, we can use array (rust version 1.51)
- Improve `OrderedStatement::order_by_customs` (instead Vec<_> parameter is generic)
- Improve `OrderedStatement::order_by_columns` (instead Vec<_> parameter is generic)
- Improve `OverStatement::partition_by_customs` (instead Vec<_> parameter is generic)
- Improve `OverStatement::partition_by_columns` (instead Vec<_> parameter is generic)

