### PR TITLE
issues-512 Add `get_random_uuid` function for postgres

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -77,6 +77,7 @@ impl QueryBuilder for PostgresQueryBuilder {
                     PgFunction::WebsearchToTsquery => "WEBSEARCH_TO_TSQUERY",
                     PgFunction::TsRank => "TS_RANK",
                     PgFunction::TsRankCd => "TS_RANK_CD",
+                    PgFunction::GetRandomUUID => "GET_RANDOM_UUID",
                     #[cfg(feature = "postgres-array")]
                     PgFunction::Any => "ANY",
                     #[cfg(feature = "postgres-array")]

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -12,6 +12,7 @@ pub enum PgFunction {
     WebsearchToTsquery,
     TsRank,
     TsRankCd,
+    GetRandomUUID,
     #[cfg(feature = "postgres-array")]
     Any,
     #[cfg(feature = "postgres-array")]
@@ -310,5 +311,25 @@ impl PgFunc {
         T: Into<SimpleExpr>,
     {
         FunctionCall::new(Function::PgFunction(PgFunction::All)).arg(expr)
+    }
+
+    /// Call `ALL` function. Postgres only.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(PgFunc::get_random_uuid())
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT ALL('{0,1}')"#
+    /// );
+    /// ```
+    pub fn get_random_uuid() -> FunctionCall {
+        FunctionCall::new(Function::PgFunction(PgFunction::GetRandomUUID))
     }
 }

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -326,7 +326,7 @@ impl PgFunc {
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT ALL('{0,1}')"#
+    ///     r#"SELECT GET_RANDOM_UUID()"#
     /// );
     /// ```
     pub fn get_random_uuid() -> FunctionCall {


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-query/issues/512

## New Features

- Added `PgFunc::get_random_uuid`
