### PR TITLE
add support for SQLite strict tables

### DIFF
--- a/src/backend/table_builder.rs
+++ b/src/backend/table_builder.rs
@@ -101,6 +101,7 @@ pub trait TableBuilder: IndexBuilder + ForeignKeyBuilder + QuotedBuilder + Table
                 TableOpt::Engine(s) => format!("ENGINE={}", s),
                 TableOpt::Collate(s) => format!("COLLATE={}", s),
                 TableOpt::CharacterSet(s) => format!("DEFAULT CHARSET={}", s),
+                TableOpt::Strict => "STRICT".to_string(),
             }
         )
         .unwrap()

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -92,6 +92,7 @@ pub enum TableOpt {
     Engine(String),
     Collate(String),
     CharacterSet(String),
+    Strict,
 }
 
 /// All available table partition options
@@ -243,6 +244,12 @@ impl TableCreateStatement {
     /// Set database character set. MySQL only.
     pub fn character_set(&mut self, string: &str) -> &mut Self {
         self.opt(TableOpt::CharacterSet(string.into()));
+        self
+    }
+
+    /// Mark table as strict. SQLite only.
+    pub fn strict(&mut self) -> &mut Self {
+        self.opt(TableOpt::Strict);
         self
     }
 

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -317,6 +317,25 @@ fn create_with_unique_index_constraint() {
 }
 
 #[test]
+fn create_strict() {
+    assert_eq!(
+        Table::create()
+            .table(Task::Table)
+            .col(ColumnDef::new(Task::Id).integer())
+            .col(ColumnDef::new(Task::IsDone).boolean())
+            .strict()
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"CREATE TABLE "task" ("#,
+            r#""id" integer,"#,
+            r#""is_done" boolean"#,
+            r#") STRICT"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Table::drop()


### PR DESCRIPTION
this PR adds support for [sqlite strict tables](https://www.sqlite.org/stricttables.html)
it does so by adding a new variant to `TableOpt` variant

example:
`create table test(a, b)` (regular create statement)
`create table test(a int, b int) strict` (strict create statement)

## Questions

Is `TableOpt` the right place to put this functionality in?
Does `TableOpt` have to be public given that there are builder methods for each individual option?