### PR TITLE
Don't use the sqlx's `macros` feature in sea-query-binder

### DIFF
--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.60"
 
 [dependencies]
 sea-query = { version = "^0.28", path = "..", features = ["thread-safe"] }
-sqlx = { version = "^0.6.1", optional = true }
+sqlx = { version = "^0.6.1", default-features = false, optional = true }
 serde_json = { version = "^1", optional = true }
 chrono = { version = "^0.4", default-features = false, features = ["clock"], optional = true }
 postgres-types = { version = "^0", optional = true }


### PR DESCRIPTION
Hi 😄 

We have a use case where we want to avoid using `sqlx`'s `macros` feature, but it seems that `sea-query-binder` depends on the default features and so on `macros` as well, but as far as I can tell it's not really needed.

## Changes

- [ ] Don't depend on `sqlx`'s default features in `sea-query-binder`
