### PR TITLE
Remove panic from SimpleExpr and impl PgExpr and SqliteExpr traits

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -261,18 +261,12 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 self.prepare_tuple(&func.args, sql);
             }
             SimpleExpr::Binary(left, op, right) => match (op, right.as_ref()) {
-                (BinOper::In, SimpleExpr::Tuple(t)) if t.is_empty() => self.binary_expr(
-                    &SimpleExpr::Value(1i32.into()),
-                    &BinOper::Equal,
-                    &SimpleExpr::Value(2i32.into()),
-                    sql,
-                ),
-                (BinOper::NotIn, SimpleExpr::Tuple(t)) if t.is_empty() => self.binary_expr(
-                    &SimpleExpr::Value(1i32.into()),
-                    &BinOper::Equal,
-                    &SimpleExpr::Value(1i32.into()),
-                    sql,
-                ),
+                (BinOper::In, SimpleExpr::Tuple(t)) if t.is_empty() => {
+                    self.binary_expr(&1i32.into(), &BinOper::Equal, &2i32.into(), sql)
+                }
+                (BinOper::NotIn, SimpleExpr::Tuple(t)) if t.is_empty() => {
+                    self.binary_expr(&1i32.into(), &BinOper::Equal, &1i32.into(), sql)
+                }
                 _ => self.binary_expr(left, op, right, sql),
             },
             SimpleExpr::SubQuery(oper, sel) => {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -791,7 +791,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).add(1).equals(Expr::value(2)))
+    ///     .and_where(Expr::val(1).add(1).equals(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -825,7 +825,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).sub(1).equals(Expr::value(2)))
+    ///     .and_where(Expr::val(1).sub(1).equals(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -859,7 +859,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).mul(1).equals(Expr::value(2)))
+    ///     .and_where(Expr::val(1).mul(1).equals(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -893,7 +893,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).div(1).equals(Expr::value(2)))
+    ///     .and_where(Expr::val(1).div(1).equals(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -927,7 +927,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).modulo(1).equals(Expr::value(2)))
+    ///     .and_where(Expr::val(1).modulo(1).equals(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -961,7 +961,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).left_shift(1).equals(Expr::value(2)))
+    ///     .and_where(Expr::val(1).left_shift(1).equals(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -995,7 +995,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).right_shift(1).equals(Expr::value(2)))
+    ///     .and_where(Expr::val(1).right_shift(1).equals(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1310,7 +1310,7 @@ impl Expr {
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
     ///     .cond_where(all![
-    ///         Expr::col(Char::SizeW).binary(BinOper::SmallerThan, Expr::value(10)),
+    ///         Expr::col(Char::SizeW).binary(BinOper::SmallerThan, 10),
     ///         Expr::col(Char::SizeW).binary(BinOper::GreaterThan, Expr::col(Char::SizeH))
     ///     ])
     ///     .to_owned();
