### PR TITLE
Deprecate MySQL column type with display length / precision

### DIFF
--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
             .col(ColumnDef::new(Document::Timestamp).timestamp())
             .col(ColumnDef::new(Document::TimestampWithTimeZone).timestamp_with_time_zone())
             .col(ColumnDef::new(Document::Decimal).decimal())
-            .col(ColumnDef::new(Document::Array).array(ColumnType::Integer(None)))
+            .col(ColumnDef::new(Document::Array).array(ColumnType::Integer))
             .build(PostgresQueryBuilder),
     ]
     .join("; ");

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -29,52 +29,20 @@ impl TableBuilder for MysqlQueryBuilder {
                     None => "varchar(255)".into(),
                 },
                 ColumnType::Text => "text".into(),
-                ColumnType::TinyInteger(length) | ColumnType::TinyUnsigned(length) =>
-                    match length {
-                        Some(length) => format!("tinyint({})", length),
-                        None => "tinyint".into(),
-                    },
-                ColumnType::SmallInteger(length) | ColumnType::SmallUnsigned(length) =>
-                    match length {
-                        Some(length) => format!("smallint({})", length),
-                        None => "smallint".into(),
-                    },
-                ColumnType::Integer(length) | ColumnType::Unsigned(length) => match length {
-                    Some(length) => format!("int({})", length),
-                    None => "int".into(),
-                },
-                ColumnType::BigInteger(length) | ColumnType::BigUnsigned(length) => match length {
-                    Some(length) => format!("bigint({})", length),
-                    None => "bigint".into(),
-                },
-                ColumnType::Float(precision) => match precision {
-                    Some(precision) => format!("float({})", precision),
-                    None => "float".into(),
-                },
-                ColumnType::Double(precision) => match precision {
-                    Some(precision) => format!("double({})", precision),
-                    None => "double".into(),
-                },
+                ColumnType::TinyInteger | ColumnType::TinyUnsigned => "tinyint".into(),
+                ColumnType::SmallInteger | ColumnType::SmallUnsigned => "smallint".into(),
+                ColumnType::Integer | ColumnType::Unsigned => "int".into(),
+                ColumnType::BigInteger | ColumnType::BigUnsigned => "bigint".into(),
+                ColumnType::Float => "float".into(),
+                ColumnType::Double => "double".into(),
                 ColumnType::Decimal(precision) => match precision {
                     Some((precision, scale)) => format!("decimal({}, {})", precision, scale),
                     None => "decimal".into(),
                 },
