### PR TITLE
Resolve issue #457

### DIFF
--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -155,8 +155,9 @@ impl TableBuilder for SqliteQueryBuilder {
                 write!(sql, " TO ").unwrap();
                 to_name.prepare(sql.as_writer(), self.quote());
             }
-            TableAlterOption::DropColumn(_) => {
-                panic!("Sqlite not support dropping table column")
+            TableAlterOption::DropColumn(col_name) => {
+                write!(sql, "DROP COLUMN ").unwrap();
+                col_name.prepare(sql.as_writer(), self.quote());
             }
             TableAlterOption::DropForeignKey(_) => {
                 panic!("Sqlite does not support modification of foreign key constraints to existing tables");

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -247,7 +247,10 @@ impl TableAlterStatement {
     ///     table.to_string(PostgresQueryBuilder),
     ///     r#"ALTER TABLE "font" DROP COLUMN "new_column""#
     /// );
-    /// // Sqlite not support modifying table column
+    /// assert_eq!(
+    ///     table.to_string(SqliteQueryBuilder),
+    ///     r#"ALTER TABLE "font" DROP COLUMN "new_column""#
+    /// );
     /// ```
     pub fn drop_column<T: 'static>(&mut self, col_name: T) -> &mut Self
     where

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -375,12 +375,14 @@ fn alter_3() {
 }
 
 #[test]
-#[should_panic(expected = "Sqlite not support dropping table column")]
 fn alter_4() {
-    Table::alter()
-        .table(Font::Table)
-        .drop_column(Alias::new("new_column"))
-        .to_string(SqliteQueryBuilder);
+    assert_eq!(
+        Table::alter()
+            .table(Font::Table)
+            .drop_column(Alias::new("new_column"))
+            .to_string(SqliteQueryBuilder),
+        r#"ALTER TABLE "font" DROP COLUMN "new_column""#
+    );
 }
 
 #[test]
@@ -405,5 +407,6 @@ fn alter_7() {
         .table(Font::Table)
         .add_column(ColumnDef::new(Alias::new("new_col")).integer())
         .rename_column(Font::Name, Alias::new("name_new"))
+        .drop_column(Alias::new("name_new"))
         .to_string(SqliteQueryBuilder);
 }


### PR DESCRIPTION
## PR Info
The issue was opened in sea-orm repo:
https://github.com/SeaQL/sea-query/issues/457

## Fixes

- [ SQL code wasn't generated for DropColumn option for SQLite even though it was added in [SQLite 3.35](https://www.sqlite.org/releaselog/3_35_0.html)] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->
- [ Fixed tests and docstring concerning above bug]