@@ -1940,9 +1940,9 @@ impl Expr {
     ///     .expr_as(
     ///         Expr::case(
     ///                 Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([2, 4]),
-    ///                 Expr::val(true)
+    ///                 true
     ///              )
-    ///             .finally(Expr::val(false)),
+    ///             .finally(false),
     ///          Alias::new("is_even")
     ///     )
     ///     .from(Glyph::Table)

--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -1,32 +1,8 @@
-use crate::{Expr, IntoLikeExpr, SimpleExpr};
+use crate::{Expr, Expression, IntoLikeExpr, SimpleExpr};
 
 use super::PgBinOper;
 
-pub trait PgExpr {
-    fn concatenate<T>(self, right: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>;
-    fn concat<T>(self, right: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>;
-    fn ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr
-    where
-        L: IntoLikeExpr;
-    fn not_ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr
-    where
-        L: IntoLikeExpr;
-    fn matches<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>;
-    fn contains<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>;
-    fn contained<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>;
-}
-
-impl PgExpr for Expr {
+pub trait PgExpr: Expression {
     /// Express an postgres concatenate (`||`) expression.
     ///
     /// # Examples
@@ -54,42 +30,14 @@ impl PgExpr for Expr {
     where
         T: Into<SimpleExpr>,
     {
-        self.binary(PgBinOper::Concatenate, right)
+        self.bin_op(PgBinOper::Concatenate, right)
     }
-
     /// Alias of [`PgExpr::concatenate`]
     fn concat<T>(self, right: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,
     {
         self.concatenate(right)
-    }
-
-    /// Express a `LIKE` expression.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .and_where(Expr::tbl(Char::Table, Char::Character).ilike("Ours'%"))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" ILIKE E'Ours\'%'"#
-    /// );
-    /// ```
-    fn ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
-        self.like_like(PgBinOper::ILike, like.into_like_expr())
-    }
-
-    /// Express a `NOT ILIKE` expression
-    fn not_ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
-        self.like_like(PgBinOper::NotILike, like.into_like_expr())
     }
 
     /// Express an postgres fulltext search matches (`@@`) expression.
@@ -115,7 +63,7 @@ impl PgExpr for Expr {
     where
         T: Into<SimpleExpr>,
     {
-        self.binary(PgBinOper::Matches, expr)
+        self.bin_op(PgBinOper::Matches, expr)
     }
 
     /// Express an postgres fulltext search contains (`@>`) expression.
@@ -141,7 +89,7 @@ impl PgExpr for Expr {
     where
         T: Into<SimpleExpr>,
     {
-        self.binary(PgBinOper::Contains, expr)
+        self.bin_op(PgBinOper::Contains, expr)
     }
 
     /// Express an postgres fulltext search contained (`<@`) expression.
@@ -167,55 +115,28 @@ impl PgExpr for Expr {
     where
         T: Into<SimpleExpr>,
     {
-        self.binary(PgBinOper::Contained, expr)
+        self.bin_op(PgBinOper::Contained, expr)
     }
 }
 
-impl PgExpr for SimpleExpr {
-    /// Express an postgres concatenate (`||`) expression.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Font::Name, Font::Variant, Font::Language])
-    ///     .from(Font::Table)
-    ///     .and_where(
-    ///         Expr::val("a")
-    ///             .concatenate(Expr::val("b"))
-    ///             .concat(Expr::val("c"))
-    ///             .concat(Expr::val("d")),
-    ///     )
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a' || 'b' || 'c' || 'd'"#
-    /// );
-    /// ```
-    fn concatenate<T>(self, right: T) -> SimpleExpr
+pub trait PgExprILike: Expression {
+    fn ilike<L>(self, like: L) -> SimpleExpr
     where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(PgBinOper::Concatenate, right)
-    }
-
-    /// Alias of [`PgExpr::concatenate`]
-    fn concat<T>(self, right: T) -> SimpleExpr
+        L: IntoLikeExpr;
+    fn not_ilike<L>(self, like: L) -> SimpleExpr
     where
-        T: Into<SimpleExpr>,
-    {
-        self.concatenate(right)
-    }
+        L: IntoLikeExpr;
+}
 
+impl PgExpr for Expr {}
+
+impl PgExprILike for Expr {
     /// Express a `LIKE` expression.
     ///
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExprILike};
     ///
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
@@ -228,90 +149,20 @@ impl PgExpr for SimpleExpr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" ILIKE E'Ours\'%'"#
     /// );
     /// ```
-    fn ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
+    fn ilike<L>(self, like: L) -> SimpleExpr
+    where
+        L: IntoLikeExpr,
+    {
         self.like_like(PgBinOper::ILike, like.into_like_expr())
     }
 
     /// Express a `NOT ILIKE` expression
-    fn not_ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
+    fn not_ilike<L>(self, like: L) -> SimpleExpr
+    where
+        L: IntoLikeExpr,
+    {
         self.like_like(PgBinOper::NotILike, like.into_like_expr())
     }
-
-    /// Express an postgres fulltext search matches (`@@`) expression.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Font::Name, Font::Variant, Font::Language])
-    ///     .from(Font::Table)
-    ///     .and_where(Expr::val("a & b").matches(Expr::val("a b")))
-    ///     .and_where(Expr::col(Font::Name).matches(Expr::val("a b")))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' @@ 'a b' AND "name" @@ 'a b'"#
-    /// );
-    /// ```
-    fn matches<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(PgBinOper::Matches, expr)
-    }
-
-    /// Express an postgres fulltext search contains (`@>`) expression.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Font::Name, Font::Variant, Font::Language])
-    ///     .from(Font::Table)
-    ///     .and_where(Expr::val("a & b").contains(Expr::val("a b")))
-    ///     .and_where(Expr::col(Font::Name).contains(Expr::val("a b")))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' @> 'a b' AND "name" @> 'a b'"#
-    /// );
-    /// ```
-    fn contains<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(PgBinOper::Contains, expr)
-    }
-
-    /// Express an postgres fulltext search contained (`<@`) expression.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Font::Name, Font::Variant, Font::Language])
-    ///     .from(Font::Table)
-    ///     .and_where(Expr::val("a & b").contained(Expr::val("a b")))
-    ///     .and_where(Expr::col(Font::Name).contained(Expr::val("a b")))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' <@ 'a b' AND "name" <@ 'a b'"#
-    /// );
-    /// ```
-    fn contained<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(PgBinOper::Contained, expr)
-    }
 }
+
+impl PgExpr for SimpleExpr {}

--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -15,9 +15,9 @@ pub trait PgExpr: Expression {
     ///     .from(Font::Table)
     ///     .and_where(
     ///         Expr::val("a")
-    ///             .concatenate(Expr::val("b"))
-    ///             .concat(Expr::val("c"))
-    ///             .concat(Expr::val("d")),
+    ///             .concatenate("b")
+    ///             .concat("c")
+    ///             .concat("d"),
     ///     )
     ///     .to_owned();
     ///
@@ -50,8 +50,8 @@ pub trait PgExpr: Expression {
     /// let query = Query::select()
     ///     .columns([Font::Name, Font::Variant, Font::Language])
     ///     .from(Font::Table)
-    ///     .and_where(Expr::val("a & b").matches(Expr::val("a b")))
-    ///     .and_where(Expr::col(Font::Name).matches(Expr::val("a b")))
+    ///     .and_where(Expr::val("a & b").matches("a b"))
+    ///     .and_where(Expr::col(Font::Name).matches("a b"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -76,8 +76,8 @@ pub trait PgExpr: Expression {
     /// let query = Query::select()
     ///     .columns([Font::Name, Font::Variant, Font::Language])
     ///     .from(Font::Table)
-    ///     .and_where(Expr::val("a & b").contains(Expr::val("a b")))
-    ///     .and_where(Expr::col(Font::Name).contains(Expr::val("a b")))
+    ///     .and_where(Expr::val("a & b").contains("a b"))
+    ///     .and_where(Expr::col(Font::Name).contains("a b"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -102,8 +102,8 @@ pub trait PgExpr: Expression {
     /// let query = Query::select()
     ///     .columns([Font::Name, Font::Variant, Font::Language])
     ///     .from(Font::Table)
-    ///     .and_where(Expr::val("a & b").contained(Expr::val("a b")))
-    ///     .and_where(Expr::col(Font::Name).contained(Expr::val("a b")))
+    ///     .and_where(Expr::val("a & b").contained("a b"))
+    ///     .and_where(Expr::col(Font::Name).contained("a b"))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -1,6 +1,5 @@
-use crate::{Expr, Expression, IntoLikeExpr, SimpleExpr};
-
 use super::PgBinOper;
+use crate::{expr::private::Expression, Expr, IntoLikeExpr, SimpleExpr};
 
 pub trait PgExpr: Expression {
     /// Express an postgres concatenate (`||`) expression.
@@ -117,26 +116,13 @@ pub trait PgExpr: Expression {
     {
         self.bin_op(PgBinOper::Contained, expr)
     }
-}
 
-pub trait PgExprILike: Expression {
-    fn ilike<L>(self, like: L) -> SimpleExpr
-    where
-        L: IntoLikeExpr;
-    fn not_ilike<L>(self, like: L) -> SimpleExpr
-    where
-        L: IntoLikeExpr;
-}
-
-impl PgExpr for Expr {}
-
-impl PgExprILike for Expr {
     /// Express a `LIKE` expression.
     ///
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExprILike};
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
     ///
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
@@ -164,5 +150,7 @@ impl PgExprILike for Expr {
         self.like_like(PgBinOper::NotILike, like.into_like_expr())
     }
 }
+
+impl PgExpr for Expr {}
 
 impl PgExpr for SimpleExpr {}

--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -1,0 +1,317 @@
+use crate::{Expr, IntoLikeExpr, SimpleExpr};
+
+use super::PgBinOper;
+
+pub trait PgExpr {
+    fn concatenate<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>;
+    fn concat<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>;
+    fn ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr
+    where
+        L: IntoLikeExpr;
+    fn not_ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr
+    where
+        L: IntoLikeExpr;
+    fn matches<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>;
+    fn contains<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>;
+    fn contained<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>;
+}
+
+impl PgExpr for Expr {
+    /// Express an postgres concatenate (`||`) expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Font::Name, Font::Variant, Font::Language])
+    ///     .from(Font::Table)
+    ///     .and_where(
+    ///         Expr::val("a")
+    ///             .concatenate(Expr::val("b"))
+    ///             .concat(Expr::val("c"))
+    ///             .concat(Expr::val("d")),
+    ///     )
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a' || 'b' || 'c' || 'd'"#
+    /// );
+    /// ```
+    fn concatenate<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(PgBinOper::Concatenate, right)
+    }
+
+    /// Alias of [`PgExpr::concatenate`]
+    fn concat<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.concatenate(right)
+    }
+
+    /// Express a `LIKE` expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::tbl(Char::Table, Char::Character).ilike("Ours'%"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" ILIKE E'Ours\'%'"#
+    /// );
+    /// ```
+    fn ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
+        self.like_like(PgBinOper::ILike, like.into_like_expr())
+    }
+
+    /// Express a `NOT ILIKE` expression
+    fn not_ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
+        self.like_like(PgBinOper::NotILike, like.into_like_expr())
+    }
+
+    /// Express an postgres fulltext search matches (`@@`) expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Font::Name, Font::Variant, Font::Language])
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::val("a & b").matches(Expr::val("a b")))
+    ///     .and_where(Expr::col(Font::Name).matches(Expr::val("a b")))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' @@ 'a b' AND "name" @@ 'a b'"#
+    /// );
+    /// ```
+    fn matches<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(PgBinOper::Matches, expr)
+    }
+
+    /// Express an postgres fulltext search contains (`@>`) expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Font::Name, Font::Variant, Font::Language])
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::val("a & b").contains(Expr::val("a b")))
+    ///     .and_where(Expr::col(Font::Name).contains(Expr::val("a b")))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' @> 'a b' AND "name" @> 'a b'"#
+    /// );
+    /// ```
+    fn contains<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(PgBinOper::Contains, expr)
+    }
+
+    /// Express an postgres fulltext search contained (`<@`) expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Font::Name, Font::Variant, Font::Language])
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::val("a & b").contained(Expr::val("a b")))
+    ///     .and_where(Expr::col(Font::Name).contained(Expr::val("a b")))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' <@ 'a b' AND "name" <@ 'a b'"#
+    /// );
+    /// ```
+    fn contained<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(PgBinOper::Contained, expr)
+    }
+}
+
+impl PgExpr for SimpleExpr {
+    /// Express an postgres concatenate (`||`) expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Font::Name, Font::Variant, Font::Language])
+    ///     .from(Font::Table)
+    ///     .and_where(
+    ///         Expr::val("a")
+    ///             .concatenate(Expr::val("b"))
+    ///             .concat(Expr::val("c"))
+    ///             .concat(Expr::val("d")),
+    ///     )
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a' || 'b' || 'c' || 'd'"#
+    /// );
+    /// ```
+    fn concatenate<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(PgBinOper::Concatenate, right)
+    }
+
+    /// Alias of [`PgExpr::concatenate`]
+    fn concat<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.concatenate(right)
+    }
+
+    /// Express a `LIKE` expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::tbl(Char::Table, Char::Character).ilike("Ours'%"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" ILIKE E'Ours\'%'"#
+    /// );
+    /// ```
+    fn ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
+        self.like_like(PgBinOper::ILike, like.into_like_expr())
+    }
+
+    /// Express a `NOT ILIKE` expression
+    fn not_ilike<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
+        self.like_like(PgBinOper::NotILike, like.into_like_expr())
+    }
+
+    /// Express an postgres fulltext search matches (`@@`) expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Font::Name, Font::Variant, Font::Language])
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::val("a & b").matches(Expr::val("a b")))
+    ///     .and_where(Expr::col(Font::Name).matches(Expr::val("a b")))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' @@ 'a b' AND "name" @@ 'a b'"#
+    /// );
+    /// ```
+    fn matches<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(PgBinOper::Matches, expr)
+    }
+
+    /// Express an postgres fulltext search contains (`@>`) expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Font::Name, Font::Variant, Font::Language])
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::val("a & b").contains(Expr::val("a b")))
+    ///     .and_where(Expr::col(Font::Name).contains(Expr::val("a b")))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' @> 'a b' AND "name" @> 'a b'"#
+    /// );
+    /// ```
+    fn contains<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(PgBinOper::Contains, expr)
+    }
+
+    /// Express an postgres fulltext search contained (`<@`) expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Font::Name, Font::Variant, Font::Language])
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::val("a & b").contained(Expr::val("a b")))
+    ///     .and_where(Expr::col(Font::Name).contained(Expr::val("a b")))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "name", "variant", "language" FROM "font" WHERE 'a & b' <@ 'a b' AND "name" <@ 'a b'"#
+    /// );
+    /// ```
+    fn contained<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(PgBinOper::Contained, expr)
+    }
+}

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -36,7 +36,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::to_tsquery(Expr::val("a & b"), None))
+    ///     .expr(PgFunc::to_tsquery("a & b", None))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -69,7 +69,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::to_tsvector(Expr::val("a b"), None))
+    ///     .expr(PgFunc::to_tsvector("a b", None))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -102,7 +102,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::phraseto_tsquery(Expr::val("a b"), None))
+    ///     .expr(PgFunc::phraseto_tsquery("a b", None))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -135,7 +135,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::plainto_tsquery(Expr::val("a b"), None))
+    ///     .expr(PgFunc::plainto_tsquery("a b", None))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -168,7 +168,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::websearch_to_tsquery(Expr::val("a b"), None))
+    ///     .expr(PgFunc::websearch_to_tsquery("a b", None))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -200,7 +200,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::ts_rank(Expr::val("a b"), Expr::val("a&b")))
+    ///     .expr(PgFunc::ts_rank("a b", "a&b"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -224,7 +224,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::ts_rank_cd(Expr::val("a b"), Expr::val("a&b")))
+    ///     .expr(PgFunc::ts_rank_cd("a b", "a&b"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -248,7 +248,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::any(Expr::val(vec![0, 1])))
+    ///     .expr(PgFunc::any(vec![0, 1]))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -272,7 +272,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::some(Expr::val(vec![0, 1])))
+    ///     .expr(PgFunc::some(vec![0, 1]))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -296,7 +296,7 @@ impl PgFunc {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(PgFunc::all(Expr::val(vec![0, 1])))
+    ///     .expr(PgFunc::all(vec![0, 1]))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/extension/postgres/mod.rs
+++ b/src/extension/postgres/mod.rs
@@ -1,9 +1,11 @@
+pub use expr::*;
 pub use func::*;
 pub use interval::*;
 pub use types::*;
 
 use crate::types::BinOper;
 
