### PR TITLE
Allow custom Postgres array types

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -651,7 +651,7 @@ mod with_mac_address {
 
 #[cfg(feature = "postgres-array")]
 #[cfg_attr(docsrs, doc(cfg(feature = "postgres-array")))]
-mod with_array {
+pub mod with_array {
     use super::*;
     use crate::SeaRc;
 


### PR DESCRIPTION
## PR Info

- Dependents:
  - <!-- PR link -->

## Changes

- [x] Make `value::with_array` module public and therefore making `NotU8` trait public as well
