### PR TITLE
ValueTrait for SQLx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ name = "sea_query"
 path = "src/lib.rs"
 
 [dependencies]
+sea-query-sqlx = { version = "^0.1", path = "sea-query-sqlx", optional = true }
 sea-query-attr = { version = "^0.1.1", path = "sea-query-attr", optional = true }
 sea-query-derive = { version = "^0.2.0", path = "sea-query-derive", optional = true }
 serde_json = { version = "^1", optional = true }

--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "sea-query-sqlx"]
+members = ["."]
 
 [package]
 name = "sea-query-binder"

--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-# A separate workspace
+members = [".", "sea-query-sqlx"]
 
 [package]
 name = "sea-query-binder"
@@ -18,6 +18,7 @@ rust-version = "1.60"
 
 [dependencies]
 sea-query = { version = "^0", path = "..", features = ["thread-safe"] }
+sea-query-sqlx = { version = "^0.1", path = "../sea-query-sqlx", optional = true }
 sqlx = { version = "^0.6.1", optional = true }
 serde_json = { version = "^1", optional = true }
 chrono = { version = "^0.4", default-features = false, features = ["clock"], optional = true }
@@ -32,9 +33,9 @@ ipnetwork = { version = "^0.19", optional = true }
 mac_address = { version = "^1.1", optional = true }
 
 [features]
-sqlx-mysql = ["sqlx/mysql"]
-sqlx-postgres = ["sqlx/postgres"]
-sqlx-sqlite = ["sqlx/sqlite"]
+sqlx-mysql = ["sqlx/mysql", "sea-query-sqlx", "sea-query/sea-query-sqlx"]
+sqlx-postgres = ["sqlx/postgres", "sea-query-sqlx", "sea-query/sea-query-sqlx"]
+sqlx-sqlite = ["sqlx/sqlite", "sea-query-sqlx", "sea-query/sea-query-sqlx"]
 sqlx-any = ["sqlx/any"]
 with-chrono = ["sqlx/chrono", "sea-query/with-chrono", "chrono"]
 with-json = ["sqlx/json", "sea-query/with-json", "serde_json"]

--- a/sea-query-binder/src/sqlx_mysql.rs
+++ b/sea-query-binder/src/sqlx_mysql.rs
@@ -117,6 +117,9 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::mysql::MySql> for SqlxValues {
                 Value::MacAddress(_) => {
                     panic!("Mysql doesn't support MacAddress arguments");
                 }
+                Value::CustomSqlx(value) => {
+                    value.0.add_mysql(&mut args);
+                }
             }
         }
         args

--- a/sea-query-binder/src/sqlx_postgres.rs
+++ b/sea-query-binder/src/sqlx_postgres.rs
@@ -129,6 +129,9 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::postgres::Postgres> for SqlxValues {
                 Value::MacAddress(mac) => {
                     args.add(mac.as_deref());
                 }
+                Value::CustomSqlx(value) => {
+                    value.0.add_postgres(&mut args);
+                }
                 #[cfg(feature = "postgres-array")]
                 Value::Array(ty, v) => match ty {
                     ArrayType::Bool => {

--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -117,6 +117,9 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 Value::Array(_, _) => {
                     panic!("Sqlite doesn't support array arguments");
                 }
+                Value::CustomSqlx(value) => {
+                    value.0.add_sqlite(&mut args);
+                }
             }
         }
         args

--- a/sea-query-sqlx/Cargo.toml
+++ b/sea-query-sqlx/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "sea-query-sqlx"
+version = "0.1.0"
+authors = [ "Chris Tsang <tyt2y7@gmail.com>" ]
+edition = "2021"
+description = "SQLx traits for working with custom types"
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/sea-query"
+repository = "https://github.com/SeaQL/sea-query"
+categories = [ "database" ]
+keywords = [ "database", "sql", "mysql", "postgres", "sqlite" ]
+rust-version = "1.60"
+
+[lib]
+
+[dependencies]
+sqlx = { version = "^0.6" }
+
+[features]
+sqlx-mysql = ["sqlx/mysql"]
+sqlx-postgres = ["sqlx/postgres"]
+sqlx-sqlite = ["sqlx/sqlite"]
+runtime-async-std-native-tls = ["sqlx/runtime-async-std-native-tls"]
+runtime-async-std-rustls = ["sqlx/runtime-async-std-rustls", ]
+runtime-actix-native-tls = ["sqlx/runtime-actix-native-tls"]
+runtime-actix-rustls = ["sqlx/runtime-actix-rustls"]
+runtime-tokio-native-tls = ["sqlx/runtime-tokio-native-tls"]
+runtime-tokio-rustls = ["sqlx/runtime-tokio-rustls"]

--- a/sea-query-sqlx/src/lib.rs
+++ b/sea-query-sqlx/src/lib.rs
@@ -1,0 +1,10 @@
+use std::fmt::Debug;
+
+pub trait SqlxValueTrait: Debug + Send + Sync {
+    #[cfg(feature = "sqlx-mysql")]
+    fn add_mysql(&self, args: &mut sqlx::mysql::MySqlArguments) -> bool;
+    #[cfg(feature = "sqlx-postgres")]
+    fn add_postgres(&self, args: &mut sqlx::postgres::PgArguments) -> bool;
+    #[cfg(feature = "sqlx-sqlite")]
+    fn add_sqlite(&self, args: &mut sqlx::sqlite::SqliteArguments) -> bool;
+}

--- a/sea-query-sqlx/src/lib.rs
+++ b/sea-query-sqlx/src/lib.rs
@@ -7,4 +7,6 @@ pub trait SqlxValueTrait: Debug + Send + Sync {
     fn add_postgres(&self, args: &mut sqlx::postgres::PgArguments) -> bool;
     #[cfg(feature = "sqlx-sqlite")]
     fn add_sqlite(&self, args: &mut sqlx::sqlite::SqliteArguments) -> bool;
+
+    fn format_sql(&self, s: &mut dyn std::fmt::Write) -> std::fmt::Result;
 }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1049,6 +1049,8 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             Value::IpNetwork(Some(v)) => write!(s, "'{}'", v).unwrap(),
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(Some(v)) => write!(s, "'{}'", v).unwrap(),
+            #[cfg(feature = "sea-query-sqlx")]
+            Value::CustomSqlx(v) => write!(s, "{:?}", v).unwrap(),
         };
         s
     }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1050,7 +1050,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(Some(v)) => write!(s, "'{}'", v).unwrap(),
             #[cfg(feature = "sea-query-sqlx")]
