### PR TITLE
Move postgres specific operator to new enum

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -37,18 +37,25 @@ impl QueryBuilder for PostgresQueryBuilder {
 
     fn prepare_bin_oper(&self, bin_oper: &BinOper, sql: &mut dyn SqlWriter) {
         match bin_oper {
-            BinOper::ILike => write!(sql, "ILIKE").unwrap(),
-            BinOper::NotLike => write!(sql, "NOT ILIKE").unwrap(),
-            BinOper::Matches => write!(sql, "@@").unwrap(),
-            BinOper::Contains => write!(sql, "@>").unwrap(),
-            BinOper::Contained => write!(sql, "<@").unwrap(),
-            BinOper::Concatenate => write!(sql, "||").unwrap(),
-            BinOper::Similarity => write!(sql, "%").unwrap(),
-            BinOper::WordSimilarity => write!(sql, "<%").unwrap(),
-            BinOper::StrictWordSimilarity => write!(sql, "<<%").unwrap(),
-            BinOper::SimilarityDistance => write!(sql, "<->").unwrap(),
-            BinOper::WordSimilarityDistance => write!(sql, "<<->").unwrap(),
-            BinOper::StrictWordSimilarityDistance => write!(sql, "<<<->").unwrap(),
+            BinOper::PgOperator(oper) => write!(
+                sql,
+                "{}",
+                match oper {
+                    PgBinOper::ILike => "ILIKE",
+                    PgBinOper::NotILike => "NOT ILIKE",
+                    PgBinOper::Matches => "@@",
+                    PgBinOper::Contains => "@>",
+                    PgBinOper::Contained => "<@",
+                    PgBinOper::Concatenate => "||",
+                    PgBinOper::Similarity => "%",
+                    PgBinOper::WordSimilarity => "<%",
+                    PgBinOper::StrictWordSimilarity => "<<%",
+                    PgBinOper::SimilarityDistance => "<->",
+                    PgBinOper::WordSimilarityDistance => "<<->",
+                    PgBinOper::StrictWordSimilarityDistance => "<<<->",
+                }
+            )
+            .unwrap(),
             _ => self.prepare_bin_oper_common(bin_oper, sql),
         }
     }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -522,8 +522,8 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             match bin_oper {
                 BinOper::And => "AND",
                 BinOper::Or => "OR",
-                BinOper::Like | BinOper::ILike => "LIKE",
-                BinOper::NotLike | BinOper::NotILike => "NOT LIKE",
+                BinOper::Like => "LIKE",
+                BinOper::NotLike => "NOT LIKE",
                 BinOper::Is => "IS",
                 BinOper::IsNot => "IS NOT",
                 BinOper::In => "IN",

--- a/src/extension/postgres/mod.rs
+++ b/src/extension/postgres/mod.rs
@@ -2,6 +2,30 @@ pub(crate) mod func;
 pub(crate) mod interval;
 pub(crate) mod types;
 
+use crate::BinOper;
 pub use func::*;
 pub use interval::*;
 pub use types::*;
+
+/// Binary operator
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PgBinOper {
+    ILike,
+    NotILike,
+    Matches,
+    Contains,
+    Contained,
+    Concatenate,
+    Similarity,
+    WordSimilarity,
+    StrictWordSimilarity,
+    SimilarityDistance,
+    WordSimilarityDistance,
+    StrictWordSimilarityDistance,
+}
+
+impl From<PgBinOper> for BinOper {
+    fn from(o: PgBinOper) -> Self {
+        Self::PgOperator(o)
+    }
+}

--- a/src/extension/postgres/mod.rs
+++ b/src/extension/postgres/mod.rs
@@ -1,11 +1,12 @@
-pub(crate) mod func;
-pub(crate) mod interval;
-pub(crate) mod types;
-
-use crate::BinOper;
 pub use func::*;
 pub use interval::*;
 pub use types::*;
+
+use crate::types::BinOper;
+
+pub(crate) mod func;
+pub(crate) mod interval;
+pub(crate) mod types;
 
 /// Binary operator
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -166,7 +166,7 @@ impl TypeCreateStatement {
     /// }
     ///
     /// impl Iden for FontFamily {
-    ///     fn unquoted(&self, s: &mut dyn std::fmt::Write) {
+    ///     fn unquoted(&self, s: &mut dyn Write) {
     ///         write!(
     ///             s,
     ///             "{}",
@@ -223,7 +223,7 @@ impl TypeDropStatement {
     /// struct FontFamily;
     ///
     /// impl Iden for FontFamily {
-    ///     fn unquoted(&self, s: &mut dyn std::fmt::Write) {
+    ///     fn unquoted(&self, s: &mut dyn Write) {
     ///         write!(s, "{}", "font_family").unwrap();
     ///     }
     /// }
@@ -293,7 +293,7 @@ impl TypeAlterStatement {
     /// }
     ///
     /// impl Iden for FontFamily {
-    ///     fn unquoted(&self, s: &mut dyn std::fmt::Write) {
+    ///     fn unquoted(&self, s: &mut dyn Write) {
     ///         write!(
     ///             s,
     ///             "{}",

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,8 @@
 use crate::{expr::*, query::*, FunctionCall, ValueTuple, Values};
 use std::fmt;
 
+#[cfg(feature = "backend-postgres")]
+use crate::extension::postgres::PgBinOper;
 #[cfg(not(feature = "thread-safe"))]
 pub use std::rc::Rc as SeaRc;
 #[cfg(feature = "thread-safe")]
@@ -112,8 +114,6 @@ pub enum BinOper {
     Or,
     Like,
     NotLike,
-    ILike,
-    NotILike,
     Is,
     IsNot,
     In,
@@ -136,25 +136,7 @@ pub enum BinOper {
     As,
     Escape,
     #[cfg(feature = "backend-postgres")]
-    Matches,
-    #[cfg(feature = "backend-postgres")]
-    Contains,
-    #[cfg(feature = "backend-postgres")]
-    Contained,
-    #[cfg(feature = "backend-postgres")]
-    Concatenate,
-    #[cfg(feature = "backend-postgres")]
-    Similarity,
-    #[cfg(feature = "backend-postgres")]
-    WordSimilarity,
-    #[cfg(feature = "backend-postgres")]
-    StrictWordSimilarity,
-    #[cfg(feature = "backend-postgres")]
-    SimilarityDistance,
-    #[cfg(feature = "backend-postgres")]
-    WordSimilarityDistance,
-    #[cfg(feature = "backend-postgres")]
-    StrictWordSimilarityDistance,
+    PgOperator(PgBinOper),
 }
 
 /// Logical chain operator

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1,5 +1,6 @@
 use super::*;
 use pretty_assertions::assert_eq;
+use sea_query::extension::postgres::PgBinOper;
 
 #[test]
 fn select_1() {
@@ -1570,7 +1571,7 @@ fn delete_returning_specific_exprs() {
 fn select_pgtrgm_similarity() {
     assert_eq!(
         Query::select()
-            .expr(Expr::col(Font::Name).binary(BinOper::Similarity, Expr::value("serif")))
+            .expr(Expr::col(Font::Name).binary(PgBinOper::Similarity, Expr::value("serif")))
             .from(Font::Table)
             .to_string(PostgresQueryBuilder),
         r#"SELECT "name" % 'serif' FROM "font""#
@@ -1581,7 +1582,7 @@ fn select_pgtrgm_similarity() {
 fn select_pgtrgm_word_similarity() {
     assert_eq!(
         Query::select()
-            .expr(Expr::col(Font::Name).binary(BinOper::WordSimilarity, Expr::value("serif")))
+            .expr(Expr::col(Font::Name).binary(PgBinOper::WordSimilarity, Expr::value("serif")))
             .from(Font::Table)
             .to_string(PostgresQueryBuilder),
         r#"SELECT "name" <% 'serif' FROM "font""#
@@ -1592,7 +1593,9 @@ fn select_pgtrgm_word_similarity() {
 fn select_pgtrgm_strict_word_similarity() {
     assert_eq!(
         Query::select()
-            .expr(Expr::col(Font::Name).binary(BinOper::StrictWordSimilarity, Expr::value("serif")))
+            .expr(
+                Expr::col(Font::Name).binary(PgBinOper::StrictWordSimilarity, Expr::value("serif"))
+            )
             .from(Font::Table)
             .to_string(PostgresQueryBuilder),
         r#"SELECT "name" <<% 'serif' FROM "font""#
@@ -1603,7 +1606,7 @@ fn select_pgtrgm_strict_word_similarity() {
 fn select_pgtrgm_similarity_distance() {
     assert_eq!(
         Query::select()
-            .expr(Expr::col(Font::Name).binary(BinOper::SimilarityDistance, Expr::value("serif")))
+            .expr(Expr::col(Font::Name).binary(PgBinOper::SimilarityDistance, Expr::value("serif")))
             .from(Font::Table)
             .to_string(PostgresQueryBuilder),
         r#"SELECT "name" <-> 'serif' FROM "font""#
@@ -1615,7 +1618,8 @@ fn select_pgtrgm_word_similarity_distance() {
     assert_eq!(
         Query::select()
             .expr(
-                Expr::col(Font::Name).binary(BinOper::WordSimilarityDistance, Expr::value("serif"))
+                Expr::col(Font::Name)
+                    .binary(PgBinOper::WordSimilarityDistance, Expr::value("serif"))
             )
             .from(Font::Table)
             .to_string(PostgresQueryBuilder),
@@ -1627,10 +1631,10 @@ fn select_pgtrgm_word_similarity_distance() {
 fn select_pgtrgm_strict_word_similarity_distance() {
     assert_eq!(
         Query::select()
-            .expr(
-                Expr::col(Font::Name)
-                    .binary(BinOper::StrictWordSimilarityDistance, Expr::value("serif"))
-            )
+            .expr(Expr::col(Font::Name).binary(
+                PgBinOper::StrictWordSimilarityDistance,
+                Expr::value("serif")
+            ))
             .from(Font::Table)
             .to_string(PostgresQueryBuilder),
         r#"SELECT "name" <<<-> 'serif' FROM "font""#


### PR DESCRIPTION
## PR Info

## Breaking Changes

- Move all postgres specific operator to own enum

Continue: https://github.com/SeaQL/sea-query/pull/506