### PR TITLE
[issues-520] Add support postgres `starts_with` function

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -77,6 +77,7 @@ impl QueryBuilder for PostgresQueryBuilder {
                     PgFunction::WebsearchToTsquery => "WEBSEARCH_TO_TSQUERY",
                     PgFunction::TsRank => "TS_RANK",
                     PgFunction::TsRankCd => "TS_RANK_CD",
+                    PgFunction::StartsWith => "STARTS_WITH",
                     #[cfg(feature = "postgres-array")]
                     PgFunction::Any => "ANY",
                     #[cfg(feature = "postgres-array")]

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -12,6 +12,7 @@ pub enum PgFunction {
     WebsearchToTsquery,
     TsRank,
     TsRankCd,
+    StartsWith,
     #[cfg(feature = "postgres-array")]
     Any,
     #[cfg(feature = "postgres-array")]
@@ -310,5 +311,30 @@ impl PgFunc {
         T: Into<SimpleExpr>,
     {
         FunctionCall::new(Function::PgFunction(PgFunction::All)).arg(expr)
+    }
+
+    /// Call `STARTS_WITH` function. Postgres only.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(PgFunc::starts_with("123", "1"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT STARTS_WITH('123', '1')"#
+    /// );
+    /// ```
+    pub fn starts_with<T, P>(text: T, prefix: P) -> FunctionCall
+    where
+        T: Into<SimpleExpr>,
+        P: Into<SimpleExpr>,
+    {
+        FunctionCall::new(Function::PgFunction(PgFunction::StartsWith))
+            .args([text.into(), prefix.into()])
     }
 }

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -339,7 +339,7 @@ impl PgFunc {
         FunctionCall::new(Function::PgFunction(PgFunction::StartsWith))
             .args([text.into(), prefix.into()])
     }
-            
+
     /// Call `GET_RANDOM_UUID` function. Postgres only.
     ///
     /// # Examples

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -323,7 +323,6 @@ impl PgFunc {
     ///
     /// let query = Query::select()
     ///     .expr(PgFunc::starts_with("123", "1"))
-    ///     .expr(PgFunc::get_random_uuid())
     ///     .to_owned();
     ///
     /// assert_eq!(


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-query/issues/520

## New Features

- Added `PgFunc::starts_with`
