### PR TITLE
Add year, bit and varbit types

### DIFF
--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -84,7 +84,7 @@ impl TableBuilder for MysqlQueryBuilder {
                         },
                         None => "year".into(),
                     }
-                },
+                }
                 ColumnType::Interval(_, _) => "unsupported".into(),
                 ColumnType::Binary(blob_size) => match blob_size {
                     BlobSize::Tiny => "tinyblob".into(),
@@ -103,10 +103,10 @@ impl TableBuilder for MysqlQueryBuilder {
                         Some(length) => format!("bit({})", length),
                         None => "bit".into(),
                     }
-                },
+                }
                 ColumnType::VarBit(length) => {
                     format!("bit({})", length)
-                },
+                }
                 ColumnType::Boolean => "bool".into(),
                 ColumnType::Money(precision) => match precision {
                     Some((precision, scale)) => format!("money({}, {})", precision, scale),

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -79,8 +79,8 @@ impl TableBuilder for MysqlQueryBuilder {
                 ColumnType::Year(length) => {
                     match length {
                         Some(length) => match length {
-                            MySQLYear::Two => "year(2)".into(),
-                            MySQLYear::Four => "year(4)".into(),
+                            MySqlYear::Two => "year(2)".into(),
+                            MySqlYear::Four => "year(4)".into(),
                         },
                         None => "year".into(),
                     }

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -98,6 +98,15 @@ impl TableBuilder for MysqlQueryBuilder {
                     BlobSize::Long => "longblob".into(),
                 },
                 ColumnType::VarBinary(length) => format!("varbinary({})", length),
+                ColumnType::Bit(length) => {
+                    match length {
+                        Some(length) => format!("bit({})", length),
+                        None => "bit".into(),
+                    }
+                },
+                ColumnType::VarBit(length) => {
+                    format!("bit({})", length)
+                },
                 ColumnType::Boolean => "bool".into(),
                 ColumnType::Money(precision) => match precision {
                     Some((precision, scale)) => format!("money({}, {})", precision, scale),

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -76,6 +76,15 @@ impl TableBuilder for MysqlQueryBuilder {
                     None => "time".into(),
                 },
                 ColumnType::Date => "date".into(),
+                ColumnType::Year(length) => {
+                    match length {
+                        Some(length) => match length {
+                            MySQLYear::Two => "year(2)".into(),
+                            MySQLYear::Four => "year(4)".into(),
+                        },
+                        None => "year".into(),
+                    }
+                },
                 ColumnType::Interval(_, _) => "unsupported".into(),
                 ColumnType::Binary(blob_size) => match blob_size {
                     BlobSize::Tiny => "tinyblob".into(),

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -88,6 +88,15 @@ impl TableBuilder for PostgresQueryBuilder {
                 }
                 ColumnType::Binary(_) => "bytea".into(),
                 ColumnType::VarBinary(length) => format!("bit varying({})", length),
+                ColumnType::Bit(length) => {
+                    match length {
+                        Some(length) => format!("varbit({})", length),
+                        None => "bit".into(),
+                    }
+                },
+                ColumnType::VarBit(length) => {
+                    format!("varbit({})", length)
+                },
                 ColumnType::Boolean => "bool".into(),
                 ColumnType::Money(precision) => match precision {
                     Some((precision, scale)) => format!("money({}, {})", precision, scale),

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -93,10 +93,10 @@ impl TableBuilder for PostgresQueryBuilder {
                         Some(length) => format!("varbit({})", length),
                         None => "bit".into(),
                     }
-                },
+                }
                 ColumnType::VarBit(length) => {
                     format!("varbit({})", length)
-                },
+                }
                 ColumnType::Boolean => "bool".into(),
                 ColumnType::Money(precision) => match precision {
                     Some((precision, scale)) => format!("money({}, {})", precision, scale),
@@ -110,8 +110,8 @@ impl TableBuilder for PostgresQueryBuilder {
                 ColumnType::Enum { name, .. } => name.to_string(),
                 ColumnType::Cidr => "cidr".into(),
                 ColumnType::Inet => "inet".into(),
-            ColumnType::MacAddr => "macaddr".into(),
-            ColumnType::Year(_) => unimplemented!("Year is not available in Postgres."),
+                ColumnType::MacAddr => "macaddr".into(),
+                ColumnType::Year(_) => unimplemented!("Year is not available in Postgres."),
             }
         )
         .unwrap()

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -101,7 +101,8 @@ impl TableBuilder for PostgresQueryBuilder {
                 ColumnType::Enum { name, .. } => name.to_string(),
                 ColumnType::Cidr => "cidr".into(),
                 ColumnType::Inet => "inet".into(),
-                ColumnType::MacAddr => "macaddr".into(),
+            ColumnType::MacAddr => "macaddr".into(),
+            ColumnType::Year(_) => unimplemented!("Year is not available in Postgres."),
             }
         )
         .unwrap()

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -116,6 +116,7 @@ impl TableBuilder for SqliteQueryBuilder {
                 ColumnType::Cidr => unimplemented!("Cidr is not available in Sqlite."),
                 ColumnType::Inet => unimplemented!("Inet is not available in Sqlite."),
                 ColumnType::MacAddr => unimplemented!("MacAddr is not available in Sqlite."),
+                ColumnType::Year(_) => unimplemented!("Year is not available in Sqlite."),
             }
         )
         .unwrap()

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -117,6 +117,8 @@ impl TableBuilder for SqliteQueryBuilder {
                 ColumnType::Inet => unimplemented!("Inet is not available in Sqlite."),
                 ColumnType::MacAddr => unimplemented!("MacAddr is not available in Sqlite."),
                 ColumnType::Year(_) => unimplemented!("Year is not available in Sqlite."),
+                ColumnType::Bit(_) => unimplemented!("Bit is not available in Sqlite."),
+                ColumnType::VarBit(_) => unimplemented!("VarBit is not available in Sqlite."),
             }
         )
         .unwrap()

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -32,7 +32,7 @@ pub enum ColumnType {
     TimestampWithTimeZone(Option<u32>),
     Time(Option<u32>),
     Date,
-    Year(Option<MySQLYear>),
+    Year(Option<MySqlYear>),
     Interval(Option<PgInterval>, Option<u32>),
     Binary(BlobSize),
     VarBinary(u32),
@@ -86,7 +86,7 @@ pub enum PgInterval {
 
 // All MySQL year type field length sizes
 #[derive(Debug, Clone)]
-pub enum MySQLYear {
+pub enum MySqlYear {
     Two,
     Four,
 }
@@ -451,7 +451,7 @@ impl ColumnDef {
 
     /// Set column type as year
     /// Only MySQL supports year
-    pub fn year(&mut self, length: Option<MySQLYear>) -> &mut Self {
+    pub fn year(&mut self, length: Option<MySqlYear>) -> &mut Self {
         self.types = Some(ColumnType::Year(length));
         self
     }

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -32,6 +32,7 @@ pub enum ColumnType {
     TimestampWithTimeZone(Option<u32>),
     Time(Option<u32>),
     Date,
+    Year(Option<MySQLYear>),
     Interval(Option<PgInterval>, Option<u32>),
     Binary(BlobSize),
     VarBinary(u32),
@@ -79,6 +80,13 @@ pub enum PgInterval {
     HourToMinute,
     HourToSecond,
     MinuteToSecond,
+}
+
+// All MySQL year type field length sizes
+#[derive(Debug, Clone)]
+pub enum MySQLYear {
+    Two,
+    Four,
 }
 
 #[derive(Debug, Clone)]
@@ -436,6 +444,13 @@ impl ColumnDef {
     /// Set column type as date
     pub fn date(&mut self) -> &mut Self {
         self.types = Some(ColumnType::Date);
+        self
+    }
+
+    /// Set column type as year
+    /// Only MySQL supports year
+    pub fn year(&mut self, length: Option<MySQLYear>) -> &mut Self {
+        self.types = Some(ColumnType::Year(length));
         self
     }
 

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -36,6 +36,8 @@ pub enum ColumnType {
     Interval(Option<PgInterval>, Option<u32>),
     Binary(BlobSize),
     VarBinary(u32),
+    Bit(Option<u32>),
+    VarBit(u32),
     Boolean,
     Money(Option<(u32, u32)>),
     Json,
@@ -475,6 +477,18 @@ impl ColumnDef {
     /// Set column type as binary with variable length
     pub fn var_binary(&mut self, length: u32) -> &mut Self {
         self.types = Some(ColumnType::VarBinary(length));
+        self
+    }
+
+    /// Set column type as bit with variable length
+    pub fn bit(&mut self, length: Option<u32>) -> &mut Self {
+        self.types = Some(ColumnType::Bit(length));
+        self
+    }
+
+    /// Set column type as varbit with variable length
+    pub fn varbit(&mut self, length: u32) -> &mut Self {
+        self.types = Some(ColumnType::VarBit(length));
         self
     }
 

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -198,6 +198,17 @@ fn create_7() {
 }
 
 #[test]
+fn create_8() {
+    assert_eq!(
+        Table::create()
+            .table(Font::Table)
+            .col(ColumnDef::new(Font::Variant).year(Some(MySQLYear::Four)))
+            .to_string(MysqlQueryBuilder),
+        ["CREATE TABLE `font` (", "`variant` year(4)", ")",].join(" ")
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Table::drop()

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -202,7 +202,7 @@ fn create_8() {
     assert_eq!(
         Table::create()
             .table(Font::Table)
-            .col(ColumnDef::new(Font::Variant).year(Some(MySQLYear::Four)))
+            .col(ColumnDef::new(Font::Variant).year(Some(MySqlYear::Four)))
             .to_string(MysqlQueryBuilder),
         ["CREATE TABLE `font` (", "`variant` year(4)", ")",].join(" ")
     );


### PR DESCRIPTION
## PR Info
There are many non standard SQL types that we haven't covered yet. I tried to add some.

I need some of them to close this issue
https://github.com/SeaQL/seaography/issues/52
And cover some of FIXME tasks
https://github.com/SeaQL/sea-schema/blob/master/src/mysql/writer/column.rs

## Adds
* [x] YEAR MySQL
* [x] BIT MySQL, Postgres
* [x] VARBIT MySQL Postgres
