### PR TITLE
issues-398 Refactoring work with function

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -255,9 +255,9 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 write!(sql, " ").unwrap();
                 self.prepare_simple_expr(expr, sql);
             }
-            SimpleExpr::FunctionCall(func, exprs) => {
-                self.prepare_function(func, sql);
-                self.prepare_tuple(exprs, sql);
+            SimpleExpr::FunctionCall(func) => {
+                self.prepare_function(&func.func, sql);
+                self.prepare_tuple(&func.args, sql);
             }
             SimpleExpr::Binary(left, op, right) => {
                 if *op == BinOper::In && right.is_values() && right.get_values().is_empty() {
@@ -465,6 +465,12 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 write!(sql, "(").unwrap();
                 self.prepare_values_list(values, sql);
                 write!(sql, ")").unwrap();
+                write!(sql, " AS ").unwrap();
+                alias.prepare(sql.as_writer(), self.quote());
+            }
+            TableRef::FunctionCall(func, alias) => {
+                self.prepare_function(&func.func, sql);
+                self.prepare_tuple(&func.args, sql);
                 write!(sql, " AS ").unwrap();
                 alias.prepare(sql.as_writer(), self.quote());
             }

--- a/src/backend/table_ref_builder.rs
+++ b/src/backend/table_ref_builder.rs
@@ -40,7 +40,9 @@ pub trait TableRefBuilder: QuotedBuilder {
                 write!(sql, " AS ").unwrap();
                 alias.prepare(sql.as_writer(), self.quote());
             }
-            TableRef::SubQuery(_, _) | TableRef::ValuesList(_, _) => {
+            TableRef::SubQuery(_, _)
+            | TableRef::ValuesList(_, _)
+            | TableRef::FunctionCall(_, _) => {
                 panic!("TableRef with values is not support")
             }
         }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -24,7 +24,7 @@ pub enum SimpleExpr {
     Column(ColumnRef),
     Tuple(Vec<SimpleExpr>),
     Unary(UnOper, Box<SimpleExpr>),
-    FunctionCall(Func),
+    FunctionCall(FunctionCall),
     Binary(Box<SimpleExpr>, BinOper, Box<SimpleExpr>),
     SubQuery(Option<SubQueryOper>, Box<SubQueryStatement>),
     Value(Value),
@@ -1488,7 +1488,7 @@ impl Expr {
     /// ```
     pub fn max(mut self) -> SimpleExpr {
         let left = self.left.take();
-        Func::new(Function::Max).arg(left.unwrap()).into()
+        Func::max(left.unwrap()).into()
     }
 
     /// Express a `MIN` function.
@@ -1518,7 +1518,7 @@ impl Expr {
     /// ```
     pub fn min(mut self) -> SimpleExpr {
         let left = self.left.take();
-        Func::new(Function::Min).arg(left.unwrap()).into()
+        Func::min(left.unwrap()).into()
     }
 
     /// Express a `SUM` function.
@@ -1548,7 +1548,7 @@ impl Expr {
     /// ```
     pub fn sum(mut self) -> SimpleExpr {
         let left = self.left.take();
-        Func::new(Function::Sum).arg(left.unwrap()).into()
+        Func::sum(left.unwrap()).into()
     }
 
     /// Express a `COUNT` function.
@@ -1578,7 +1578,7 @@ impl Expr {
     /// ```
     pub fn count(mut self) -> SimpleExpr {
         let left = self.left.take();
-        Func::new(Function::Count).arg(left.unwrap()).into()
+        Func::count(left.unwrap()).into()
     }
 
     /// Express a `IF NULL` function.
@@ -1611,9 +1611,7 @@ impl Expr {
         V: Into<SimpleExpr>,
     {
         let left = self.left.take();
-        Func::new(Function::IfNull)
-            .args([left.unwrap(), v.into()])
-            .into()
+        Func::if_null(left.unwrap(), v).into()
     }
 
     /// Express a `IN` expression.
@@ -2304,8 +2302,8 @@ where
     }
 }
 
-impl From<Func> for SimpleExpr {
-    fn from(func: Func) -> Self {
+impl From<FunctionCall> for SimpleExpr {
+    fn from(func: FunctionCall) -> Self {
         SimpleExpr::FunctionCall(func)
     }
 }

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -1,6 +1,9 @@
 //! For calling built-in Postgres SQL functions.
 
-use crate::{expr::*, func::Function};
+use crate::{
+    expr::*,
+    func::{Func, Function},
+};
 
 /// Functions
 #[derive(Debug, Clone)]
@@ -44,16 +47,16 @@ impl PgFunc {
     ///     r#"SELECT TO_TSQUERY('a & b')"#
     /// );
     /// ```
-    pub fn to_tsquery<T>(expr: T, regconfig: Option<u32>) -> SimpleExpr
+    pub fn to_tsquery<T>(expr: T, regconfig: Option<u32>) -> Func
     where
         T: Into<SimpleExpr>,
     {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Expr::func(Function::PgFunction(PgFunction::ToTsquery)).args([config, expr.into()])
+                Func::new(Function::PgFunction(PgFunction::ToTsquery)).args([config, expr.into()])
             }
-            None => Expr::func(Function::PgFunction(PgFunction::ToTsquery)).arg(expr),
+            None => Func::new(Function::PgFunction(PgFunction::ToTsquery)).arg(expr),
         }
     }
 
@@ -76,16 +79,16 @@ impl PgFunc {
     ///     r#"SELECT TO_TSVECTOR('a b')"#
     /// );
     /// ```
-    pub fn to_tsvector<T>(expr: T, regconfig: Option<u32>) -> SimpleExpr
+    pub fn to_tsvector<T>(expr: T, regconfig: Option<u32>) -> Func
     where
         T: Into<SimpleExpr>,
     {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Expr::func(Function::PgFunction(PgFunction::ToTsvector)).args([config, expr.into()])
+                Func::new(Function::PgFunction(PgFunction::ToTsvector)).args([config, expr.into()])
             }
-            None => Expr::func(Function::PgFunction(PgFunction::ToTsvector)).arg(expr),
+            None => Func::new(Function::PgFunction(PgFunction::ToTsvector)).arg(expr),
         }
     }
 
@@ -108,17 +111,17 @@ impl PgFunc {
     ///     r#"SELECT PHRASETO_TSQUERY('a b')"#
     /// );
     /// ```
-    pub fn phraseto_tsquery<T>(expr: T, regconfig: Option<u32>) -> SimpleExpr
+    pub fn phraseto_tsquery<T>(expr: T, regconfig: Option<u32>) -> Func
     where
         T: Into<SimpleExpr>,
     {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Expr::func(Function::PgFunction(PgFunction::PhrasetoTsquery))
+                Func::new(Function::PgFunction(PgFunction::PhrasetoTsquery))
                     .args([config, expr.into()])
             }
-            None => Expr::func(Function::PgFunction(PgFunction::PhrasetoTsquery)).arg(expr),
+            None => Func::new(Function::PgFunction(PgFunction::PhrasetoTsquery)).arg(expr),
         }
     }
 
@@ -141,17 +144,17 @@ impl PgFunc {
     ///     r#"SELECT PLAINTO_TSQUERY('a b')"#
     /// );
     /// ```
-    pub fn plainto_tsquery<T>(expr: T, regconfig: Option<u32>) -> SimpleExpr
+    pub fn plainto_tsquery<T>(expr: T, regconfig: Option<u32>) -> Func
     where
         T: Into<SimpleExpr>,
     {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Expr::func(Function::PgFunction(PgFunction::PlaintoTsquery))
+                Func::new(Function::PgFunction(PgFunction::PlaintoTsquery))
                     .args([config, expr.into()])
             }
-            None => Expr::func(Function::PgFunction(PgFunction::PlaintoTsquery)).arg(expr),
+            None => Func::new(Function::PgFunction(PgFunction::PlaintoTsquery)).arg(expr),
         }
     }
 
@@ -174,17 +177,17 @@ impl PgFunc {
     ///     r#"SELECT WEBSEARCH_TO_TSQUERY('a b')"#
     /// );
     /// ```
-    pub fn websearch_to_tsquery<T>(expr: T, regconfig: Option<u32>) -> SimpleExpr
+    pub fn websearch_to_tsquery<T>(expr: T, regconfig: Option<u32>) -> Func
     where
         T: Into<SimpleExpr>,
     {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Expr::func(Function::PgFunction(PgFunction::WebsearchToTsquery))
+                Func::new(Function::PgFunction(PgFunction::WebsearchToTsquery))
                     .args([config, expr.into()])
             }
-            None => Expr::func(Function::PgFunction(PgFunction::WebsearchToTsquery)).arg(expr),
+            None => Func::new(Function::PgFunction(PgFunction::WebsearchToTsquery)).arg(expr),
         }
     }
 
@@ -204,11 +207,11 @@ impl PgFunc {
     ///     r#"SELECT TS_RANK('a b', 'a&b')"#
     /// );
     /// ```
-    pub fn ts_rank<T>(vector: T, query: T) -> SimpleExpr
+    pub fn ts_rank<T>(vector: T, query: T) -> Func
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::PgFunction(PgFunction::TsRank)).args([vector, query])
+        Func::new(Function::PgFunction(PgFunction::TsRank)).args([vector.into(), query.into()])
     }
 
     /// Call `TS_RANK_CD` function. Postgres only.
@@ -227,11 +230,11 @@ impl PgFunc {
     ///     r#"SELECT TS_RANK_CD('a b', 'a&b')"#
     /// );
     /// ```
-    pub fn ts_rank_cd<T>(vector: T, query: T) -> SimpleExpr
+    pub fn ts_rank_cd<T>(vector: T, query: T) -> Func
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::PgFunction(PgFunction::TsRankCd)).args([vector, query])
+        Func::new(Function::PgFunction(PgFunction::TsRankCd)).args([vector.into(), query.into()])
     }
 
     /// Call `ANY` function. Postgres only.
@@ -251,11 +254,11 @@ impl PgFunc {
     /// );
     /// ```
     #[cfg(feature = "postgres-array")]
-    pub fn any<T>(expr: T) -> SimpleExpr
+    pub fn any<T>(expr: T) -> Func
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::PgFunction(PgFunction::Any)).arg(expr)
+        Func::new(Function::PgFunction(PgFunction::Any)).arg(expr)
     }
 
     /// Call `SOME` function. Postgres only.
