### PR TITLE
add support for some sqlite specific binary operators

### DIFF
--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::extension::sqlite::SqliteBinOper;
 
 impl QueryBuilder for SqliteQueryBuilder {
     fn prepare_select_lock(&self, _select_lock: &LockClause, _sql: &mut dyn SqlWriter) {
@@ -17,6 +18,22 @@ impl QueryBuilder for SqliteQueryBuilder {
             }
         )
         .unwrap();
+    }
+
+    fn prepare_bin_oper(&self, bin_oper: &BinOper, sql: &mut dyn SqlWriter) {
+        match bin_oper {
+            BinOper::SqliteOperator(bin_oper) => write!(
+                sql,
+                "{}",
+                match bin_oper {
+                    SqliteBinOper::Match => "MATCH",
+                    SqliteBinOper::GetJsonField => "->",
+                    SqliteBinOper::CastJsonField => "->>",
+                }
+            )
+            .unwrap(),
+            _ => self.prepare_bin_oper_common(bin_oper, sql),
+        }
     }
 
     fn prepare_query_statement(&self, query: &SubQueryStatement, sql: &mut dyn SqlWriter) {

--- a/src/extension/mod.rs
+++ b/src/extension/mod.rs
@@ -3,3 +3,7 @@
 #[cfg(feature = "backend-postgres")]
 #[cfg_attr(docsrs, doc(cfg(feature = "backend-postgres")))]
 pub mod postgres;
+
+#[cfg(feature = "backend-sqlite")]
+#[cfg_attr(docsrs, doc(cfg(feature = "backend-sqlite")))]
+pub mod sqlite;

--- a/src/extension/sqlite/mod.rs
+++ b/src/extension/sqlite/mod.rs
@@ -1,0 +1,18 @@
+use crate::types::BinOper;
+
+/// Sqlite-specific binary operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqliteBinOper {
+    /// 'MATCH'.
+    Match,
+    /// '->'. Retreives JSON field as JSON value.
+    GetJsonField,
+    /// '->>'. Retreives JSON field and casts it to an appropriate SQL type.
+    CastJsonField,
+}
+
+impl From<SqliteBinOper> for BinOper {
+    fn from(o: SqliteBinOper) -> Self {
+        Self::SqliteOperator(o)
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,8 @@ use std::fmt;
 
 #[cfg(feature = "backend-postgres")]
 use crate::extension::postgres::PgBinOper;
+#[cfg(feature = "backend-sqlite")]
+use crate::extension::sqlite::SqliteBinOper;
 #[cfg(not(feature = "thread-safe"))]
 pub use std::rc::Rc as SeaRc;
 #[cfg(feature = "thread-safe")]
@@ -137,6 +139,8 @@ pub enum BinOper {
     Escape,
     #[cfg(feature = "backend-postgres")]
     PgOperator(PgBinOper),
+    #[cfg(feature = "backend-sqlite")]
+    SqliteOperator(SqliteBinOper),
 }
 
 /// Logical chain operator

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1,5 +1,6 @@
 use super::*;
 use pretty_assertions::assert_eq;
+use sea_query::extension::sqlite::SqliteBinOper;
 
 #[test]
 fn select_1() {
@@ -973,6 +974,55 @@ fn select_58() {
         (
             r#"SELECT "character" FROM "character" WHERE "character" LIKE ? ESCAPE '\'"#.to_owned(),
             Values(vec!["A".into()])
+        )
+    );
+}
+
+#[test]
+fn match_bin_oper() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).binary(SqliteBinOper::Match, Expr::val("test")))
+            .build(SqliteQueryBuilder),
+        (
+            r#"SELECT "character" FROM "character" WHERE "character" MATCH ?"#.to_owned(),
+            Values(vec!["test".into()])
+        )
+    );
+}
+
+#[test]
+fn get_json_field_bin_oper() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(
+                Expr::col(Char::Character).binary(SqliteBinOper::GetJsonField, Expr::val("test"))
+            )
+            .build(SqliteQueryBuilder),
+        (
+            r#"SELECT "character" FROM "character" WHERE "character" -> ?"#.to_owned(),
+            Values(vec!["test".into()])
+        )
+    );
+}
+
+#[test]
+fn cast_json_field_bin_oper() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(
+                Expr::col(Char::Character).binary(SqliteBinOper::CastJsonField, Expr::val("test"))
+            )
+            .build(SqliteQueryBuilder),
+        (
+            r#"SELECT "character" FROM "character" WHERE "character" ->> ?"#.to_owned(),
+            Values(vec!["test".into()])
         )
     );
 }


### PR DESCRIPTION
This PR adds support for sqlite specific operators (only some of them as for now).
The PR is very similar to [this one](https://github.com/SeaQL/sea-query/pull/507) which adds support to postgres specific operators

The operators added here are: MATCH, ->, ->>