### PR TITLE
support SQLite virtual tables (introduce TableModifier)

### DIFF
--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -317,6 +317,23 @@ fn create_with_unique_index_constraint() {
 }
 
 #[test]
+fn create_virtual_table() {
+    assert_eq!(
+        Table::create()
+            .table(Font::Table)
+            .if_not_exists()
+            .modifier(TableModifier::new().virtual_table("fts5").take())
+            .col(ColumnDef::new(Font::Name).text().not_null())
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"CREATE VIRTUAL TABLE IF NOT EXISTS "font" USING fts5 ("#,
+            r#""name" text NOT NULL"#,
+            r#")"#,
+        ].join(" ")
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Table::drop()


### PR DESCRIPTION
This PR introduces support for SQLite VIRTUAL tables

it does so by introducing a new entity for `CreateTableStatement` - `TableModifier`

The idea of `TableModifier` is that it modifies the very `CREATE TABLE` part of the statement (in this case it is `CREATE VIRTUAL TABLE`). 
At the moment `TableModifier` is a struct with just one field `virtual_table`. The idea is that it will contain as many fields as there are options to modify the table. Fpostgres for instance we can have several modifiers at once (e.g `CREATE GLOBAL TEMPORARY TABLE`).