@@ -275,11 +278,11 @@ impl PgFunc {
     /// );
     /// ```
     #[cfg(feature = "postgres-array")]
-    pub fn some<T>(expr: T) -> SimpleExpr
+    pub fn some<T>(expr: T) -> Func
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::PgFunction(PgFunction::Some)).arg(expr)
+        Func::new(Function::PgFunction(PgFunction::Some)).arg(expr)
     }
 
     /// Call `ALL` function. Postgres only.
@@ -299,10 +302,10 @@ impl PgFunc {
     /// );
     /// ```
     #[cfg(feature = "postgres-array")]
-    pub fn all<T>(expr: T) -> SimpleExpr
+    pub fn all<T>(expr: T) -> Func
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::PgFunction(PgFunction::All)).arg(expr)
+        Func::new(Function::PgFunction(PgFunction::All)).arg(expr)
     }
 }

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -1,9 +1,6 @@
 //! For calling built-in Postgres SQL functions.
 
-use crate::{
-    expr::*,
-    func::{Func, Function},
-};
+use crate::{expr::*, func::*};
 
 /// Functions
 #[derive(Debug, Clone)]
@@ -47,16 +44,17 @@ impl PgFunc {
     ///     r#"SELECT TO_TSQUERY('a & b')"#
     /// );
     /// ```
-    pub fn to_tsquery<T>(expr: T, regconfig: Option<u32>) -> Func
+    pub fn to_tsquery<T>(expr: T, regconfig: Option<u32>) -> FunctionCall
     where
         T: Into<SimpleExpr>,
     {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Func::new(Function::PgFunction(PgFunction::ToTsquery)).args([config, expr.into()])
+                FunctionCall::new(Function::PgFunction(PgFunction::ToTsquery))
+                    .args([config, expr.into()])
             }
-            None => Func::new(Function::PgFunction(PgFunction::ToTsquery)).arg(expr),
+            None => FunctionCall::new(Function::PgFunction(PgFunction::ToTsquery)).arg(expr),
         }
     }
 