-                ColumnType::DateTime(precision) => match precision {
-                    Some(precision) => format!("datetime({})", precision),
-                    None => "datetime".into(),
-                },
-                ColumnType::Timestamp(precision) => match precision {
-                    Some(precision) => format!("timestamp({})", precision),
-                    None => "timestamp".into(),
-                },
-                ColumnType::TimestampWithTimeZone(precision) => match precision {
-                    Some(precision) => format!("timestamp({})", precision),
-                    None => "timestamp".into(),
-                },
-                ColumnType::Time(precision) => match precision {
-                    Some(precision) => format!("time({})", precision),
-                    None => "time".into(),
-                },
+                ColumnType::DateTime => "datetime".into(),
+                ColumnType::Timestamp => "timestamp".into(),
+                ColumnType::TimestampWithTimeZone => "timestamp".into(),
+                ColumnType::Time => "time".into(),
                 ColumnType::Date => "date".into(),
                 ColumnType::Year(length) => {
                     match length {
@@ -133,10 +101,10 @@ impl TableBuilder for MysqlQueryBuilder {
         .unwrap();
         if matches!(
             column_type,
-            ColumnType::TinyUnsigned(_)
-                | ColumnType::SmallUnsigned(_)
-                | ColumnType::Unsigned(_)
-                | ColumnType::BigUnsigned(_)
+            ColumnType::TinyUnsigned
+                | ColumnType::SmallUnsigned
+                | ColumnType::Unsigned
+                | ColumnType::BigUnsigned
         ) {
             write!(sql, " ").unwrap();
             write!(sql, "UNSIGNED").unwrap();

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -29,52 +29,20 @@ impl TableBuilder for PostgresQueryBuilder {
                     None => "varchar".into(),
                 },
                 ColumnType::Text => "text".into(),
-                ColumnType::TinyInteger(length) | ColumnType::TinyUnsigned(length) =>
-                    match length {
-                        Some(length) => format!("smallint({})", length),
-                        None => "smallint".into(),
-                    },
-                ColumnType::SmallInteger(length) | ColumnType::SmallUnsigned(length) =>
-                    match length {
-                        Some(length) => format!("smallint({})", length),
-                        None => "smallint".into(),
-                    },
-                ColumnType::Integer(length) | ColumnType::Unsigned(length) => match length {
-                    Some(length) => format!("integer({})", length),
-                    None => "integer".into(),
-                },
-                ColumnType::BigInteger(length) | ColumnType::BigUnsigned(length) => match length {
-                    Some(length) => format!("bigint({})", length),
-                    None => "bigint".into(),
-                },
-                ColumnType::Float(precision) => match precision {
-                    Some(precision) => format!("real({})", precision),
-                    None => "real".into(),
-                },
-                ColumnType::Double(precision) => match precision {
-                    Some(precision) => format!("double precision({})", precision),
-                    None => "double precision".into(),
-                },
+                ColumnType::TinyInteger | ColumnType::TinyUnsigned => "smallint".into(),
+                ColumnType::SmallInteger | ColumnType::SmallUnsigned => "smallint".into(),
+                ColumnType::Integer | ColumnType::Unsigned => "integer".into(),
+                ColumnType::BigInteger | ColumnType::BigUnsigned => "bigint".into(),
+                ColumnType::Float => "real".into(),
+                ColumnType::Double => "double precision".into(),
                 ColumnType::Decimal(precision) => match precision {
                     Some((precision, scale)) => format!("decimal({}, {})", precision, scale),
                     None => "decimal".into(),
                 },
-                ColumnType::DateTime(precision) => match precision {
-                    Some(precision) => format!("timestamp({}) without time zone", precision),
-                    None => "timestamp without time zone".into(),
-                },
-                ColumnType::Timestamp(precision) => match precision {
-                    Some(precision) => format!("timestamp({})", precision),
-                    None => "timestamp".into(),
-                },
-                ColumnType::TimestampWithTimeZone(precision) => match precision {
-                    Some(precision) => format!("timestamp({}) with time zone", precision),
-                    None => "timestamp with time zone".into(),
-                },
-                ColumnType::Time(precision) => match precision {
-                    Some(precision) => format!("time({})", precision),
-                    None => "time".into(),
-                },
+                ColumnType::DateTime => "timestamp without time zone".into(),
+                ColumnType::Timestamp => "timestamp".into(),
+                ColumnType::TimestampWithTimeZone => "timestamp with time zone".into(),
+                ColumnType::Time => "time".into(),
                 ColumnType::Date => "date".into(),
                 ColumnType::Interval(fields, precision) => {
                     let mut typ = "interval".to_string();
@@ -249,9 +217,9 @@ impl TableBuilder for PostgresQueryBuilder {
 impl PostgresQueryBuilder {
     fn prepare_column_auto_increment(&self, column_type: &ColumnType, sql: &mut dyn SqlWriter) {
         match &column_type {
-            ColumnType::SmallInteger(_) => write!(sql, "smallserial").unwrap(),
-            ColumnType::Integer(_) => write!(sql, "serial").unwrap(),
-            ColumnType::BigInteger(_) => write!(sql, "bigserial").unwrap(),
+            ColumnType::SmallInteger => write!(sql, "smallserial").unwrap(),
+            ColumnType::Integer => write!(sql, "serial").unwrap(),
+            ColumnType::BigInteger => write!(sql, "bigserial").unwrap(),
             _ => unimplemented!("{:?} doesn't support auto increment", column_type),
         }
     }

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -49,52 +49,20 @@ impl TableBuilder for SqliteQueryBuilder {
                     None => "text".into(),
                 },
                 ColumnType::Text => "text".into(),
-                ColumnType::TinyInteger(length) | ColumnType::TinyUnsigned(length) =>
-                    match length {
-                        Some(length) => format!("integer({})", length),
-                        None => "integer".into(),
-                    },
-                ColumnType::SmallInteger(length) | ColumnType::SmallUnsigned(length) =>
-                    match length {
-                        Some(length) => format!("integer({})", length),
-                        None => "integer".into(),
-                    },
-                ColumnType::Integer(length) | ColumnType::Unsigned(length) => match length {
-                    Some(length) => format!("integer({})", length),
-                    None => "integer".into(),
-                },
-                ColumnType::BigInteger(length) | ColumnType::BigUnsigned(length) => match length {
-                    Some(length) => format!("integer({})", length),
-                    None => "integer".into(),
-                },
-                ColumnType::Float(precision) => match precision {
-                    Some(precision) => format!("real({})", precision),
-                    None => "real".into(),
-                },
-                ColumnType::Double(precision) => match precision {
-                    Some(precision) => format!("real({})", precision),
-                    None => "real".into(),
-                },
+                ColumnType::TinyInteger | ColumnType::TinyUnsigned => "integer".into(),
+                ColumnType::SmallInteger | ColumnType::SmallUnsigned => "integer".into(),
+                ColumnType::Integer | ColumnType::Unsigned => "integer".into(),
+                ColumnType::BigInteger | ColumnType::BigUnsigned => "integer".into(),
+                ColumnType::Float => "real".into(),
+                ColumnType::Double => "real".into(),
                 ColumnType::Decimal(precision) => match precision {
                     Some((precision, scale)) => format!("real({}, {})", precision, scale),
                     None => "real".into(),
                 },
-                ColumnType::DateTime(precision) => match precision {
-                    Some(precision) => format!("text({})", precision),
-                    None => "text".into(),
-                },
-                ColumnType::Timestamp(precision) => match precision {
-                    Some(precision) => format!("text({})", precision),
-                    None => "text".into(),
-                },
-                ColumnType::TimestampWithTimeZone(precision) => match precision {
-                    Some(precision) => format!("text({})", precision),
-                    None => "text".into(),
-                },
-                ColumnType::Time(precision) => match precision {
-                    Some(precision) => format!("text({})", precision),
-                    None => "text".into(),
-                },
+                ColumnType::DateTime => "text".into(),
+                ColumnType::Timestamp => "text".into(),
+                ColumnType::TimestampWithTimeZone => "text".into(),
+                ColumnType::Time => "text".into(),
                 ColumnType::Date => "text".into(),
                 ColumnType::Interval(_, _) => "unsupported".into(),
                 ColumnType::Binary(blob_size) => match blob_size {

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -16,21 +16,21 @@ pub enum ColumnType {
     Char(Option<u32>),
     String(Option<u32>),
     Text,
-    TinyInteger(Option<u32>),
-    SmallInteger(Option<u32>),
-    Integer(Option<u32>),
-    BigInteger(Option<u32>),
-    TinyUnsigned(Option<u32>),
-    SmallUnsigned(Option<u32>),
-    Unsigned(Option<u32>),
-    BigUnsigned(Option<u32>),
-    Float(Option<u32>),
-    Double(Option<u32>),
+    TinyInteger,
+    SmallInteger,
+    Integer,
+    BigInteger,
+    TinyUnsigned,
+    SmallUnsigned,
+    Unsigned,
+    BigUnsigned,
+    Float,
+    Double,
     Decimal(Option<(u32, u32)>),
-    DateTime(Option<u32>),
-    Timestamp(Option<u32>),
-    TimestampWithTimeZone(Option<u32>),
-    Time(Option<u32>),
+    DateTime,
+    Timestamp,
+    TimestampWithTimeZone,
+    Time,
     Date,
     Year(Option<MySqlYear>),
     Interval(Option<PgInterval>, Option<u32>),
@@ -218,123 +218,63 @@ impl ColumnDef {
         self
     }
 
-    /// Set column type as tiny_integer with custom length
-    pub fn tiny_integer_len(&mut self, length: u32) -> &mut Self {
-        self.types = Some(ColumnType::TinyInteger(Some(length)));
-        self
-    }
-
     /// Set column type as tiny_integer
     pub fn tiny_integer(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::TinyInteger(None));
-        self
-    }
-
-    /// Set column type as small_integer with custom length
-    pub fn small_integer_len(&mut self, length: u32) -> &mut Self {
-        self.types = Some(ColumnType::SmallInteger(Some(length)));
+        self.types = Some(ColumnType::TinyInteger);
         self
     }
 
     /// Set column type as small_integer
     pub fn small_integer(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::SmallInteger(None));
-        self
-    }
-
-    /// Set column type as integer with custom length
-    pub fn integer_len(&mut self, length: u32) -> &mut Self {
-        self.types = Some(ColumnType::Integer(Some(length)));
+        self.types = Some(ColumnType::SmallInteger);
         self
     }
 
     /// Set column type as integer
     pub fn integer(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::Integer(None));
-        self
-    }
-
-    /// Set column type as big_integer with custom length
-    pub fn big_integer_len(&mut self, length: u32) -> &mut Self {
-        self.types = Some(ColumnType::BigInteger(Some(length)));
+        self.types = Some(ColumnType::Integer);
         self
     }
 
     /// Set column type as big_integer
     pub fn big_integer(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::BigInteger(None));
-        self
-    }
-
-    /// Set column type as tiny_unsigned with custom length
-    pub fn tiny_unsigned_len(&mut self, length: u32) -> &mut Self {
-        self.types = Some(ColumnType::TinyUnsigned(Some(length)));
+        self.types = Some(ColumnType::BigInteger);
         self
     }
 
     /// Set column type as tiny_unsigned
     pub fn tiny_unsigned(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::TinyUnsigned(None));
-        self
-    }
-
-    /// Set column type as small_unsigned with custom length
-    pub fn small_unsigned_len(&mut self, length: u32) -> &mut Self {
-        self.types = Some(ColumnType::SmallUnsigned(Some(length)));
+        self.types = Some(ColumnType::TinyUnsigned);
         self
     }
 
     /// Set column type as small_unsigned
     pub fn small_unsigned(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::SmallUnsigned(None));
-        self
-    }
-
-    /// Set column type as unsigned with custom length
-    pub fn unsigned_len(&mut self, length: u32) -> &mut Self {
-        self.types = Some(ColumnType::Unsigned(Some(length)));
+        self.types = Some(ColumnType::SmallUnsigned);
         self
     }
 
     /// Set column type as unsigned
     pub fn unsigned(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::Unsigned(None));
-        self
-    }
-
-    /// Set column type as big_unsigned with custom length
-    pub fn big_unsigned_len(&mut self, length: u32) -> &mut Self {
-        self.types = Some(ColumnType::BigUnsigned(Some(length)));
+        self.types = Some(ColumnType::Unsigned);
         self
     }
 
     /// Set column type as big_unsigned
     pub fn big_unsigned(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::BigUnsigned(None));
-        self
-    }
-
-    /// Set column type as float with custom precision
-    pub fn float_len(&mut self, precision: u32) -> &mut Self {
-        self.types = Some(ColumnType::Float(Some(precision)));
+        self.types = Some(ColumnType::BigUnsigned);
         self
     }
 
     /// Set column type as float
     pub fn float(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::Float(None));
-        self
-    }
-
-    /// Set column type as double with custom precision
-    pub fn double_len(&mut self, precision: u32) -> &mut Self {
-        self.types = Some(ColumnType::Double(Some(precision)));
+        self.types = Some(ColumnType::Float);
         self
     }
 
     /// Set column type as double
     pub fn double(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::Double(None));
