### PR TITLE
[issues-344] Improve expr

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -603,6 +603,7 @@ impl Expr {
     {
         self.binary(BinOper::NotEqual, v)
     }
+
     /// Express a equal expression between two table columns,
     /// you will mainly use this to relate identical value between two table columns.
     ///
@@ -674,13 +675,6 @@ impl Expr {
         self.binary(BinOper::GreaterThan, v.into())
     }
 
-    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::gt`]")]
-    pub fn greater_than<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(BinOper::GreaterThan, expr)
-    }
     /// Express a greater than or equal (`>=`) expression.
     ///
     /// # Examples
@@ -712,14 +706,6 @@ impl Expr {
         V: Into<SimpleExpr>,
     {
         self.binary(BinOper::GreaterThanOrEqual, v)
-    }
-
-    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::gte`]")]
-    pub fn greater_or_equal<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(BinOper::GreaterThanOrEqual, expr)
     }
 
     /// Express a less than (`<`) expression.
@@ -755,14 +741,6 @@ impl Expr {
         self.binary(BinOper::SmallerThan, v)
     }
 
-    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::lt`]")]
-    pub fn less_than<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(BinOper::SmallerThan, expr)
-    }
-
     /// Express a less than or equal (`<=`) expression.
     ///
     /// # Examples
@@ -796,14 +774,6 @@ impl Expr {
         self.binary(BinOper::SmallerThanOrEqual, v)
     }
 
-    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::lte`]")]
-    pub fn less_or_equal<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(BinOper::SmallerThanOrEqual, expr)
-    }
-
     /// Express an arithmetic addition operation.
     ///
     /// # Examples
@@ -814,7 +784,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).add(1).equals(2))
+    ///     .and_where(Expr::val(1).add(1).eq(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -848,7 +818,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).sub(1).equals(2))
+    ///     .and_where(Expr::val(1).sub(1).eq(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -882,7 +852,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).mul(1).equals(2))
+    ///     .and_where(Expr::val(1).mul(1).eq(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -916,7 +886,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).div(1).equals(2))
+    ///     .and_where(Expr::val(1).div(1).eq(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -950,7 +920,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).modulo(1).equals(2))
+    ///     .and_where(Expr::val(1).modulo(1).eq(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -984,7 +954,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).left_shift(1).equals(2))
+    ///     .and_where(Expr::val(1).left_shift(1).eq(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1018,7 +988,7 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).right_shift(1).equals(2))
+    ///     .and_where(Expr::val(1).right_shift(1).eq(2))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1927,14 +1897,6 @@ impl Expr {
         self.into()
     }
 
-    #[deprecated(
-        since = "0.28.0",
-        note = "Please use the [`Into::<SimpleExpr>::into()`]"
-    )]
-    pub fn into_simple_expr(self) -> SimpleExpr {
-        self.into()
-    }
-
     /// Adds new `CASE WHEN` to existing case statement.
     ///
     /// # Examples
@@ -2037,6 +1999,46 @@ impl Expr {
     /// ```
     pub fn current_timestamp() -> SimpleExpr {
         SimpleExpr::Keyword(Keyword::CurrentTimestamp)
+    }
+
+    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::gt`]")]
+    pub fn greater_than<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(BinOper::GreaterThan, expr)
+    }
+
+    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::gte`]")]
+    pub fn greater_or_equal<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(BinOper::GreaterThanOrEqual, expr)
+    }
+
+    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::lt`]")]
+    pub fn less_than<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(BinOper::SmallerThan, expr)
+    }
+
+    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::lte`]")]
+    pub fn less_or_equal<T>(self, expr: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.binary(BinOper::SmallerThanOrEqual, expr)
+    }
+
+    #[deprecated(
+        since = "0.28.0",
+        note = "Please use the [`Into::<SimpleExpr>::into()`]"
+    )]
+    pub fn into_simple_expr(self) -> SimpleExpr {
+        self.into()
     }
 }
 
@@ -2149,36 +2151,73 @@ impl SimpleExpr {
         self.binary(BinOper::Or, right)
     }
 
-    /// Compares with another [`SimpleExpr`] for equality.
+    /// Express an equal (`=`) expression.
     ///
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{tests_cfg::*, *};
+    /// use sea_query::{*, tests_cfg::*};
     ///
     /// let query = Query::select()
