### PR TITLE
feat: added trgm operators

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -41,6 +41,12 @@ impl QueryBuilder for PostgresQueryBuilder {
             BinOper::Contains => write!(sql, "@>").unwrap(),
             BinOper::Contained => write!(sql, "<@").unwrap(),
             BinOper::Concatenate => write!(sql, "||").unwrap(),
+            BinOper::Similarity => write!(sql, "%").unwrap(),
+            BinOper::WordSimilarity => write!(sql, "<%").unwrap(),
+            BinOper::StrictWordSimilarity => write!(sql, "<<%").unwrap(),
+            BinOper::SimilarityDistance => write!(sql, "<->").unwrap(),
+            BinOper::WordSimilarityDistance => write!(sql, "<<->").unwrap(),
+            BinOper::StrictWordSimilarityDistance => write!(sql, "<<<->").unwrap(),
             _ => self.prepare_bin_oper_common(bin_oper, sql),
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -139,6 +139,18 @@ pub enum BinOper {
     Contained,
     #[cfg(feature = "backend-postgres")]
     Concatenate,
+    #[cfg(feature = "backend-postgres")]
+    Similarity,
+    #[cfg(feature = "backend-postgres")]
+    WordSimilarity,
+    #[cfg(feature = "backend-postgres")]
+    StrictWordSimilarity,
+    #[cfg(feature = "backend-postgres")]
+    SimilarityDistance,
+    #[cfg(feature = "backend-postgres")]
+    WordSimilarityDistance,
+    #[cfg(feature = "backend-postgres")]
+    StrictWordSimilarityDistance,
 }
 
 /// Logical chain operator

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1565,3 +1565,74 @@ fn delete_returning_specific_exprs() {
         r#"DELETE FROM "glyph" WHERE "id" = 1 RETURNING "id", "image""#
     );
 }
+
+#[test]
+fn select_pgtrgm_similarity() {
+    assert_eq!(
+        Query::select()
+            .expr(Expr::col(Font::Name).binary(BinOper::Similarity, Expr::value("serif")))
+            .from(Font::Table)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "name" % 'serif' FROM "font""#
+    );
+}
+
+#[test]
+fn select_pgtrgm_word_similarity() {
+    assert_eq!(
+        Query::select()
+            .expr(Expr::col(Font::Name).binary(BinOper::WordSimilarity, Expr::value("serif")))
+            .from(Font::Table)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "name" <% 'serif' FROM "font""#
+    );
+}
+
+#[test]
+fn select_pgtrgm_strict_word_similarity() {
+    assert_eq!(
+        Query::select()
+            .expr(Expr::col(Font::Name).binary(BinOper::StrictWordSimilarity, Expr::value("serif")))
+            .from(Font::Table)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "name" <<% 'serif' FROM "font""#
+    );
+}
+
+#[test]
+fn select_pgtrgm_similarity_distance() {
+    assert_eq!(
+        Query::select()
+            .expr(Expr::col(Font::Name).binary(BinOper::SimilarityDistance, Expr::value("serif")))
+            .from(Font::Table)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "name" <-> 'serif' FROM "font""#
+    );
+}
+
+#[test]
+fn select_pgtrgm_word_similarity_distance() {
+    assert_eq!(
+        Query::select()
+            .expr(
+                Expr::col(Font::Name).binary(BinOper::WordSimilarityDistance, Expr::value("serif"))
+            )
+            .from(Font::Table)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "name" <<-> 'serif' FROM "font""#
+    );
+}
+
+#[test]
+fn select_pgtrgm_strict_word_similarity_distance() {
+    assert_eq!(
+        Query::select()
+            .expr(
+                Expr::col(Font::Name)
+                    .binary(BinOper::StrictWordSimilarityDistance, Expr::value("serif"))
+            )
+            .from(Font::Table)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "name" <<<-> 'serif' FROM "font""#
+    );
+}


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

Adds [`pg_trgm`](https://github.com/SeaQL/sea-query/discussions/483) binary operators which are required to allow proper use of indexes for Postgres.

## Adds

- Binary operators from the Postgres `pg_trgm` extension