+        self.types = Some(ColumnType::Double);
         self
     }
 
@@ -350,15 +290,9 @@ impl ColumnDef {
         self
     }
 
-    /// Set column type as date_time with custom precision
-    pub fn date_time_len(&mut self, precision: u32) -> &mut Self {
-        self.types = Some(ColumnType::DateTime(Some(precision)));
-        self
-    }
-
     /// Set column type as date_time
     pub fn date_time(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::DateTime(None));
+        self.types = Some(ColumnType::DateTime);
         self
     }
 
@@ -407,39 +341,21 @@ impl ColumnDef {
         self
     }
 
-    /// Set column type as timestamp with custom precision
-    pub fn timestamp_len(&mut self, precision: u32) -> &mut Self {
-        self.types = Some(ColumnType::Timestamp(Some(precision)));
-        self
-    }
-
     /// Set column type as timestamp
     pub fn timestamp(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::Timestamp(None));
+        self.types = Some(ColumnType::Timestamp);
         self
     }
 
     /// Set column type as timestamp with time zone. Postgres only
     pub fn timestamp_with_time_zone(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::TimestampWithTimeZone(None));
-        self
-    }
-
-    /// Set column type as timestamp with time zone plus custom precision
-    pub fn timestamp_with_time_zone_len(&mut self, precision: u32) -> &mut Self {
-        self.types = Some(ColumnType::TimestampWithTimeZone(Some(precision)));
-        self
-    }
-
-    /// Set column type as time with custom precision
-    pub fn time_len(&mut self, precision: u32) -> &mut Self {
-        self.types = Some(ColumnType::Time(Some(precision)));
+        self.types = Some(ColumnType::TimestampWithTimeZone);
         self
     }
 
     /// Set column type as time
     pub fn time(&mut self) -> &mut Self {
-        self.types = Some(ColumnType::Time(None));
+        self.types = Some(ColumnType::Time);
         self
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -360,16 +360,16 @@ macro_rules! type_to_box_value {
 }
 
 type_to_value!(bool, Bool, Boolean);
-type_to_value!(i8, TinyInt, TinyInteger(None));
-type_to_value!(i16, SmallInt, SmallInteger(None));
-type_to_value!(i32, Int, Integer(None));
-type_to_value!(i64, BigInt, BigInteger(None));
-type_to_value!(u8, TinyUnsigned, TinyUnsigned(None));
-type_to_value!(u16, SmallUnsigned, SmallUnsigned(None));
-type_to_value!(u32, Unsigned, Unsigned(None));
-type_to_value!(u64, BigUnsigned, BigUnsigned(None));
-type_to_value!(f32, Float, Float(None));
-type_to_value!(f64, Double, Double(None));
+type_to_value!(i8, TinyInt, TinyInteger);
+type_to_value!(i16, SmallInt, SmallInteger);
+type_to_value!(i32, Int, Integer);
+type_to_value!(i64, BigInt, BigInteger);
+type_to_value!(u8, TinyUnsigned, TinyUnsigned);
+type_to_value!(u16, SmallUnsigned, SmallUnsigned);
+type_to_value!(u32, Unsigned, Unsigned);
+type_to_value!(u64, BigUnsigned, BigUnsigned);
+type_to_value!(f32, Float, Float);
+type_to_value!(f64, Double, Double);
 type_to_value!(char, Char, Char(None));
 
 impl<'a> From<&'a [u8]> for Value {
@@ -446,8 +446,8 @@ mod with_chrono {
     use chrono::{Local, Offset, Utc};
 
     type_to_box_value!(NaiveDate, ChronoDate, Date);
-    type_to_box_value!(NaiveTime, ChronoTime, Time(None));
-    type_to_box_value!(NaiveDateTime, ChronoDateTime, DateTime(None));
+    type_to_box_value!(NaiveTime, ChronoTime, Time);
+    type_to_box_value!(NaiveDateTime, ChronoDateTime, DateTime);
 
     impl From<DateTime<Utc>> for Value {
         fn from(v: DateTime<Utc>) -> Value {
@@ -491,7 +491,7 @@ mod with_chrono {
         }
 
         fn column_type() -> ColumnType {
-            ColumnType::TimestampWithTimeZone(None)
+            ColumnType::TimestampWithTimeZone
         }
     }
 
@@ -518,7 +518,7 @@ mod with_chrono {
         }
 
         fn column_type() -> ColumnType {
-            ColumnType::TimestampWithTimeZone(None)
+            ColumnType::TimestampWithTimeZone
         }
     }
 
@@ -545,7 +545,7 @@ mod with_chrono {
         }
 
         fn column_type() -> ColumnType {
-            ColumnType::TimestampWithTimeZone(None)
+            ColumnType::TimestampWithTimeZone
         }
     }
 }
@@ -572,8 +572,8 @@ mod with_time {
     use super::*;
 
     type_to_box_value!(time::Date, TimeDate, Date);
-    type_to_box_value!(time::Time, TimeTime, Time(None));
-    type_to_box_value!(PrimitiveDateTime, TimeDateTime, DateTime(None));
+    type_to_box_value!(time::Time, TimeTime, Time);
+    type_to_box_value!(PrimitiveDateTime, TimeDateTime, DateTime);
 
     impl From<OffsetDateTime> for Value {
         fn from(v: OffsetDateTime) -> Value {
@@ -604,7 +604,7 @@ mod with_time {
         }
 
         fn column_type() -> ColumnType {
-            ColumnType::TimestampWithTimeZone(None)
+            ColumnType::TimestampWithTimeZone
         }
     }
 }

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -7,7 +7,7 @@ fn create_1() {
             .table(Glyph::Table)
             .col(
                 ColumnDef::new(Glyph::Id)
-                    .integer_len(11)
+                    .integer()
                     .not_null()
                     .auto_increment()
                     .primary_key()
@@ -20,7 +20,7 @@ fn create_1() {
             .to_string(MysqlQueryBuilder),
         [
             "CREATE TABLE `glyph` (",
-            "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
+            "`id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,",
             "`aspect` double NOT NULL,",
             "`image` text",
             ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
@@ -36,7 +36,7 @@ fn create_2() {
             .table(Font::Table)
             .col(
                 ColumnDef::new(Font::Id)
-                    .integer_len(11)
+                    .integer()
                     .not_null()
                     .auto_increment()
                     .primary_key()
@@ -50,7 +50,7 @@ fn create_2() {
             .to_string(MysqlQueryBuilder),
         [
             "CREATE TABLE `font` (",
-            "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
+            "`id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,",
             "`name` varchar(255) NOT NULL,",
             "`variant` varchar(255) NOT NULL,",
             "`language` varchar(1024) NOT NULL",
@@ -68,18 +68,18 @@ fn create_3() {
             .if_not_exists()
             .col(
                 ColumnDef::new(Char::Id)
-                    .integer_len(11)
+                    .integer()
                     .not_null()
                     .auto_increment()
                     .primary_key()
             )
-            .col(ColumnDef::new(Char::FontSize).integer_len(11).not_null())
+            .col(ColumnDef::new(Char::FontSize).integer().not_null())
             .col(ColumnDef::new(Char::Character).string_len(255).not_null())
-            .col(ColumnDef::new(Char::SizeW).unsigned_len(11).not_null())
-            .col(ColumnDef::new(Char::SizeH).unsigned_len(11).not_null())
+            .col(ColumnDef::new(Char::SizeW).unsigned().not_null())
+            .col(ColumnDef::new(Char::SizeH).unsigned().not_null())
             .col(
                 ColumnDef::new(Char::FontId)
-                    .integer_len(11)
+                    .integer()
                     .default(Value::Int(None))
             )
             .foreign_key(
@@ -96,12 +96,12 @@ fn create_3() {
             .to_string(MysqlQueryBuilder),
         [
             "CREATE TABLE IF NOT EXISTS `character` (",
-            "`id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,",
-            "`font_size` int(11) NOT NULL,",
+            "`id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,",
+            "`font_size` int NOT NULL,",
             "`character` varchar(255) NOT NULL,",
-            "`size_w` int(11) UNSIGNED NOT NULL,",
-            "`size_h` int(11) UNSIGNED NOT NULL,",
-            "`font_id` int(11) DEFAULT NULL,",
+            "`size_w` int UNSIGNED NOT NULL,",
+            "`size_h` int UNSIGNED NOT NULL,",
+            "`font_id` int DEFAULT NULL,",
             "CONSTRAINT `FK_2e303c3a712662f1fc2a4d0aad6`",
             "FOREIGN KEY (`font_id`) REFERENCES `font` (`id`)",
             "ON DELETE CASCADE ON UPDATE RESTRICT",

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -239,13 +239,13 @@ fn create_11() {
             .table(Char::Table)
             .col(
                 ColumnDef::new(Char::CreatedAt)
-                    .timestamp_with_time_zone_len(0)
+                    .timestamp_with_time_zone()
                     .not_null()
             )
             .to_string(PostgresQueryBuilder),
         [
             r#"CREATE TABLE "character" ("#,
-            r#""created_at" timestamp(0) with time zone NOT NULL"#,
+            r#""created_at" timestamp with time zone NOT NULL"#,
             r#")"#,
         ]
         .join(" ")


### PR DESCRIPTION
## PR Info

- In response to https://github.com/SeaQL/sea-query/pull/492#issuecomment-1288114667

## Breaking Changes

- [x] Integer and date time column types with display length or precision option has been removed.
- [x] Its corresponding constructor methods are also being removed, i.e. `ColumnDef::xxx_len()` method