-    ///     .column(Char::Character)
+    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(
-    ///         Expr::col(Char::SizeW)
-    ///             .mul(2)
-    ///             .equals(Expr::col(Char::SizeH).mul(3)),
-    ///     )
+    ///     .and_where(Expr::value("What!").eq("Nothing"))
     ///     .to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character` FROM `character` WHERE `size_w` * 2 = `size_h` * 3"#
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 'What!' = 'Nothing'"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character" FROM "character" WHERE "size_w" * 2 = "size_h" * 3"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'What!' = 'Nothing'"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character" FROM "character" WHERE "size_w" * 2 = "size_h" * 3"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'What!' = 'Nothing'"#
     /// );
     /// ```
+    pub fn eq<V>(self, v: V) -> SimpleExpr
+    where
+        V: Into<SimpleExpr>,
+    {
+        self.binary(BinOper::Equal, v)
+    }
+
+    /// Express a not equal (`<>`) expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::value("Morning").ne("Good"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 'Morning' <> 'Good'"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'Morning' <> 'Good'"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'Morning' <> 'Good'"#
+    /// );
+    /// ```
+    pub fn ne<V>(self, v: V) -> SimpleExpr
+    where
+        V: Into<SimpleExpr>,
+    {
+        self.binary(BinOper::NotEqual, v)
+    }
+
+    #[deprecated(since = "0.28.0", note = "Please use the [`SimpleExpr::eq`]")]
     pub fn equals<T>(self, right: T) -> Self
     where
         T: Into<SimpleExpr>,
@@ -2186,36 +2225,7 @@ impl SimpleExpr {
         self.binary(BinOper::Equal, right)
     }
 
-    /// Compares with another [`SimpleExpr`] for inequality.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select()
-    ///     .column(Char::Character)
-    ///     .from(Char::Table)
-    ///     .and_where(
-    ///         Expr::col(Char::SizeW)
-    ///             .mul(2)
-    ///             .not_equals(Expr::col(Char::SizeH)),
-    ///     )
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character` FROM `character` WHERE `size_w` * 2 <> `size_h`"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character" FROM "character" WHERE "size_w" * 2 <> "size_h""#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character" FROM "character" WHERE "size_w" * 2 <> "size_h""#
-    /// );
-    /// ```
+    #[deprecated(since = "0.28.0", note = "Please use the [`SimpleExpr::ne`]")]
     pub fn not_equals<T>(self, right: T) -> Self
     where
         T: Into<SimpleExpr>,
@@ -2403,7 +2413,34 @@ impl SimpleExpr {
         Self::FunctionCall(func)
     }
 
-    pub(crate) fn binary<O, T>(self, op: O, right: T) -> Self
+    /// Create any binary operation
+    ///
+    /// # Examples
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
+    ///     .from(Char::Table)
+    ///     .cond_where(all![
+    ///         Expr::value(10).binary(BinOper::SmallerThan, Expr::col(Char::SizeW)),
+    ///         Expr::value(20).binary(BinOper::GreaterThan, Expr::col(Char::SizeH))
+    ///     ])
+    ///     .to_owned();
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 10 < `size_w` AND 20 > `size_h`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 10 < "size_w" AND 20 > "size_h""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 10 < "size_w" AND 20 > "size_h""#
+    /// );
+    ///
+    pub fn binary<O, T>(self, op: O, right: T) -> Self
     where
         O: Into<BinOper>,
         T: Into<SimpleExpr>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@
 //!         .and_where(
 //!             Expr::expr(Expr::col(Char::SizeW).add(1))
 //!                 .mul(2)
-//!                 .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+//!                 .eq(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
 //!         )
 //!         .and_where(
 //!             Expr::col(Char::SizeW).in_subquery(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,7 +351,7 @@
 //!     .column(Char::Character)
 //!     .column((Font::Table, Font::Name))
 //!     .from(Char::Table)
-//!     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+//!     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
 //!     .and_where(Expr::col(Char::SizeW).is_in([3, 4]))
 //!     .and_where(Expr::col(Char::Character).like("A%"))
 //!     .to_owned();

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -96,8 +96,8 @@ impl CaseStatement {
     ///         )
     ///         .case(
     ///             Cond::any()
-    ///                 .add(Expr::tbl(Character::Table, Character::FontSize).between(24,48).into_condition())
-    ///                 .add(Expr::tbl(Character::Table, Character::SizeW).between(300,500).into_condition()),
+    ///                 .add(Expr::tbl(Character::Table, Character::FontSize).between(24,48))
+    ///                 .add(Expr::tbl(Character::Table, Character::SizeW).between(300,500)),
     ///             "medium"
     ///         )
     ///         .finally("small"),

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -20,7 +20,7 @@ use crate::{
 ///     .column(Char::Character)
 ///     .column((Font::Table, Font::Name))
 ///     .from(Char::Table)
-///     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+///     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
 ///     .and_where(Expr::col(Char::SizeW).is_in([3, 4]))
 ///     .and_where(Expr::col(Char::Character).like("A%"))
 ///     .to_owned();
@@ -816,7 +816,7 @@ impl SelectStatement {
     ///     .expr(Expr::asterisk())
     ///     .from(Char::Table)
     ///     .from(Font::Table)
-    ///     .and_where(Expr::tbl(Font::Table, Font::Id).equals(Char::Table, Char::FontId))
+    ///     .and_where(Expr::tbl(Font::Table, Font::Id).equals((Char::Table, Char::FontId)))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1026,7 +1026,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
-    ///     .cross_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///     .cross_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1050,8 +1050,8 @@ impl SelectStatement {
     ///         .cross_join(
     ///             Font::Table,
     ///             all![
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
     ///             ]
     ///         )
     ///         .to_owned();
@@ -1088,7 +1088,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
-    ///     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///     .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1112,8 +1112,8 @@ impl SelectStatement {
     ///         .left_join(
     ///             Font::Table,
     ///             all![
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
     ///             ]
     ///         )
     ///         .to_owned();
@@ -1150,7 +1150,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
-    ///     .right_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///     .right_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1174,8 +1174,8 @@ impl SelectStatement {
     ///         .right_join(
     ///             Font::Table,
     ///             all![
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
     ///             ]
     ///         )
     ///         .to_owned();
@@ -1212,7 +1212,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
-    ///     .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///     .inner_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1236,8 +1236,8 @@ impl SelectStatement {
     ///         .inner_join(
     ///             Font::Table,
     ///             all![
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
     ///             ]
     ///         )
     ///         .to_owned();
@@ -1274,7 +1274,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
-    ///     .full_outer_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///     .full_outer_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1294,8 +1294,8 @@ impl SelectStatement {
     ///         .full_outer_join(
     ///             Font::Table,
     ///             all![
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
     ///             ]
     ///         )
     ///         .to_owned();
@@ -1328,7 +1328,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
-    ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1353,8 +1353,8 @@ impl SelectStatement {
     ///             JoinType::RightJoin,
     ///             Font::Table,
     ///             all![
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
-    ///                 Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
+    ///                 Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
     ///             ]
     ///         )
     ///         .to_owned();
@@ -1402,7 +1402,7 @@ impl SelectStatement {
     ///         JoinType::RightJoin,
     ///         Font::Table,
     ///         Alias::new("f"),
-    ///         Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
+    ///         Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id))
     ///     )
     ///     .to_owned();
     ///
@@ -1430,8 +1430,8 @@ impl SelectStatement {
     ///             Font::Table,
     ///             Alias::new("f"),
     ///             Condition::all()
-    ///                 .add(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
-    ///                 .add(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///                 .add(Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
+    ///                 .add(Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
     ///         )
     ///         .to_string(MysqlQueryBuilder),
     ///     r#"SELECT `character`, `font`.`name` FROM `character` RIGHT JOIN `font` AS `f` ON `character`.`font_id` = `font`.`id` AND `character`.`font_id` = `font`.`id`"#
@@ -1474,7 +1474,7 @@ impl SelectStatement {
     ///         JoinType::LeftJoin,
     ///         Query::select().column(Glyph::Id).from(Glyph::Table).take(),
     ///         sub_glyph.clone(),
-    ///         Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id)
+    ///         Expr::tbl(Font::Table, Font::Id).equals((sub_glyph.clone(), Glyph::Id))
     ///     )
     ///     .to_owned();
     ///
@@ -1501,8 +1501,8 @@ impl SelectStatement {
     ///             Query::select().column(Glyph::Id).from(Glyph::Table).take(),
     ///             sub_glyph.clone(),
     ///             Condition::all()
-    ///                 .add(Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id))
-    ///                 .add(Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id))
+    ///                 .add(Expr::tbl(Font::Table, Font::Id).equals((sub_glyph.clone(), Glyph::Id)))
+    ///                 .add(Expr::tbl(Font::Table, Font::Id).equals((sub_glyph.clone(), Glyph::Id)))
     ///         )
     ///         .to_string(MysqlQueryBuilder),
     ///     r#"SELECT `name` FROM `font` LEFT JOIN (SELECT `id` FROM `glyph`) AS `sub_glyph` ON `font`.`id` = `sub_glyph`.`id` AND `font`.`id` = `sub_glyph`.`id`"#
@@ -1544,7 +1544,7 @@ impl SelectStatement {
     ///         JoinType::LeftJoin,
     ///         Query::select().column(Glyph::Id).from(Glyph::Table).take(),
     ///         sub_glyph.clone(),
-    ///         Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id)
+    ///         Expr::tbl(Font::Table, Font::Id).equals((sub_glyph.clone(), Glyph::Id))
     ///     )
     ///     .to_owned();
     ///
@@ -1567,8 +1567,8 @@ impl SelectStatement {
     ///             Query::select().column(Glyph::Id).from(Glyph::Table).take(),
     ///             sub_glyph.clone(),
     ///             Condition::all()
-    ///                 .add(Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id))
-    ///                 .add(Expr::tbl(Font::Table, Font::Id).equals(sub_glyph.clone(), Glyph::Id))
+    ///                 .add(Expr::tbl(Font::Table, Font::Id).equals((sub_glyph.clone(), Glyph::Id)))
+    ///                 .add(Expr::tbl(Font::Table, Font::Id).equals((sub_glyph.clone(), Glyph::Id)))
     ///         )
     ///         .to_string(MysqlQueryBuilder),
     ///     r#"SELECT `name` FROM `font` LEFT JOIN LATERAL (SELECT `id` FROM `glyph`) AS `sub_glyph` ON `font`.`id` = `sub_glyph`.`id` AND `font`.`id` = `sub_glyph`.`id`"#
@@ -1622,7 +1622,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
-    ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
     ///     .group_by_columns([
     ///         Char::Character,
     ///     ])
@@ -1649,7 +1649,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
-    ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
     ///     .group_by_columns([
     ///         (Char::Table, Char::Character),
     ///     ])
@@ -1689,7 +1689,7 @@ impl SelectStatement {
     ///     .column(Char::Character)
     ///     .column((Font::Table, Font::Name))
     ///     .from(Char::Table)
-    ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+    ///     .join(JoinType::RightJoin, Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
     ///     .group_by_col((Char::Table, Char::Character))
     ///     .to_owned();
     ///
@@ -2221,7 +2221,7 @@ impl SelectStatement {
     ///                             .join(
     ///                                 JoinType::InnerJoin,
     ///                                 Alias::new("cte_traversal"),
-    ///                                 Expr::tbl(Alias::new("cte_traversal"), Alias::new("next")).equals(Alias::new("table"), Alias::new("id")).into_condition()
+    ///                                 Expr::tbl(Alias::new("cte_traversal"), Alias::new("next")).equals((Alias::new("table"), Alias::new("id")))
     ///                             )
     ///                             .to_owned();
     ///

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -396,7 +396,7 @@ impl Cycle {
 ///                             .join(
 ///                                 JoinType::InnerJoin,
 ///                                 Alias::new("cte_traversal"),
-///                                 Expr::tbl(Alias::new("cte_traversal"), Alias::new("next")).equals(Alias::new("table"), Alias::new("id")).into_condition()
+///                                 Expr::tbl(Alias::new("cte_traversal"), Alias::new("next")).equals((Alias::new("table"), Alias::new("id")))
 ///                             )
 ///                             .to_owned();
 ///

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -369,7 +369,7 @@ fn select_25() {
             .and_where(
                 Expr::col(Char::SizeW)
                     .mul(2)
-                    .equals(Expr::col(Char::SizeH).div(2))
+                    .eq(Expr::col(Char::SizeH).div(2))
             )
             .to_string(MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE `size_w` * 2 = `size_h` / 2"
@@ -385,7 +385,7 @@ fn select_26() {
             .and_where(
                 Expr::expr(Expr::col(Char::SizeW).add(1))
                     .mul(2)
-                    .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+                    .eq(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
             )
             .to_string(MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE (`size_w` + 1) * 2 = (`size_h` / 2) - 1"
@@ -437,7 +437,7 @@ fn select_30() {
             .and_where(
                 Expr::col(Char::SizeW).mul(2)
                     .add(Expr::col(Char::SizeH).div(3))
-                    .equals(4)
+                    .eq(4)
             )
             .to_string(MysqlQueryBuilder),
         "SELECT `character`, `size_w`, `size_h` FROM `character` WHERE (`size_w` * 2) + (`size_h` / 3) = 4"

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -104,7 +104,7 @@ fn select_8() {
                 Char::Character,
             ])
             .from(Char::Table)
-            .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+            .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
             .to_string(MysqlQueryBuilder),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id`"
     );
@@ -118,8 +118,8 @@ fn select_9() {
                 Char::Character,
             ])
             .from(Char::Table)
-            .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
-            .inner_join(Glyph::Table, Expr::tbl(Char::Table, Char::Character).equals(Glyph::Table, Glyph::Image))
+            .left_join(Font::Table, Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
+            .inner_join(Glyph::Table, Expr::tbl(Char::Table, Char::Character).equals((Glyph::Table, Glyph::Image)))
             .to_string(MysqlQueryBuilder),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` INNER JOIN `glyph` ON `character`.`character` = `glyph`.`image`"
     );
@@ -134,8 +134,8 @@ fn select_10() {
             ])
             .from(Char::Table)
             .left_join(Font::Table,
-                Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
-                .and(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+                Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id))
+                .and(Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
             )
             .to_string(MysqlQueryBuilder),
         "SELECT `character` FROM `character` LEFT JOIN `font` ON (`character`.`font_id` = `font`.`id`) AND (`character`.`font_id` = `font`.`id`)"
@@ -784,7 +784,7 @@ fn select_50() {
         .from(Char::Table)
         .inner_join(
             Font::Table,
-            Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+            Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
         )
         .to_string(MysqlQueryBuilder);
 
@@ -881,7 +881,7 @@ fn select_54() {
         .expr(Expr::asterisk())
         .from(Char::Table)
         .from(Font::Table)
-        .and_where(Expr::tbl(Font::Table, Font::Id).equals(Char::Table, Char::FontId))
+        .and_where(Expr::tbl(Font::Table, Font::Id).equals((Char::Table, Char::FontId)))
         .to_string(MysqlQueryBuilder);
 
     assert_eq!(
@@ -1372,7 +1372,7 @@ fn union_1() {
                     .from(Char::Table)
                     .left_join(
                         Font::Table,
-                        Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
+                        Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id))
                     )
                     .order_by((Font::Table, Font::Id), Order::Asc)
                     .take()

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -358,7 +358,7 @@ fn select_25() {
             .and_where(
                 Expr::col(Char::SizeW)
                     .mul(2)
-                    .equals(Expr::col(Char::SizeH).div(2))
+                    .eq(Expr::col(Char::SizeH).div(2))
             )
             .to_string(PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "size_w" * 2 = "size_h" / 2"#
@@ -374,7 +374,7 @@ fn select_26() {
             .and_where(
                 Expr::expr(Expr::col(Char::SizeW).add(1))
                     .mul(2)
-                    .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+                    .eq(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
             )
             .to_string(PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#
@@ -421,7 +421,7 @@ fn select_30() {
                 Expr::col(Char::SizeW)
                     .mul(2)
                     .add(Expr::col(Char::SizeH).div(3))
-                    .equals(4)
+                    .eq(4)
             )
             .to_string(PostgresQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" * 2) + ("size_h" / 3) = 4"#

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -103,7 +103,7 @@ fn select_8() {
             .from(Char::Table)
             .left_join(
                 Font::Table,
-                Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
+                Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id))
             )
             .to_string(PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id""#
@@ -118,11 +118,11 @@ fn select_9() {
             .from(Char::Table)
             .left_join(
                 Font::Table,
-                Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
+                Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id))
             )
             .inner_join(
                 Glyph::Table,
-                Expr::tbl(Char::Table, Char::Character).equals(Glyph::Table, Glyph::Image)
+                Expr::tbl(Char::Table, Char::Character).equals((Glyph::Table, Glyph::Image))
             )
             .to_string(PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" INNER JOIN "glyph" ON "character"."character" = "glyph"."image""#
@@ -138,8 +138,8 @@ fn select_10() {
             .left_join(
                 Font::Table,
                 Expr::tbl(Char::Table, Char::FontId)
-                    .equals(Font::Table, Font::Id)
-                    .and(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id))
+                    .equals((Font::Table, Font::Id))
+                    .and(Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)))
             )
             .to_string(PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON ("character"."font_id" = "font"."id") AND ("character"."font_id" = "font"."id")"#
@@ -768,7 +768,7 @@ fn select_50() {
         .from(Char::Table)
         .inner_join(
             Font::Table,
-            Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+            Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
         )
         .to_string(PostgresQueryBuilder);
 
@@ -887,7 +887,7 @@ fn select_55() {
         .expr(Expr::asterisk())
         .from(Char::Table)
         .from(Font::Table)
-        .and_where(Expr::tbl(Font::Table, Font::Id).equals(Char::Table, Char::FontId))
+        .and_where(Expr::tbl(Font::Table, Font::Id).equals((Char::Table, Char::FontId)))
         .to_string(PostgresQueryBuilder);
 
     assert_eq!(
@@ -1645,7 +1645,7 @@ fn union_1() {
                     .from(Char::Table)
                     .left_join(
                         Font::Table,
-                        Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
+                        Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id))
                     )
                     .order_by((Font::Table, Font::Id), Order::Asc)
                     .take()

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -103,7 +103,7 @@ fn select_8() {
             .from(Char::Table)
             .left_join(
                 Font::Table,
-                Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+                Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
             )
             .to_string(SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id""#
@@ -118,11 +118,11 @@ fn select_9() {
             .from(Char::Table)
             .left_join(
                 Font::Table,
-                Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+                Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
             )
             .inner_join(
                 Glyph::Table,
-                Expr::tbl(Char::Table, Char::Character).equals(Glyph::Table, Glyph::Image),
+                Expr::tbl(Char::Table, Char::Character).equals((Glyph::Table, Glyph::Image)),
             )
             .to_string(SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" INNER JOIN "glyph" ON "character"."character" = "glyph"."image""#
@@ -138,8 +138,8 @@ fn select_10() {
             .left_join(
                 Font::Table,
                 Expr::tbl(Char::Table, Char::FontId)
-                    .equals(Font::Table, Font::Id)
-                    .and(Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)),
+                    .equals((Font::Table, Font::Id))
+                    .and(Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id))),
             )
             .to_string(SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" LEFT JOIN "font" ON ("character"."font_id" = "font"."id") AND ("character"."font_id" = "font"."id")"#
@@ -768,7 +768,7 @@ fn select_50() {
         .from(Char::Table)
         .inner_join(
             Font::Table,
-            Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id),
+            Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id)),
         )
         .to_string(SqliteQueryBuilder);
 
@@ -859,7 +859,7 @@ fn select_54() {
         .expr(Expr::asterisk())
         .from(Char::Table)
         .from(Font::Table)
-        .and_where(Expr::tbl(Font::Table, Font::Id).equals(Char::Table, Char::FontId))
+        .and_where(Expr::tbl(Font::Table, Font::Id).equals((Char::Table, Char::FontId)))
         .to_string(SqliteQueryBuilder);
 
     assert_eq!(
@@ -1514,7 +1514,7 @@ fn union_1() {
                     .from(Char::Table)
                     .left_join(
                         Font::Table,
-                        Expr::tbl(Char::Table, Char::FontId).equals(Font::Table, Font::Id)
+                        Expr::tbl(Char::Table, Char::FontId).equals((Font::Table, Font::Id))
                     )
                     .order_by((Font::Table, Font::Id), Order::Asc)
                     .take()

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -358,7 +358,7 @@ fn select_25() {
             .and_where(
                 Expr::col(Char::SizeW)
                     .mul(2)
-                    .equals(Expr::col(Char::SizeH).div(2))
+                    .eq(Expr::col(Char::SizeH).div(2))
             )
             .to_string(SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE "size_w" * 2 = "size_h" / 2"#
@@ -374,7 +374,7 @@ fn select_26() {
             .and_where(
                 Expr::expr(Expr::col(Char::SizeW).add(1))
                     .mul(2)
-                    .equals(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+                    .eq(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
             )
             .to_string(SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#
@@ -421,7 +421,7 @@ fn select_30() {
                 Expr::col(Char::SizeW)
                     .mul(2)
                     .add(Expr::col(Char::SizeH).div(3))
-                    .equals(4)
+                    .eq(4)
             )
             .to_string(SqliteQueryBuilder),
         r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" * 2) + ("size_h" / 3) = 4"#


### PR DESCRIPTION
## New Features

- Added `SimpleExpr::eq`
- Added `SimpleExpr::ne`
- Added `Expr::not_equals`

## Breaking Changes

- Deprecated `SimpleExpr::equals`
- Deprecated `SimpleExpr::not_equals`
- `Expr::equals` not accept `C: IntoColumntRef` instead `T: IntoIden, C: IntoIden`
