### PR TITLE
add support for sqlite MATCH operator

### DIFF
--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -40,6 +40,13 @@ impl QueryBuilder for SqliteQueryBuilder {
         }
     }
 
+    fn prepare_bin_oper(&self, bin_oper: &BinOper, sql: &mut dyn SqlWriter) {
+        match bin_oper {
+            BinOper::Matches => write!(sql, "MATCH").unwrap(),
+            _ => self.prepare_bin_oper_common(bin_oper, sql),
+        }
+    }
+
     fn prepare_value(&self, value: &Value, sql: &mut dyn SqlWriter) {
         sql.push_param(value.clone(), self as _);
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2002,7 +2002,9 @@ impl Expr {
         )
     }
 
-    /// Express an postgres fulltext search matches (`@@`) expression.
+    /// Express postgres/sqlite fulltext search match expression:
+    /// - postgres: '@@'
+    /// - sqlite: 'MATCH'
     ///
     /// # Examples
     ///
@@ -2020,8 +2022,12 @@ impl Expr {
     ///     query.to_string(PostgresQueryBuilder),
     ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' @@ 'a b' AND "name" @@ 'a b'"#
     /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' MATCH 'a b' AND "name" MATCH 'a b'"#
+    /// );
     /// ```
-    #[cfg(feature = "backend-postgres")]
+    #[cfg(any(feature = "backend-postgres", feature = "backend-sqlite"))]
     pub fn matches<T>(self, expr: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -135,7 +135,7 @@ pub enum BinOper {
     RShift,
     As,
     Escape,
-    #[cfg(feature = "backend-postgres")]
+    #[cfg(any(feature = "backend-postgres", feature = "backend-sqlite"))]
     Matches,
     #[cfg(feature = "backend-postgres")]
     Contains,

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -978,6 +978,21 @@ fn select_58() {
 }
 
 #[test]
+fn select_59() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).matches("pattern"))
+            .build(SqliteQueryBuilder),
+        (
+            r#"SELECT "character" FROM "character" WHERE "character" MATCH ?"#.to_owned(),
+            Values(vec!["pattern".into()])
+        )
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(


### PR DESCRIPTION
this PR adds support for sqlite MATCH operator used primarily for full text search purposes
It does so by allowing `Expr::Matches` to be used not only for postgres but also for sqlite