### PR TITLE
regression: sqlite union invalid parentheses

### DIFF
--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -36,6 +36,21 @@ impl QueryBuilder for SqliteQueryBuilder {
         }
     }
 
+    fn prepare_union_statement(
+        &self,
+        union_type: UnionType,
+        select_statement: &SelectStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
+        match union_type {
+            UnionType::Intersect => write!(sql, " INTERSECT ").unwrap(),
+            UnionType::Distinct => write!(sql, " UNION ").unwrap(),
+            UnionType::Except => write!(sql, " EXCEPT ").unwrap(),
+            UnionType::All => write!(sql, " UNION ALL ").unwrap(),
+        }
+        self.prepare_select_statement(select_statement, sql);
+    }
+
     fn prepare_query_statement(&self, query: &SubQueryStatement, sql: &mut dyn SqlWriter) {
         query.prepare_statement(self, sql);
     }

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -2143,7 +2143,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 UNION ALL (SELECT "character" FROM "character" WHERE "font_id" = 4)"#
+    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 UNION ALL SELECT "character" FROM "character" WHERE "font_id" = 4"#
     /// );
     /// ```
     pub fn union(&mut self, union_type: UnionType, query: SelectStatement) -> &mut Self {
@@ -2186,7 +2186,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 UNION ALL (SELECT "character" FROM "character" WHERE "font_id" = 4) UNION (SELECT "character" FROM "character" WHERE "font_id" = 3)"#
+    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5 UNION ALL SELECT "character" FROM "character" WHERE "font_id" = 4 UNION SELECT "character" FROM "character" WHERE "font_id" = 3"#
     /// );
     /// ```
     pub fn unions<T: IntoIterator<Item = (UnionType, SelectStatement)>>(
@@ -2256,7 +2256,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"WITH RECURSIVE "cte_traversal" ("id", "depth", "next", "value") AS (SELECT "id", 1, "next", "value" FROM "table" UNION ALL (SELECT "id", "depth" + 1, "next", "value" FROM "table" INNER JOIN "cte_traversal" ON "cte_traversal"."next" = "table"."id")) SELECT * FROM "cte_traversal""#
+    ///     r#"WITH RECURSIVE "cte_traversal" ("id", "depth", "next", "value") AS (SELECT "id", 1, "next", "value" FROM "table" UNION ALL SELECT "id", "depth" + 1, "next", "value" FROM "table" INNER JOIN "cte_traversal" ON "cte_traversal"."next" = "table"."id") SELECT * FROM "cte_traversal""#
     /// );
     /// ```
     pub fn with(self, clause: WithClause) -> WithQuery {

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -434,7 +434,7 @@ impl Cycle {
 /// );
 /// assert_eq!(
 ///     query.to_string(SqliteQueryBuilder),
-///     r#"WITH RECURSIVE "cte_traversal" ("id", "depth", "next", "value") AS (SELECT "id", 1, "next", "value" FROM "table" UNION ALL (SELECT "id", "depth" + 1, "next", "value" FROM "table" INNER JOIN "cte_traversal" ON "cte_traversal"."next" = "table"."id")) SELECT * FROM "cte_traversal""#
+///     r#"WITH RECURSIVE "cte_traversal" ("id", "depth", "next", "value") AS (SELECT "id", 1, "next", "value" FROM "table" UNION ALL SELECT "id", "depth" + 1, "next", "value" FROM "table" INNER JOIN "cte_traversal" ON "cte_traversal"."next" = "table"."id") SELECT * FROM "cte_traversal""#
 /// );
 /// ```
 #[derive(Debug, Clone, Default)]

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1521,8 +1521,8 @@ fn union_1() {
             )
             .to_string(SqliteQueryBuilder),
         [
-            r#"SELECT "character" FROM "character" UNION (SELECT "character" FROM "character""#,
-            r#"LEFT JOIN "font" ON "character"."font_id" = "font"."id" ORDER BY "font"."id" ASC)"#
+            r#"SELECT "character" FROM "character" UNION SELECT "character" FROM "character""#,
+            r#"LEFT JOIN "font" ON "character"."font_id" = "font"."id" ORDER BY "font"."id" ASC"#
         ]
         .join(" ")
     );


### PR DESCRIPTION
this PR fixes regression reported [here](https://github.com/SeaQL/sea-query/issues/514)

it introduces new method `QueryBuilder::prepare_union_statement` which has parentheses-wrapping default implementeation and parentheses-omitting implementation for sqlite