### PR TITLE
Skip running CI on MD changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,10 +2,16 @@ name: tests
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - .gitignore
   push:
     branches:
       - master
       - pr/**/ci
+    paths-ignore:
+      - '**.md'
+      - .gitignore
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}


### PR DESCRIPTION
Skip running CI on MD changes.

Inspired by: https://github.com/SeaQL/sea-orm/pull/1184