-            Value::CustomSqlx(v) => write!(s, "{:?}", v).unwrap(),
+            Value::CustomSqlx(v) => v.0.format_sql(&mut s).unwrap(),
         };
         s
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -29,6 +29,9 @@ use std::net::IpAddr;
 #[cfg(feature = "with-mac_address")]
 use mac_address::MacAddress;
 
+#[cfg(feature = "sea-query-sqlx")]
+use sea_query_sqlx::SqlxValueTrait;
+
 use crate::{BlobSize, ColumnType, CommonSqlQueryBuilder, QueryBuilder};
 
 /// [`Value`] types variant for Postgres array
@@ -203,6 +206,9 @@ pub enum Value {
     #[cfg(feature = "with-mac_address")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-mac_address")))]
     MacAddress(Option<Box<MacAddress>>),
+
+    #[cfg(feature = "sea-query-sqlx")]
+    CustomSqlx(CustomSqlxValue),
 }
 
 impl std::fmt::Display for Value {
@@ -1391,6 +1397,18 @@ impl IntoIterator for Values {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+#[cfg(feature = "sea-query-sqlx")]
+#[derive(Debug, Clone)]
+pub struct CustomSqlxValue(pub crate::SeaRc<dyn SqlxValueTrait>);
+
+#[cfg(feature = "sea-query-sqlx")]
+impl PartialEq for CustomSqlxValue {
+    fn eq(&self, other: &Self) -> bool {
+        #[allow(clippy::vtable_address_comparisons)]
+        crate::SeaRc::ptr_eq(&self.0, &other.0)
     }
 }
 


### PR DESCRIPTION
This is an initial design of `ValueTrait` to allow custom `Value` to be used with SeaQuery.

The tricky part is the dependency tree:

```
sea-query-binder v0.1.0 (/home/chris/sea-query/sea-query-binder)
├── sea-query v0.27.0 (/home/chris/sea-query)
│   ├── sea-query-derive v0.2.0 (proc-macro) (/home/chris/sea-query/sea-query-derive)
│   └── sea-query-sqlx v0.1.0 (/home/chris/sea-query/sea-query-sqlx)
│       └── sqlx v0.6.2
│           ├── sqlx-core v0.6.2
│           │   ├── sqlx-rt v0.6.2
│           └── sqlx-macros v0.6.2 (proc-macro)
│               ├── sqlx-core v0.6.2
│               │   ├── sqlx-rt v0.6.2 (*)
│               ├── sqlx-rt v0.6.2 (*)
├── sea-query-sqlx v0.1.0 (/home/chris/sea-query/sea-query-sqlx) (*)
└── sqlx v0.6.2 (*)
```

Now sadly we can no longer `cargo b --all-features`.