### PR TITLE
SQLite bind `rust_decimal` & `bigdecimal` as f64

### DIFF
--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -96,12 +96,16 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(decimal) => {
                     use rust_decimal::prelude::ToPrimitive;
-                    args.add(decimal.map(|d| d.to_f64().unwrap()));
+                    args.add(
+                        decimal.map(|d| d.to_f64().expect("Fail to convert rust_decimal as f64")),
+                    );
                 }
                 #[cfg(feature = "with-bigdecimal")]
                 Value::BigDecimal(big_decimal) => {
                     use bigdecimal::ToPrimitive;
-                    args.add(big_decimal.map(|d| d.to_f64().unwrap()));
+                    args.add(
+                        big_decimal.map(|d| d.to_f64().expect("Fail to convert bigdecimal as f64")),
+                    );
                 }
                 #[cfg(feature = "with-json")]
                 Value::Json(j) => {

--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -94,12 +94,14 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                     args.add(uuid.map(|uuid| *uuid));
                 }
                 #[cfg(feature = "with-rust_decimal")]
-                Value::Decimal(_) => {
-                    panic!("Sqlite doesn't support decimal arguments");
+                Value::Decimal(decimal) => {
+                    use rust_decimal::prelude::ToPrimitive;
+                    args.add(decimal.map(|d| d.to_f64().unwrap()));
                 }
                 #[cfg(feature = "with-bigdecimal")]
-                Value::BigDecimal(_) => {
-                    panic!("Sqlite doesn't support bigdecimal arguments");
+                Value::BigDecimal(big_decimal) => {
+                    use bigdecimal::ToPrimitive;
+                    args.add(big_decimal.map(|d| d.to_f64().unwrap()));
                 }
                 #[cfg(feature = "with-json")]
                 Value::Json(j) => {


### PR DESCRIPTION
## PR Info

- Dependents:
  - https://github.com/SeaQL/sea-orm/pull/985

## Fixes

- [x] Bind `rust_decimal` & `bigdecimal` as f64, instead if panicking. The behavior used to be converting both as f64 before binding.

https://github.com/SeaQL/sea-query/blob/b7da280dcd42162740c3b494a8ca521ff356b252/sea-query-driver/src/sqlx_sqlite.rs#L47-L57