### PR TITLE
issues-452 Fix alter table for PostgreSQL

### DIFF
--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -143,7 +143,7 @@ impl TableBuilder for PostgresQueryBuilder {
                         write!(sql, " TYPE").unwrap();
                         self.prepare_column_type_check_auto_increment(column_def, sql);
                     }
-                    let first = !column_def.types.is_some();
+                    let first = column_def.types.is_none();
 
                     column_def.spec.iter().fold(first, |first, column_spec| {
                         if !first && !matches!(column_spec, ColumnSpec::AutoIncrement) {

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -193,7 +193,7 @@ impl TypeCreateStatement {
     ///     r#"CREATE TYPE "font_family" AS ENUM ('serif', 'sans', 'monospace')"#
     /// );
     /// ```
-    pub fn as_enum<T: 'static>(&mut self, name: T) -> &mut Self
+    pub fn as_enum<T>(&mut self, name: T) -> &mut Self
     where
         T: IntoTypeRef,
     {

--- a/src/foreign_key/drop.rs
+++ b/src/foreign_key/drop.rs
@@ -50,7 +50,7 @@ impl ForeignKeyDropStatement {
     }
 
     /// Set key table and referencing table
-    pub fn table<T: 'static>(&mut self, table: T) -> &mut Self
+    pub fn table<T>(&mut self, table: T) -> &mut Self
     where
         T: IntoTableRef,
     {

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -171,7 +171,7 @@ impl IndexCreateStatement {
     }
 
     /// Set target table
-    pub fn table<T: 'static>(&mut self, table: T) -> &mut Self
+    pub fn table<T>(&mut self, table: T) -> &mut Self
     where
         T: IntoTableRef,
     {
@@ -180,7 +180,7 @@ impl IndexCreateStatement {
     }
 
     /// Add index column
-    pub fn col<C: 'static>(&mut self, col: C) -> &mut Self
+    pub fn col<C>(&mut self, col: C) -> &mut Self
     where
         C: IntoIndexColumn,
     {

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -53,7 +53,7 @@ impl IndexDropStatement {
     }
 
     /// Set target table
-    pub fn table<T: 'static>(&mut self, table: T) -> &mut Self
+    pub fn table<T>(&mut self, table: T) -> &mut Self
     where
         T: IntoTableRef,
     {

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -70,7 +70,7 @@ impl TableAlterStatement {
     }
 
     /// Set table name
-    pub fn table<T: 'static>(&mut self, table: T) -> &mut Self
+    pub fn table<T>(&mut self, table: T) -> &mut Self
     where
         T: IntoTableRef,
     {
@@ -216,14 +216,14 @@ impl TableAlterStatement {
     ///     r#"ALTER TABLE "font" RENAME COLUMN "new_col" TO "new_column""#
     /// );
     /// ```
-    pub fn rename_column<T: 'static, R: 'static>(&mut self, from_name: T, to_name: R) -> &mut Self
+    pub fn rename_column<T, R>(&mut self, from_name: T, to_name: R) -> &mut Self
     where
-        T: Iden,
-        R: Iden,
+        T: IntoIden,
+        R: IntoIden,
     {
         self.add_alter_option(TableAlterOption::RenameColumn(
-            SeaRc::new(from_name),
-            SeaRc::new(to_name),
+            from_name.into_iden(),
+            to_name.into_iden(),
         ))
     }
 
@@ -252,11 +252,11 @@ impl TableAlterStatement {
     ///     r#"ALTER TABLE "font" DROP COLUMN "new_column""#
     /// );
     /// ```
-    pub fn drop_column<T: 'static>(&mut self, col_name: T) -> &mut Self
+    pub fn drop_column<T>(&mut self, col_name: T) -> &mut Self
     where
-        T: Iden,
+        T: IntoIden,
     {
-        self.add_alter_option(TableAlterOption::DropColumn(SeaRc::new(col_name)))
+        self.add_alter_option(TableAlterOption::DropColumn(col_name.into_iden()))
     }
 
     /// Add a foreign key to existing table

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -114,26 +114,26 @@ impl quote::ToTokens for PgInterval {
 
 impl ColumnDef {
     /// Construct a table column
-    pub fn new<T: 'static>(name: T) -> Self
+    pub fn new<T>(name: T) -> Self
     where
-        T: Iden,
+        T: IntoIden,
     {
         Self {
             table: None,
-            name: SeaRc::new(name),
+            name: name.into_iden(),
             types: None,
             spec: Vec::new(),
         }
     }
 
     /// Construct a table column with column type
-    pub fn new_with_type<T: 'static>(name: T, types: ColumnType) -> Self
+    pub fn new_with_type<T>(name: T, types: ColumnType) -> Self
     where
-        T: Iden,
+        T: IntoIden,
     {
         Self {
             table: None,
-            name: SeaRc::new(name),
+            name: name.into_iden(),
             types: Some(types),
             spec: Vec::new(),
         }

--- a/src/table/drop.rs
+++ b/src/table/drop.rs
@@ -56,7 +56,7 @@ impl TableDropStatement {
     }
 
     /// Set table name
-    pub fn table<T: 'static>(&mut self, table: T) -> &mut Self
+    pub fn table<T>(&mut self, table: T) -> &mut Self
     where
         T: IntoTableRef,
     {

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -46,7 +46,7 @@ impl TableRenameStatement {
     }
 
     /// Set old and new table name
-    pub fn table<T: 'static, R: 'static>(&mut self, from_name: T, to_name: R) -> &mut Self
+    pub fn table<T, R>(&mut self, from_name: T, to_name: R) -> &mut Self
     where
         T: IntoTableRef,
         R: IntoTableRef,

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -40,7 +40,7 @@ impl TableTruncateStatement {
     }
 
     /// Set table name
-    pub fn table<T: 'static>(&mut self, table: T) -> &mut Self
+    pub fn table<T>(&mut self, table: T) -> &mut Self
     where
         T: IntoTableRef,
     {

--- a/src/types.rs
+++ b/src/types.rs
@@ -353,7 +353,7 @@ where
 
 impl TableRef {
     /// Add or replace the current alias
-    pub fn alias<A: 'static>(self, alias: A) -> Self
+    pub fn alias<A>(self, alias: A) -> Self
     where
         A: IntoIden,
     {

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -463,6 +463,31 @@ fn alter_8() {
 }
 
 #[test]
+fn alter_9() {
+    assert_eq!(
+        Table::alter()
+            .table(Glyph::Table)
+            .modify_column(
+                ColumnDef::new(Glyph::Aspect)
+                    .integer()
+                    .auto_increment()
+                    .not_null()
+                    .unique_key()
+                    .primary_key()
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"ALTER TABLE "glyph""#,
+            r#"ALTER COLUMN "aspect" TYPE serial,"#,
+            r#"ALTER COLUMN "aspect" SET NOT NULL,"#,
+            r#"ADD UNIQUE ("aspect"),"#,
+            r#"ADD PRIMARY KEY ("aspect")"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn rename_1() {
     assert_eq!(
         Table::rename()


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-query/issues/452

## Fixes

- `ALTER TABLE` for PosgreSQL with `UNIQUE` constraint

## Changes

- Remove unneeded lifetimes
- `TableAlterStatement::rename_column` accepts `IntoIden` instead `Iden`
- `TableAlterStatement::drop_column` accepts `IntoIden` instead `Iden`
- `ColumnDef::new` accepts `IntoIden` instead `Iden`
- `ColumnDef::new_with_type` accepts `IntoIden` instead `Iden`