@@ -79,16 +77,17 @@ impl PgFunc {
     ///     r#"SELECT TO_TSVECTOR('a b')"#
     /// );
     /// ```
-    pub fn to_tsvector<T>(expr: T, regconfig: Option<u32>) -> Func
+    pub fn to_tsvector<T>(expr: T, regconfig: Option<u32>) -> FunctionCall
     where
         T: Into<SimpleExpr>,
     {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Func::new(Function::PgFunction(PgFunction::ToTsvector)).args([config, expr.into()])
+                FunctionCall::new(Function::PgFunction(PgFunction::ToTsvector))
+                    .args([config, expr.into()])
             }
-            None => Func::new(Function::PgFunction(PgFunction::ToTsvector)).arg(expr),
+            None => FunctionCall::new(Function::PgFunction(PgFunction::ToTsvector)).arg(expr),
         }
     }
 
@@ -111,17 +110,17 @@ impl PgFunc {
     ///     r#"SELECT PHRASETO_TSQUERY('a b')"#
     /// );
     /// ```
-    pub fn phraseto_tsquery<T>(expr: T, regconfig: Option<u32>) -> Func
+    pub fn phraseto_tsquery<T>(expr: T, regconfig: Option<u32>) -> FunctionCall
     where
         T: Into<SimpleExpr>,
     {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Func::new(Function::PgFunction(PgFunction::PhrasetoTsquery))
+                FunctionCall::new(Function::PgFunction(PgFunction::PhrasetoTsquery))
                     .args([config, expr.into()])
             }
-            None => Func::new(Function::PgFunction(PgFunction::PhrasetoTsquery)).arg(expr),
+            None => FunctionCall::new(Function::PgFunction(PgFunction::PhrasetoTsquery)).arg(expr),
         }
     }
 
