### PR TITLE
Fix consecutive spacing

### DIFF
--- a/src/backend/mysql/index.rs
+++ b/src/backend/mysql/index.rs
@@ -7,7 +7,7 @@ impl IndexBuilder for MysqlQueryBuilder {
         sql: &mut dyn SqlWriter,
     ) {
         self.prepare_index_prefix(create, sql);
-        write!(sql, " KEY ").unwrap();
+        write!(sql, "KEY ").unwrap();
 
         if let Some(name) = &create.index.name {
             write!(sql, "{}{}{} ", self.quote(), name, self.quote()).unwrap();
@@ -28,12 +28,7 @@ impl IndexBuilder for MysqlQueryBuilder {
     ) {
         write!(sql, "CREATE ").unwrap();
         self.prepare_index_prefix(create, sql);
-        if create.unique || create.primary || matches!(create.index_type, Some(IndexType::FullText))
-        {
-            write!(sql, " INDEX ").unwrap();
-        } else {
-            write!(sql, "INDEX ").unwrap();
-        }
+        write!(sql, "INDEX ").unwrap();
 
         if let Some(name) = &create.index.name {
             write!(sql, "{}{}{}", self.quote(), name, self.quote()).unwrap();
@@ -87,13 +82,13 @@ impl IndexBuilder for MysqlQueryBuilder {
 
     fn prepare_index_prefix(&self, create: &IndexCreateStatement, sql: &mut dyn SqlWriter) {
         if create.primary {
-            write!(sql, "PRIMARY").unwrap();
+            write!(sql, "PRIMARY ").unwrap();
         }
         if create.unique {
-            write!(sql, "UNIQUE").unwrap();
+            write!(sql, "UNIQUE ").unwrap();
         }
         if matches!(create.index_type, Some(IndexType::FullText)) {
-            write!(sql, "FULLTEXT").unwrap();
+            write!(sql, "FULLTEXT ").unwrap();
         }
     }
 }

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -208,7 +208,6 @@ fn create_8() {
     );
 }
 
-
 #[test]
 fn create_9() {
     assert_eq!(

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -208,6 +208,7 @@ fn create_8() {
     );
 }
 
+
 #[test]
 fn create_9() {
     assert_eq!(

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -215,12 +215,7 @@ fn create_9() {
             .table(Glyph::Table)
             .index(Index::create().name("idx-glyph-id").col(Glyph::Id))
             .to_string(MysqlQueryBuilder),
-        [
-            "CREATE TABLE `glyph` (",
-            "KEY `idx-glyph-id` (`id`)",
-            ")",
-        ]
-        .join(" ")
+        ["CREATE TABLE `glyph` (", "KEY `idx-glyph-id` (`id`)", ")",].join(" ")
     );
 }
 

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -215,7 +215,7 @@ fn create_9() {
             .table(Glyph::Table)
             .index(Index::create().name("idx-glyph-id").col(Glyph::Id))
             .to_string(MysqlQueryBuilder),
-        ["CREATE TABLE `glyph` (", "KEY `idx-glyph-id` (`id`)", ")",].join(" ")
+        "CREATE TABLE `glyph` ( KEY `idx-glyph-id` (`id`) )"
     );
 }
 

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -209,6 +209,22 @@ fn create_8() {
 }
 
 #[test]
+fn create_9() {
+    assert_eq!(
+        Table::create()
+            .table(Glyph::Table)
+            .index(Index::create().name("idx-glyph-id").col(Glyph::Id))
+            .to_string(MysqlQueryBuilder),
+        [
+            "CREATE TABLE `glyph` (",
+            "KEY `idx-glyph-id` (`id`)",
+            ")",
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Table::drop()


### PR DESCRIPTION
## PR Info

- Dependents:
  - https://github.com/SeaQL/sea-schema/pull/81

## Fixes

- [x] MySQL index writer: extra space is being appended to the SQL - https://github.com/SeaQL/sea-schema/actions/runs/3264622479/jobs/5365581089#step:5:294

This issue isn't visible because we used to skip consecutive spaces.

https://github.com/SeaQL/sea-query/blob/b7da280dcd42162740c3b494a8ca521ff356b252/src/prepare.rs#L82-L94