### PR TITLE
`Value::Bytes` should write as byte string instead of bit string

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -983,7 +983,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             }
             Value::Bytes(Some(v)) => write!(
                 s,
-                "x'{}'",
+                "'{}'",
                 v.iter().map(|b| format!("{:02X}", b)).collect::<String>()
             )
             .unwrap(),

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -182,7 +182,7 @@ mod tests {
     fn inject_parameters_7() {
         assert_eq!(
             inject_parameters("?", [vec![0xABu8, 0xCD, 0xEF].into()], &MysqlQueryBuilder),
-            "x'ABCDEF'"
+            "'ABCDEF'"
         );
     }
 }


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-query/issues/458

## Fixes

- [x] `QueryBuilder::value_to_string` method write byte as byte string instead of bit string