@@ -144,17 +143,17 @@ impl PgFunc {
     ///     r#"SELECT PLAINTO_TSQUERY('a b')"#
     /// );
     /// ```
-    pub fn plainto_tsquery<T>(expr: T, regconfig: Option<u32>) -> Func
+    pub fn plainto_tsquery<T>(expr: T, regconfig: Option<u32>) -> FunctionCall
     where
         T: Into<SimpleExpr>,
     {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Func::new(Function::PgFunction(PgFunction::PlaintoTsquery))
+                FunctionCall::new(Function::PgFunction(PgFunction::PlaintoTsquery))
                     .args([config, expr.into()])
             }
-            None => Func::new(Function::PgFunction(PgFunction::PlaintoTsquery)).arg(expr),
+            None => FunctionCall::new(Function::PgFunction(PgFunction::PlaintoTsquery)).arg(expr),
         }
     }
 
@@ -177,17 +176,19 @@ impl PgFunc {
     ///     r#"SELECT WEBSEARCH_TO_TSQUERY('a b')"#
     /// );
     /// ```
-    pub fn websearch_to_tsquery<T>(expr: T, regconfig: Option<u32>) -> Func
+    pub fn websearch_to_tsquery<T>(expr: T, regconfig: Option<u32>) -> FunctionCall
     where
         T: Into<SimpleExpr>,
     {
         match regconfig {
             Some(config) => {
                 let config = SimpleExpr::Value(config.into());
-                Func::new(Function::PgFunction(PgFunction::WebsearchToTsquery))
+                FunctionCall::new(Function::PgFunction(PgFunction::WebsearchToTsquery))
                     .args([config, expr.into()])
             }
-            None => Func::new(Function::PgFunction(PgFunction::WebsearchToTsquery)).arg(expr),
+            None => {
+                FunctionCall::new(Function::PgFunction(PgFunction::WebsearchToTsquery)).arg(expr)
+            }
         }
     }
 
@@ -207,11 +208,12 @@ impl PgFunc {
     ///     r#"SELECT TS_RANK('a b', 'a&b')"#
     /// );
     /// ```
-    pub fn ts_rank<T>(vector: T, query: T) -> Func
+    pub fn ts_rank<T>(vector: T, query: T) -> FunctionCall
     where
         T: Into<SimpleExpr>,
     {
-        Func::new(Function::PgFunction(PgFunction::TsRank)).args([vector.into(), query.into()])
+        FunctionCall::new(Function::PgFunction(PgFunction::TsRank))
+            .args([vector.into(), query.into()])
     }
 
     /// Call `TS_RANK_CD` function. Postgres only.
@@ -230,11 +232,12 @@ impl PgFunc {
     ///     r#"SELECT TS_RANK_CD('a b', 'a&b')"#
     /// );
     /// ```
-    pub fn ts_rank_cd<T>(vector: T, query: T) -> Func
+    pub fn ts_rank_cd<T>(vector: T, query: T) -> FunctionCall
     where
         T: Into<SimpleExpr>,
     {
-        Func::new(Function::PgFunction(PgFunction::TsRankCd)).args([vector.into(), query.into()])
+        FunctionCall::new(Function::PgFunction(PgFunction::TsRankCd))
+            .args([vector.into(), query.into()])
     }
 
     /// Call `ANY` function. Postgres only.
@@ -254,11 +257,11 @@ impl PgFunc {
     /// );
     /// ```
     #[cfg(feature = "postgres-array")]
-    pub fn any<T>(expr: T) -> Func
+    pub fn any<T>(expr: T) -> FunctionCall
     where
         T: Into<SimpleExpr>,
     {
-        Func::new(Function::PgFunction(PgFunction::Any)).arg(expr)
+        FunctionCall::new(Function::PgFunction(PgFunction::Any)).arg(expr)
     }
 
     /// Call `SOME` function. Postgres only.
@@ -278,11 +281,11 @@ impl PgFunc {
     /// );
     /// ```
     #[cfg(feature = "postgres-array")]
-    pub fn some<T>(expr: T) -> Func
+    pub fn some<T>(expr: T) -> FunctionCall
     where
         T: Into<SimpleExpr>,
     {
-        Func::new(Function::PgFunction(PgFunction::Some)).arg(expr)
+        FunctionCall::new(Function::PgFunction(PgFunction::Some)).arg(expr)
     }
 
     /// Call `ALL` function. Postgres only.
@@ -302,10 +305,10 @@ impl PgFunc {
     /// );
     /// ```
     #[cfg(feature = "postgres-array")]
-    pub fn all<T>(expr: T) -> Func
+    pub fn all<T>(expr: T) -> FunctionCall
     where
         T: Into<SimpleExpr>,
     {
-        Func::new(Function::PgFunction(PgFunction::All)).arg(expr)
+        FunctionCall::new(Function::PgFunction(PgFunction::All)).arg(expr)
     }
 }

--- a/src/func.rs
+++ b/src/func.rs
@@ -1,6 +1,6 @@
 //! For calling built-in SQL functions.
 
-use crate::{expr::*, types::*, Value};
+use crate::{expr::*, types::*};
 
 #[cfg(feature = "backend-postgres")]
 pub use crate::extension::postgres::{PgFunc, PgFunction};
@@ -28,9 +28,19 @@ pub enum Function {
 
 /// Function call helper.
 #[derive(Debug, Clone)]
-pub struct Func;
+pub struct Func {
+    pub(crate) func: Function,
+    pub(crate) args: Vec<SimpleExpr>,
+}
 
 impl Func {
+    pub(crate) fn new(func: Function) -> Self {
+        Self {
+            func,
+            args: Vec::new(),
+        }
+    }
+
     /// Call a custom function.
     ///
     /// # Examples
@@ -47,7 +57,7 @@ impl Func {
     /// }
     ///
     /// let query = Query::select()
-    ///     .expr(Func::cust(MyFunction).args([Expr::val("hello")]))
+    ///     .expr(Func::cust(MyFunction).arg(Expr::val("hello")))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -63,11 +73,11 @@ impl Func {
     ///     r#"SELECT MY_FUNCTION('hello')"#
     /// );
     /// ```
-    pub fn cust<T>(func: T) -> Expr
+    pub fn cust<T>(func: T) -> Self
     where
         T: IntoIden,
     {
-        Expr::func(Function::Custom(func.into_iden()))
+        Func::new(Function::Custom(func.into_iden()))
     }
 
     /// Call `MAX` function.
@@ -95,11 +105,11 @@ impl Func {
     ///     r#"SELECT MAX("character"."size_w") FROM "character""#
     /// );
     /// ```
-    pub fn max<T>(expr: T) -> SimpleExpr
+    pub fn max<T>(expr: T) -> Self
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::Max).arg(expr)
+        Func::new(Function::Max).arg(expr)
     }
 
     /// Call `MIN` function.
@@ -127,11 +137,11 @@ impl Func {
     ///     r#"SELECT MIN("character"."size_h") FROM "character""#
     /// );
     /// ```
-    pub fn min<T>(expr: T) -> SimpleExpr
+    pub fn min<T>(expr: T) -> Self
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::Min).arg(expr)
+        Func::new(Function::Min).arg(expr)
     }
 
     /// Call `SUM` function.
@@ -159,11 +169,11 @@ impl Func {
     ///     r#"SELECT SUM("character"."size_h") FROM "character""#
     /// );
     /// ```
-    pub fn sum<T>(expr: T) -> SimpleExpr
+    pub fn sum<T>(expr: T) -> Self
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::Sum).arg(expr)
+        Func::new(Function::Sum).arg(expr)
     }
 
     /// Call `AVG` function.
@@ -191,11 +201,11 @@ impl Func {
     ///     r#"SELECT AVG("character"."size_h") FROM "character""#
     /// );
     /// ```
-    pub fn avg<T>(expr: T) -> SimpleExpr
+    pub fn avg<T>(expr: T) -> Self
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::Avg).arg(expr)
+        Func::new(Function::Avg).arg(expr)
     }
 
     /// Call `ABS` function.
@@ -223,11 +233,11 @@ impl Func {
     ///     r#"SELECT ABS("character"."size_h") FROM "character""#
     /// );
     /// ```
-    pub fn abs<T>(expr: T) -> SimpleExpr
+    pub fn abs<T>(expr: T) -> Self
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::Abs).arg(expr)
+        Func::new(Function::Abs).arg(expr)
     }
 
     /// Call `COUNT` function.
@@ -255,11 +265,11 @@ impl Func {
     ///     r#"SELECT COUNT("character"."id") FROM "character""#
     /// );
     /// ```
-    pub fn count<T>(expr: T) -> SimpleExpr
+    pub fn count<T>(expr: T) -> Self
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::Count).arg(expr)
+        Func::new(Function::Count).arg(expr)
     }
 
     /// Call `CHAR_LENGTH` function.
@@ -287,11 +297,11 @@ impl Func {
     ///     r#"SELECT LENGTH("character"."character") FROM "character""#
     /// );
     /// ```
-    pub fn char_length<T>(expr: T) -> SimpleExpr
+    pub fn char_length<T>(expr: T) -> Self
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::CharLength).arg(expr)
+        Func::new(Function::CharLength).arg(expr)
     }
 
     /// Call `IF NULL` function.
@@ -322,12 +332,12 @@ impl Func {
     ///     r#"SELECT IFNULL("size_w", "size_h") FROM "character""#
     /// );
     /// ```
-    pub fn if_null<A, B>(a: A, b: B) -> SimpleExpr
+    pub fn if_null<A, B>(a: A, b: B) -> Self
     where
         A: Into<SimpleExpr>,
         B: Into<SimpleExpr>,
     {
-        Expr::func(Function::IfNull).args([a.into(), b.into()])
+        Func::new(Function::IfNull).args([a.into(), b.into()])
     }
 
     /// Call `CAST` function with a custom type.
@@ -354,12 +364,13 @@ impl Func {
     ///     r#"SELECT CAST('hello' AS MyType)"#
     /// );
     /// ```
-    pub fn cast_as<V, I>(value: V, iden: I) -> SimpleExpr
+    pub fn cast_as<V, I>(expr: V, iden: I) -> Self
     where
-        V: Into<Value>,
+        V: Into<SimpleExpr>,
         I: IntoIden,
     {
-        Expr::func(Function::Cast).arg(Expr::val(value.into()).bin_oper(
+        let expr: SimpleExpr = expr.into();
+        Func::new(Function::Cast).arg(expr.binary(
             BinOper::As,
             Expr::cust(iden.into_iden().to_string().as_str()),
         ))
@@ -374,9 +385,9 @@ impl Func {
     ///
     /// let query = Query::select()
     ///     .expr(Func::coalesce([
-    ///         Expr::col(Char::SizeW),
-    ///         Expr::col(Char::SizeH),
-    ///         Expr::val(12),
+    ///         Expr::col(Char::SizeW).into(),
+    ///         Expr::col(Char::SizeH).into(),
+    ///         Expr::val(12).into(),
     ///     ]))
     ///     .from(Char::Table)
     ///     .to_owned();
@@ -394,12 +405,11 @@ impl Func {
     ///     r#"SELECT COALESCE("size_w", "size_h", 12) FROM "character""#
     /// );
     /// ```
-    pub fn coalesce<I, T>(args: I) -> SimpleExpr
+    pub fn coalesce<I>(args: I) -> Self
     where
-        T: Into<SimpleExpr>,
-        I: IntoIterator<Item = T>,
+        I: IntoIterator<Item = SimpleExpr>,
     {
-        Expr::func(Function::Coalesce).args(args)
+        Func::new(Function::Coalesce).args(args)
     }
 
     /// Call `LOWER` function.
@@ -407,7 +417,6 @@ impl Func {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::tests_cfg::Character::Character;
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
@@ -428,11 +437,11 @@ impl Func {
     ///     r#"SELECT LOWER("character") FROM "character""#
     /// );
     /// ```
-    pub fn lower<T>(expr: T) -> SimpleExpr
+    pub fn lower<T>(expr: T) -> Self
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::Lower).arg(expr)
+        Func::new(Function::Lower).arg(expr)
     }
 
     /// Call `UPPER` function.
@@ -440,7 +449,6 @@ impl Func {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::tests_cfg::Character::Character;
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
@@ -461,11 +469,11 @@ impl Func {
     ///     r#"SELECT UPPER("character") FROM "character""#
     /// );
     /// ```
-    pub fn upper<T>(expr: T) -> SimpleExpr
+    pub fn upper<T>(expr: T) -> Self
     where
         T: Into<SimpleExpr>,
     {
-        Expr::func(Function::Upper).arg(expr)
+        Func::new(Function::Upper).arg(expr)
     }
 
     /// Call `RANDOM` function.
@@ -484,7 +492,26 @@ impl Func {
     ///
     /// assert_eq!(query.to_string(SqliteQueryBuilder), r#"SELECT RANDOM()"#);
     /// ```
-    pub fn random() -> SimpleExpr {
-        Expr::func(Function::Random).into()
+    pub fn random() -> Self {
+        Func {
+            func: Function::Random,
+            args: vec![],
+        }
+    }
+
+    pub fn arg<T>(mut self, arg: T) -> Self
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.args = vec![arg.into()];
+        self
+    }
+
+    pub fn args<I>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = SimpleExpr>,
+    {
+        self.args = args.into_iter().collect();
+        self
     }
 }

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -176,7 +176,7 @@ impl InsertStatement {
     ///     .columns([Glyph::Aspect, Glyph::Image])
     ///     .values([
     ///         2.into(),
-    ///         Func::cast_as("2020-02-02 00:00:00", Alias::new("DATE")),
+    ///         Func::cast_as("2020-02-02 00:00:00", Alias::new("DATE")).into(),
     ///     ])
     ///     .unwrap()
     ///     .to_owned();

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -198,10 +198,7 @@ impl InsertStatement {
     where
         I: IntoIterator<Item = SimpleExpr>,
     {
-        let values = values
-            .into_iter()
-            .map(|v| v.into())
-            .collect::<Vec<SimpleExpr>>();
+        let values = values.into_iter().collect::<Vec<SimpleExpr>>();
         if self.columns.len() != values.len() {
             return Err(Error::ColValNumMismatch {
                 col_len: self.columns.len(),

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1,13 +1,12 @@
 use crate::{
     backend::QueryBuilder,
     expr::*,
-    func::Func,
     prepare::*,
     query::{condition::*, OrderedStatement},
     types::*,
     value::*,
-    QueryStatementBuilder, QueryStatementWriter, SubQueryStatement, WindowStatement, WithClause,
-    WithQuery,
+    FunctionCall, QueryStatementBuilder, QueryStatementWriter, SubQueryStatement, WindowStatement,
+    WithClause, WithQuery,
 };
 
 /// Select rows from an existing table
@@ -1003,7 +1002,7 @@ impl SelectStatement {
     ///     r#"SELECT * FROM RANDOM() AS "func""#
     /// );
     /// ```
-    pub fn from_function<T>(&mut self, func: Func, alias: T) -> &mut Self
+    pub fn from_function<T>(&mut self, func: FunctionCall, alias: T) -> &mut Self
     where
         T: IntoIden,
     {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Base types used throughout sea-query.
 
-use crate::{expr::*, query::*, ValueTuple, Values};
+use crate::{expr::*, func::Func, query::*, ValueTuple, Values};
 use std::fmt;
 
 #[cfg(not(feature = "thread-safe"))]
@@ -91,6 +91,8 @@ pub enum TableRef {
     SubQuery(SelectStatement, DynIden),
     /// Values list with alias
     ValuesList(Vec<ValueTuple>, DynIden),
+    /// Function call with alias
+    FunctionCall(Func, DynIden),
 }
 
 pub trait IntoTableRef {
@@ -374,6 +376,7 @@ impl TableRef {
             }
             Self::SubQuery(statement, _) => Self::SubQuery(statement, alias.into_iden()),
             Self::ValuesList(values, _) => Self::ValuesList(values, alias.into_iden()),
+            Self::FunctionCall(func, _) => Self::FunctionCall(func, alias.into_iden()),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 //! Base types used throughout sea-query.
 
-use crate::{expr::*, func::Func, query::*, ValueTuple, Values};
+use crate::{expr::*, query::*, FunctionCall, ValueTuple, Values};
 use std::fmt;
 
 #[cfg(not(feature = "thread-safe"))]
@@ -92,7 +92,7 @@ pub enum TableRef {
     /// Values list with alias
     ValuesList(Vec<ValueTuple>, DynIden),
     /// Function call with alias
-    FunctionCall(Func, DynIden),
+    FunctionCall(FunctionCall, DynIden),
 }
 
 pub trait IntoTableRef {


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-query/issues/398

## Adds

- `SelectStatement::from_function` - allow to use `SELECT FROM func()`
- `impl<T> From<T> for SelectExpr where T: Into<SimpleExpr>`
- `impl From<FunctionCall> for SimpleExpr`
- New `struct FunctionCall` hold function and args for call the function

## Breaking Changes

- `Func::*` now return `FunctionCall` insted `SimpleExpr`
- `Func::coalesce` accept `IntoIterator<Item = SimpleExpr>` instead `IntoIterator<Item = Into<SimpleExpr>`

## Changes

- `Expr::expr` accept `Into<SimpleExpr>` instead `SimpleExpr`
- Removed `Expr::arg` and `Expr::args` - this functions are unneeded