+pub(crate) mod expr;
 pub(crate) mod func;
 pub(crate) mod interval;
 pub(crate) mod types;

--- a/src/extension/sqlite/expr.rs
+++ b/src/extension/sqlite/expr.rs
@@ -1,0 +1,63 @@
+use crate::{Expr, SimpleExpr};
+
+use super::SqliteBinOper;
+
+pub trait SqliteExpr {
+    fn matches<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>;
+
+    fn get_json_field<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>;
+
+    fn cast_json_field<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>;
+}
+
+impl SqliteExpr for Expr {
+    fn matches<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(SqliteBinOper::Match, right)
+    }
+
+    fn get_json_field<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(SqliteBinOper::GetJsonField, right)
+    }
+
+    fn cast_json_field<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(SqliteBinOper::CastJsonField, right)
+    }
+}
+
+impl SqliteExpr for SimpleExpr {
+    fn matches<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(SqliteBinOper::Match, right)
+    }
+
+    fn get_json_field<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(SqliteBinOper::GetJsonField, right)
+    }
+
+    fn cast_json_field<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(SqliteBinOper::CastJsonField, right)
+    }
+}

--- a/src/extension/sqlite/expr.rs
+++ b/src/extension/sqlite/expr.rs
@@ -4,6 +4,23 @@ use super::SqliteBinOper;
 
 pub trait SqliteExpr: Expression {
     /// Express an sqlite `MATCH` operator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::sqlite::SqliteExpr};
+    ///
+    /// let query = Query::select()
+    ///     .column(Font::Name)
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::col(Font::Name).matches("a"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "name" FROM "font" WHERE "name" MATCH 'a'"#
+    /// );
+    /// ```
     fn matches<T>(self, right: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,
@@ -12,6 +29,23 @@ pub trait SqliteExpr: Expression {
     }
 
     /// Express an sqlite retrieves JSON field as JSON value (`->`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::sqlite::SqliteExpr};
+    ///
+    /// let query = Query::select()
+    ///     .column(Font::Variant)
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::col(Font::Variant).get_json_field("a"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "variant" FROM "font" WHERE "variant" -> 'a'"#
+    /// );
+    /// ```
     fn get_json_field<T>(self, right: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,
@@ -20,6 +54,23 @@ pub trait SqliteExpr: Expression {
     }
 
     /// Express an sqlite retrieves JSON field and casts it to an appropriate SQL type (`->>`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*, extension::sqlite::SqliteExpr};
+    ///
+    /// let query = Query::select()
+    ///     .column(Font::Variant)
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::col(Font::Variant).cast_json_field("a"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "variant" FROM "font" WHERE "variant" ->> 'a'"#
+    /// );
+    /// ```
     fn cast_json_field<T>(self, right: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,

--- a/src/extension/sqlite/expr.rs
+++ b/src/extension/sqlite/expr.rs
@@ -1,63 +1,33 @@
-use crate::{Expr, SimpleExpr};
+use crate::{Expr, Expression, SimpleExpr};
 
 use super::SqliteBinOper;
 
-pub trait SqliteExpr {
-    fn matches<T>(self, right: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>;
-
-    fn get_json_field<T>(self, right: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>;
-
-    fn cast_json_field<T>(self, right: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>;
-}
-
-impl SqliteExpr for Expr {
+pub trait SqliteExpr: Expression {
+    /// Express an sqlite `MATCH` operator.
     fn matches<T>(self, right: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,
     {
-        self.binary(SqliteBinOper::Match, right)
+        self.bin_op(SqliteBinOper::Match, right)
     }
 
+    /// Express an sqlite retrieves JSON field as JSON value (`->`).
     fn get_json_field<T>(self, right: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,
     {
-        self.binary(SqliteBinOper::GetJsonField, right)
+        self.bin_op(SqliteBinOper::GetJsonField, right)
     }
 
+    /// Express an sqlite retrieves JSON field and casts it to an appropriate SQL type (`->>`).
     fn cast_json_field<T>(self, right: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,
     {
-        self.binary(SqliteBinOper::CastJsonField, right)
+        self.bin_op(SqliteBinOper::CastJsonField, right)
     }
 }
 
-impl SqliteExpr for SimpleExpr {
-    fn matches<T>(self, right: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(SqliteBinOper::Match, right)
-    }
+impl SqliteExpr for Expr {}
 
-    fn get_json_field<T>(self, right: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(SqliteBinOper::GetJsonField, right)
-    }
-
-    fn cast_json_field<T>(self, right: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(SqliteBinOper::CastJsonField, right)
-    }
-}
+impl SqliteExpr for SimpleExpr {}

--- a/src/extension/sqlite/expr.rs
+++ b/src/extension/sqlite/expr.rs
@@ -1,4 +1,4 @@
-use crate::{Expr, Expression, SimpleExpr};
+use crate::{expr::private::Expression, Expr, SimpleExpr};
 
 use super::SqliteBinOper;
 

--- a/src/extension/sqlite/mod.rs
+++ b/src/extension/sqlite/mod.rs
@@ -1,4 +1,8 @@
+pub use expr::SqliteExpr;
+
 use crate::types::BinOper;
+
+mod expr;
 
 /// Sqlite-specific binary operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/extension/sqlite/mod.rs
+++ b/src/extension/sqlite/mod.rs
@@ -7,11 +7,11 @@ mod expr;
 /// Sqlite-specific binary operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SqliteBinOper {
-    /// 'MATCH'.
+    /// `MATCH`.
     Match,
-    /// '->'. Retreives JSON field as JSON value.
+    /// `->`. Retrieves JSON field as JSON value.
     GetJsonField,
-    /// '->>'. Retreives JSON field and casts it to an appropriate SQL type.
+    /// `->>`. Retrieves JSON field and casts it to an appropriate SQL type.
     CastJsonField,
 }
 

--- a/src/func.rs
+++ b/src/func.rs
@@ -79,7 +79,7 @@ impl Func {
     /// }
     ///
     /// let query = Query::select()
-    ///     .expr(Func::cust(MyFunction).arg(Expr::val("hello")))
+    ///     .expr(Func::cust(MyFunction).arg("hello"))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -23,8 +23,8 @@ impl CaseStatement {
     /// let query = Query::select()
     ///     .expr_as(
     ///         CaseStatement::new()
-    ///             .case(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([2, 4]), Expr::val(true))
-    ///             .finally(Expr::val(false)),
+    ///             .case(Expr::tbl(Glyph::Table, Glyph::Aspect).is_in([2, 4]), true)
+    ///             .finally(false),
     ///          Alias::new("is_even")
     ///     )
     ///     .from(Glyph::Table)
@@ -50,13 +50,13 @@ impl CaseStatement {
     ///     .expr_as(
     ///             Expr::case(
     ///                 Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
-    ///                 Expr::val("positive")
+    ///                 "positive"
     ///              )
     ///             .case(
     ///                 Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
-    ///                 Expr::val("negative")
+    ///                 "negative"
     ///              )
-    ///             .finally(Expr::val("zero")),
+    ///             .finally("zero"),
     ///          Alias::new("polarity")
     ///     )
     ///     .from(Glyph::Table)
@@ -92,15 +92,15 @@ impl CaseStatement {
     ///             Cond::any()
     ///                 .add(Expr::tbl(Character::Table, Character::FontSize).gt(48))
     ///                 .add(Expr::tbl(Character::Table, Character::SizeW).gt(500)),
-    ///             Expr::val("large")
+    ///             "large"
     ///         )
     ///         .case(
     ///             Cond::any()
     ///                 .add(Expr::tbl(Character::Table, Character::FontSize).between(24,48).into_condition())
     ///                 .add(Expr::tbl(Character::Table, Character::SizeW).between(300,500).into_condition()),
-    ///             Expr::val("medium")
+    ///             "medium"
     ///         )
-    ///         .finally(Expr::val("small")),
+    ///         .finally("small"),
     ///         Alias::new("char_size"))
     ///     .from(Character::Table)
     ///     .to_owned();

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -246,7 +246,7 @@ impl SelectStatement {
     ///     .from(Char::Table)
     ///     .expr(Expr::val(42))
     ///     .expr(Expr::col(Char::Id).max())
-    ///     .expr((1..10_i32).fold(Expr::value(0), |expr, i| expr.add(Expr::value(i))))
+    ///     .expr((1..10_i32).fold(Expr::value(0), |expr, i| expr.add(i)))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -281,7 +281,7 @@ impl SelectStatement {
     ///     .from(Char::Table)
     ///     .exprs([
     ///         Expr::col(Char::Id).max(),
-    ///         (1..10_i32).fold(Expr::value(0), |expr, i| expr.add(Expr::value(i))),
+    ///         (1..10_i32).fold(Expr::value(0), |expr, i| expr.add(i)),
     ///     ])
     ///     .to_owned();
     ///
@@ -2152,7 +2152,7 @@ impl SelectStatement {
     ///
     /// let base_query = SelectStatement::new()
     ///                     .column(Alias::new("id"))
-    ///                     .expr(Expr::val(1i32))
+    ///                     .expr(1i32)
     ///                     .column(Alias::new("next"))
     ///                     .column(Alias::new("value"))
     ///                     .from(Alias::new("table"))

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -381,7 +381,7 @@ impl Cycle {
 ///
 /// let base_query = SelectStatement::new()
 ///                     .column(Alias::new("id"))
-///                     .expr(Expr::val(1i32))
+///                     .expr(1i32)
 ///                     .column(Alias::new("next"))
 ///                     .column(Alias::new("value"))
 ///                     .from(Alias::new("table"))

--- a/src/value.rs
+++ b/src/value.rs
@@ -1628,7 +1628,7 @@ mod tests {
     #[test]
     #[cfg(feature = "with-chrono")]
     fn test_chrono_value() {
-        let timestamp = chrono::NaiveDate::from_ymd(2020, 1, 1).and_hms(2, 2, 2);
+        let timestamp = NaiveDate::from_ymd(2020, 1, 1).and_hms(2, 2, 2);
         let value: Value = timestamp.into();
         let out: NaiveDateTime = value.unwrap();
         assert_eq!(out, timestamp);
@@ -1672,7 +1672,7 @@ mod tests {
         let string = "2020-01-01T02:02:02+08:00";
         let timestamp = DateTime::parse_from_rfc3339(string).unwrap();
 
-        let query = Query::select().expr(Expr::val(timestamp)).to_owned();
+        let query = Query::select().expr(timestamp).to_owned();
 
         let formatted = "2020-01-01 02:02:02 +08:00";
 
@@ -1740,7 +1740,7 @@ mod tests {
         use time::macros::datetime;
 
         let timestamp = datetime!(2020-01-01 02:02:02 +8);
-        let query = Query::select().expr(Expr::val(timestamp)).to_owned();
+        let query = Query::select().expr(timestamp).to_owned();
         let formatted = "2020-01-01 02:02:02.000000 +08:00";
 
         assert_eq!(
@@ -1762,7 +1762,7 @@ mod tests {
     fn test_uuid_value() {
         let uuid = Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap();
         let value: Value = uuid.into();
-        let out: uuid::Uuid = value.unwrap();
+        let out: Uuid = value.unwrap();
         assert_eq!(out, uuid);
     }
 

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -732,11 +732,8 @@ fn select_48() {
         .from(Glyph::Table)
         .cond_where(
             Cond::all().add_option(Some(ConditionExpression::SimpleExpr(
-                Expr::tuple([
-                    Expr::col(Glyph::Aspect).into_simple_expr(),
-                    Expr::value(100),
-                ])
-                .lt(Expr::tuple([Expr::value(8), Expr::value(100)])),
+                Expr::tuple([Expr::col(Glyph::Aspect).into(), Expr::value(100)])
+                    .lt(Expr::tuple([Expr::value(8), Expr::value(100)])),
             ))),
         )
         .to_string(MysqlQueryBuilder);
@@ -755,7 +752,7 @@ fn select_48a() {
         .cond_where(
             Cond::all().add_option(Some(ConditionExpression::SimpleExpr(
                 Expr::tuple([
-                    Expr::col(Glyph::Aspect).into_simple_expr(),
+                    Expr::col(Glyph::Aspect).into(),
                     Expr::value(String::from("100")),
                 ])
                 .in_tuples([(8, String::from("100"))]),

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -437,7 +437,7 @@ fn select_30() {
             .and_where(
                 Expr::col(Char::SizeW).mul(2)
                     .add(Expr::col(Char::SizeH).div(3))
-                    .equals(Expr::value(4))
+                    .equals(4)
             )
             .to_string(MysqlQueryBuilder),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE (`size_w` * 2) + (`size_h` / 3) = 4"
@@ -448,7 +448,7 @@ fn select_30() {
 fn select_31() {
     assert_eq!(
         Query::select()
-            .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(Expr::value(i)) }))
+            .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(i) }))
             .to_string(MysqlQueryBuilder),
         "SELECT 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9"
     );
@@ -952,15 +952,9 @@ fn select_57() {
     let query = Query::select()
         .expr_as(
             CaseStatement::new()
-                .case(
-                    Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
-                    Expr::val("positive"),
-                )
-                .case(
-                    Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
-                    Expr::val("negative"),
-                )
-                .finally(Expr::val("zero")),
+                .case(Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0), "positive")
+                .case(Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0), "negative")
+                .finally("zero"),
             Alias::new("polarity"),
         )
         .from(Glyph::Table)

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -421,7 +421,7 @@ fn select_30() {
                 Expr::col(Char::SizeW)
                     .mul(2)
                     .add(Expr::col(Char::SizeH).div(3))
-                    .equals(Expr::value(4))
+                    .equals(4)
             )
             .to_string(PostgresQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" * 2) + ("size_h" / 3) = 4"#
@@ -432,7 +432,7 @@ fn select_30() {
 fn select_31() {
     assert_eq!(
         Query::select()
-            .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(Expr::value(i)) }))
+            .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(i) }))
             .to_string(PostgresQueryBuilder),
         r#"SELECT 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9"#
     );
@@ -995,15 +995,9 @@ fn select_59() {
     let query = Query::select()
         .expr_as(
             CaseStatement::new()
-                .case(
-                    Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
-                    Expr::val("positive"),
-                )
-                .case(
-                    Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
-                    Expr::val("negative"),
-                )
-                .finally(Expr::val("zero")),
+                .case(Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0), "positive")
+                .case(Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0), "negative")
+                .finally("zero"),
             Alias::new("polarity"),
         )
         .from(Glyph::Table)

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -716,11 +716,8 @@ fn select_48() {
         .from(Glyph::Table)
         .cond_where(
             Cond::all().add_option(Some(ConditionExpression::SimpleExpr(
-                Expr::tuple([
-                    Expr::col(Glyph::Aspect).into_simple_expr(),
-                    Expr::value(100),
-                ])
-                .lt(Expr::tuple([Expr::value(8), Expr::value(100)])),
+                Expr::tuple([Expr::col(Glyph::Aspect).into(), Expr::value(100)])
+                    .lt(Expr::tuple([Expr::value(8), Expr::value(100)])),
             ))),
         )
         .to_string(PostgresQueryBuilder);
@@ -739,7 +736,7 @@ fn select_48a() {
         .cond_where(
             Cond::all().add_option(Some(ConditionExpression::SimpleExpr(
                 Expr::tuple([
-                    Expr::col(Glyph::Aspect).into_simple_expr(),
+                    Expr::col(Glyph::Aspect).into(),
                     Expr::value(String::from("100")),
                 ])
                 .in_tuples([(8, String::from("100"))]),

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -421,7 +421,7 @@ fn select_30() {
                 Expr::col(Char::SizeW)
                     .mul(2)
                     .add(Expr::col(Char::SizeH).div(3))
-                    .equals(Expr::value(4))
+                    .equals(4)
             )
             .to_string(SqliteQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" * 2) + ("size_h" / 3) = 4"#
@@ -432,7 +432,7 @@ fn select_30() {
 fn select_31() {
     assert_eq!(
         Query::select()
-            .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(Expr::value(i)) }))
+            .expr((1..10_i32).fold(Expr::value(0), |expr, i| { expr.add(i) }))
             .to_string(SqliteQueryBuilder),
         r#"SELECT 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9"#
     );
@@ -940,15 +940,9 @@ fn select_57() {
     let query = Query::select()
         .expr_as(
             CaseStatement::new()
-                .case(
-                    Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0),
-                    Expr::val("positive"),
-                )
-                .case(
-                    Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0),
-                    Expr::val("negative"),
-                )
-                .finally(Expr::val("zero")),
+                .case(Expr::tbl(Glyph::Table, Glyph::Aspect).gt(0), "positive")
+                .case(Expr::tbl(Glyph::Table, Glyph::Aspect).lt(0), "negative")
+                .finally("zero"),
             Alias::new("polarity"),
         )
         .from(Glyph::Table)

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -716,11 +716,8 @@ fn select_48() {
         .from(Glyph::Table)
         .cond_where(
             Cond::all().add_option(Some(ConditionExpression::SimpleExpr(
-                Expr::tuple([
-                    Expr::col(Glyph::Aspect).into_simple_expr(),
-                    Expr::value(100),
-                ])
-                .lt(Expr::tuple([Expr::value(8), Expr::value(100)])),
+                Expr::tuple([Expr::col(Glyph::Aspect).into(), Expr::value(100)])
+                    .lt(Expr::tuple([Expr::value(8), Expr::value(100)])),
             ))),
         )
         .to_string(SqliteQueryBuilder);
@@ -739,7 +736,7 @@ fn select_48a() {
         .cond_where(
             Cond::all().add_option(Some(ConditionExpression::SimpleExpr(
                 Expr::tuple([
-                    Expr::col(Glyph::Aspect).into_simple_expr(),
+                    Expr::col(Glyph::Aspect).into(),
                     Expr::value(String::from("100")),
                 ])
                 .in_tuples([(8, String::from("100"))]),


### PR DESCRIPTION
## PR Info

## New Features

- Introduce `trait Expression`
- Introduce `trait PgExpr` with postgres specific method and operator
- Introduce `trait SqliteExpr` with sqlite specific method and operator

## Breaking Changes

- Deprecate `Expr::into_simple_expr`

## Changes

- Remove `panic` from `SimpleExpr`

CC @evgeniy-terekhin 
