### PR TITLE
Updated the way `distinct_on` is processed internally

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -16,17 +16,22 @@ impl QueryBuilder for PostgresQueryBuilder {
         }
     }
 
-    fn prepare_select_distinct(&self, select_distinct: &SelectDistinct, sql: &mut dyn SqlWriter) {
+    fn prepare_select_distinct(
+        &self,
+        select_distinct: &SelectDistinct,
+        sql: &mut SqlWriter,
+        _collector: &mut dyn FnMut(Value),
+    ) {
         match select_distinct {
             SelectDistinct::All => write!(sql, "ALL").unwrap(),
             SelectDistinct::Distinct => write!(sql, "DISTINCT").unwrap(),
             SelectDistinct::DistinctOn(cols) => {
                 write!(sql, "DISTINCT ON (").unwrap();
-                cols.iter().fold(true, |first, c| {
+                cols.iter().fold(true, |first, column_ref| {
                     if !first {
                         write!(sql, ", ").unwrap();
                     }
-                    c.prepare(sql.as_writer(), self.quote());
+                    self.prepare_column_ref(column_ref, sql);
                     false
                 });
                 write!(sql, ")").unwrap();

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -19,8 +19,7 @@ impl QueryBuilder for PostgresQueryBuilder {
     fn prepare_select_distinct(
         &self,
         select_distinct: &SelectDistinct,
-        sql: &mut SqlWriter,
-        _collector: &mut dyn FnMut(Value),
+        sql: &mut dyn SqlWriter,
     ) {
         match select_distinct {
             SelectDistinct::All => write!(sql, "ALL").unwrap(),

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -16,11 +16,7 @@ impl QueryBuilder for PostgresQueryBuilder {
         }
     }
 
-    fn prepare_select_distinct(
-        &self,
-        select_distinct: &SelectDistinct,
-        sql: &mut dyn SqlWriter,
-    ) {
+    fn prepare_select_distinct(&self, select_distinct: &SelectDistinct, sql: &mut dyn SqlWriter) {
         match select_distinct {
             SelectDistinct::All => write!(sql, "ALL").unwrap(),
             SelectDistinct::Distinct => write!(sql, "DISTINCT").unwrap(),

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -339,6 +339,23 @@ impl SelectStatement {
     ///     r#"SELECT DISTINCT ON ("character") "character", "size_w", "size_h" FROM "character""#
     /// )
     /// ```
+    /// 
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .from(Char::Table)
+    ///     .distinct_on(vec![(Char::Table, Char::Character)])
+    ///     .column(Char::Character)
+    ///     .column(Char::SizeW)
+    ///     .column(Char::SizeH)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT DISTINCT ON ("character"."character") "character", "size_w", "size_h" FROM "character""#
+    /// )
+    /// ```
     ///
     /// ```
     /// use sea_query::{tests_cfg::*, *};

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -61,7 +61,7 @@ pub enum SelectDistinct {
     All,
     Distinct,
     DistinctRow,
-    DistinctOn(Vec<DynIden>),
+    DistinctOn(Vec<ColumnRef>),
 }
 
 /// Window type in [`SelectExpr`]
@@ -364,11 +364,8 @@ impl SelectStatement {
     {
         let cols = cols
             .into_iter()
-            .filter_map(|col| match col.into_column_ref() {
-                ColumnRef::Column(c) => Some(c),
-                _ => None,
-            })
-            .collect::<Vec<DynIden>>();
+            .map(|col|  col.into_column_ref() )
+            .collect::<Vec<ColumnRef>>();
         self.distinct = if !cols.is_empty() {
             Some(SelectDistinct::DistinctOn(cols))
         } else {

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -339,7 +339,7 @@ impl SelectStatement {
     ///     r#"SELECT DISTINCT ON ("character") "character", "size_w", "size_h" FROM "character""#
     /// )
     /// ```
-    /// 
+    ///
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
@@ -381,7 +381,7 @@ impl SelectStatement {
     {
         let cols = cols
             .into_iter()
-            .map(|col|  col.into_column_ref() )
+            .map(|col| col.into_column_ref())
             .collect::<Vec<ColumnRef>>();
         self.distinct = if !cols.is_empty() {
             Some(SelectDistinct::DistinctOn(cols))


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-query/issues/449

- Dependencies:
  - None

- Dependents:
  - None

## Fixes

- [x] Behavior of `distinct_on` with more complex cases of `ColumnRef`

## Breaking Changes

- [x] I don't believe so?

## Changes

- [x] Updated the `DistinctOn` case of the `SelectDistinct` enum to contain a vec of `ColumnRef` instead of `DynIden`
- [x] Modified `prepare_select_distinct` in backend/postgres/query.rs to use this new typing
