### PR TITLE
[CI] use `dtolnay/rust-toolchain`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - master
       - pr/**/ci
-      - ci-rust-toolchain
     paths-ignore:
       - '**.md'
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
       - pr/**/ci
+      - ci-rust-toolchain
     paths-ignore:
       - '**.md'
       - '.github/ISSUE_TEMPLATE/**'
@@ -28,205 +29,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        name: Run rustfmt on `sea-query`
-        with:
-          command: fmt
-          args: >
-            --all
-            --
-            --check
-
-      - uses: actions-rs/cargo@v1
-        name: Run rustfmt on `sea-query-binder`
-        with:
-          command: fmt
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --all
-            --
-            --check
-
-      - uses: actions-rs/cargo@v1
-        name: Run rustfmt on `sea-query-rusqlite`
-        with:
-          command: fmt
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --all
-            --
-            --check
-
-      - uses: actions-rs/cargo@v1
-        name: Run rustfmt on `sea-query-postgres`
-        with:
-          command: fmt
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --all
-            --
-            --check
+      - run: cargo fmt --all -- --check
+      - run: cargo fmt --manifest-path sea-query-binder/Cargo.toml --all -- --check
+      - run: cargo fmt --manifest-path sea-query-rusqlite/Cargo.toml --all -- --check
+      - run: cargo fmt --manifest-path sea-query-postgres/Cargo.toml --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
           components: clippy
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        name: Run clippy on `sea-query`
-        with:
-          command: clippy
-          args: >
-            --all-features
-            --workspace
-            --
-            -D warnings
-
-      - uses: actions-rs/cargo@v1
-        name: Run clippy on `sea-query-binder`
-        with:
-          command: clippy
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace
-            --features runtime-async-std-rustls
-            --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array
-            --
-            -D warnings
-
-      - uses: actions-rs/cargo@v1
-        name: Run clippy on `sea-query-rusqlite`
-        with:
-          command: clippy
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --all-features
-            --workspace
-            --
-            -D warnings
-
-      - uses: actions-rs/cargo@v1
-        name: Run clippy on `sea-query-postgres`
-        with:
-          command: clippy
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --all-features
-            --workspace
-            --
-            -D warnings
+      - run: cargo clippy --all-features --workspace -- -D warnings
+      - run: cargo clippy --manifest-path sea-query-binder/Cargo.toml --workspace --features runtime-async-std-rustls --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array -- -D warnings
+      - run: cargo clippy --manifest-path sea-query-rusqlite/Cargo.toml --all-features --workspace -- -D warnings
+      - run: cargo clippy --manifest-path sea-query-postgres/Cargo.toml --all-features --workspace -- -D warnings
 
   build:
     name: Build `sea-query`
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --no-default-features
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --all-features
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --features=with-chrono
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --features=with-json
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --features=with-rust_decimal
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --features=with-bigdecimal
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --features=with-uuid
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --features=with-time
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --features=with-ipnetwork
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --features=with-mac_address
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --features=postgres-array
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --workspace 
-            --features=thread-safe
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --workspace --no-default-features
+      - run: cargo build --workspace --all-features
+      - run: cargo build --workspace --features=with-chrono
+      - run: cargo build --workspace --features=with-json
+      - run: cargo build --workspace --features=with-rust_decimal
+      - run: cargo build --workspace --features=with-bigdecimal
+      - run: cargo build --workspace --features=with-uuid
+      - run: cargo build --workspace --features=with-time
+      - run: cargo build --workspace --features=with-ipnetwork
+      - run: cargo build --workspace --features=with-mac_address
+      - run: cargo build --workspace --features=postgres-array
+      - run: cargo build --workspace --features=thread-safe
 
   binder-build:
     name: Build `sea-query-binder`
@@ -234,300 +77,55 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtime: [ async-std ]
-        tls: [ rustls ]
+        runtime: [async-std]
+        tls: [rustls]
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace 
-            --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql
-            --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace 
-            --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql
-            --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --features=with-chrono
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace 
-            --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql
-            --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --features=with-json
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace 
-            --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql
-            --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --features=with-rust_decimal
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace 
-            --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql
-            --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --features=with-bigdecimal
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace 
-            --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql
-            --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --features=with-uuid
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace 
-            --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql
-            --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --features=with-time
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace 
-            --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql
-            --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --features=with-ipnetwork
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace 
-            --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql
-            --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --features=with-mac_address
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-binder/Cargo.toml
-            --workspace 
-            --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql
-            --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }}
-            --features=postgres-array
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --manifest-path sea-query-binder/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array
+      - run: cargo build --manifest-path sea-query-binder/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-chrono
+      - run: cargo build --manifest-path sea-query-binder/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-json
+      - run: cargo build --manifest-path sea-query-binder/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-rust_decimal
+      - run: cargo build --manifest-path sea-query-binder/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-bigdecimal
+      - run: cargo build --manifest-path sea-query-binder/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-uuid
+      - run: cargo build --manifest-path sea-query-binder/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-time
+      - run: cargo build --manifest-path sea-query-binder/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-ipnetwork
+      - run: cargo build --manifest-path sea-query-binder/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-mac_address
+      - run: cargo build --manifest-path sea-query-binder/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=postgres-array
 
   rusqlite-build:
     name: Build `sea-query-rusqlite`
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --workspace 
-            --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --workspace 
-            --features=with-chrono
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --workspace 
-            --features=with-json
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --workspace 
-            --features=with-rust_decimal
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --workspace 
-            --features=with-bigdecimal
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --workspace 
-            --features=with-uuid
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --workspace 
-            --features=with-time
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --workspace 
-            --features=with-ipnetwork
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --workspace 
-            --features=with-mac_address
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-rusqlite/Cargo.toml
-            --workspace 
-            --features=postgres-array
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-chrono
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-json
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-rust_decimal
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-bigdecimal
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-uuid
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-time
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-ipnetwork
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-mac_address
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=postgres-array
 
   postgres-build:
     name: Build `sea-query-postgres`
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --workspace 
-            --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --workspace 
-            --features=with-chrono
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --workspace 
-            --features=with-json
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --workspace 
-            --features=with-rust_decimal
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --workspace 
-            --features=with-bigdecimal
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --workspace 
-            --features=with-uuid
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --workspace 
-            --features=with-time
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --workspace 
-            --features=with-ipnetwork
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --workspace 
-            --features=with-mac_address
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --manifest-path sea-query-postgres/Cargo.toml
-            --workspace 
-            --features=postgres-array
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-chrono
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-json
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-rust_decimal
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-bigdecimal
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-uuid
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-time
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-ipnetwork
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-mac_address
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=postgres-array
 
   test:
     name: Unit Test
@@ -535,17 +133,8 @@ jobs:
     needs: ["build"]
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --all-features
 
   derive-test:
     name: Derive Tests
@@ -553,24 +142,9 @@ jobs:
     needs: ["build"]
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: Swatinem/rust-cache@v2
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --package sea-query-derive --all-features
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --package sea-query-derive --all-features
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --package sea-query-derive --all-features
+      - run: cargo test --package sea-query-derive --all-features
 
   sqlite:
     name: SQLite
@@ -581,22 +155,9 @@ jobs:
         example: [rusqlite, sqlx_sqlite]
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path examples/${{ matrix.example }}/Cargo.toml
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path examples/${{ matrix.example }}/Cargo.toml
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
+      - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml
 
   mysql:
     name: MySQL
@@ -624,22 +185,9 @@ jobs:
           --health-retries=3
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path examples/${{ matrix.example }}/Cargo.toml
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path examples/${{ matrix.example }}/Cargo.toml
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
+      - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml
 
   mariadb:
     name: MariaDB
@@ -667,22 +215,9 @@ jobs:
           --health-retries=3
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path examples/${{ matrix.example }}/Cargo.toml
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path examples/${{ matrix.example }}/Cargo.toml
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
+      - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml
 
   postgres:
     name: PostgreSQL
@@ -709,19 +244,6 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path examples/${{ matrix.example }}/Cargo.toml
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path examples/${{ matrix.example }}/Cargo.toml
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
+      - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2007,8 +2007,14 @@ impl Expr {
     /// let query = Query::select().expr(Expr::current_date()).to_owned();
     ///
     /// assert_eq!(query.to_string(MysqlQueryBuilder), r#"SELECT CURRENT_DATE"#);
-    /// assert_eq!(query.to_string(PostgresQueryBuilder), r#"SELECT CURRENT_DATE"#);
-    /// assert_eq!(query.to_string(SqliteQueryBuilder), r#"SELECT CURRENT_DATE"#);
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT CURRENT_DATE"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT CURRENT_DATE"#
+    /// );
     /// ```
     pub fn current_date() -> Expr {
         Expr::new_with_left(Keyword::CurrentDate)
@@ -2024,8 +2030,14 @@ impl Expr {
     /// let query = Query::select().expr(Expr::current_time()).to_owned();
     ///
     /// assert_eq!(query.to_string(MysqlQueryBuilder), r#"SELECT CURRENT_TIME"#);
-    /// assert_eq!(query.to_string(PostgresQueryBuilder), r#"SELECT CURRENT_TIME"#);
-    /// assert_eq!(query.to_string(SqliteQueryBuilder), r#"SELECT CURRENT_TIME"#);
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT CURRENT_TIME"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT CURRENT_TIME"#
+    /// );
     /// ```
     pub fn current_time() -> Expr {
         Expr::new_with_left(Keyword::CurrentTime)
@@ -2040,9 +2052,18 @@ impl Expr {
     ///
     /// let query = Query::select().expr(Expr::current_timestamp()).to_owned();
     ///
-    /// assert_eq!(query.to_string(MysqlQueryBuilder), r#"SELECT CURRENT_TIMESTAMP"#);
-    /// assert_eq!(query.to_string(PostgresQueryBuilder), r#"SELECT CURRENT_TIMESTAMP"#);
-    /// assert_eq!(query.to_string(SqliteQueryBuilder), r#"SELECT CURRENT_TIMESTAMP"#);
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT CURRENT_TIMESTAMP"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT CURRENT_TIMESTAMP"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT CURRENT_TIMESTAMP"#
+    /// );
     /// ```
     pub fn current_timestamp() -> Expr {
         Expr::new_with_left(Keyword::CurrentTimestamp)
@@ -2055,7 +2076,9 @@ impl Expr {
     /// ```
     /// use sea_query::*;
     ///
-    /// let query = Query::select().expr(Expr::custom_keyword(Alias::new("test"))).to_owned();
+    /// let query = Query::select()
+    ///     .expr(Expr::custom_keyword(Alias::new("test")))
+    ///     .to_owned();
     ///
     /// assert_eq!(query.to_string(MysqlQueryBuilder), r#"SELECT test"#);
     /// assert_eq!(query.to_string(PostgresQueryBuilder), r#"SELECT test"#);
@@ -2169,7 +2192,7 @@ impl SimpleExpr {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*};
+    /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
     ///     .column(Char::SizeW)
@@ -2264,7 +2287,7 @@ impl SimpleExpr {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*};
+    /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
@@ -2297,7 +2320,7 @@ impl SimpleExpr {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*};
+    /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
@@ -2547,7 +2570,6 @@ impl SimpleExpr {
     ///     query.to_string(SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 10 < "size_w" AND 20 > "size_h""#
     /// );
-    ///
     pub fn binary<O, T>(self, op: O, right: T) -> Self
     where
         O: Into<BinOper>,

--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -7,17 +7,12 @@ pub trait PgExpr: Expression {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::postgres::PgExpr};
+    /// use sea_query::{extension::postgres::PgExpr, tests_cfg::*, *};
     ///
     /// let query = Query::select()
     ///     .columns([Font::Name, Font::Variant, Font::Language])
     ///     .from(Font::Table)
-    ///     .and_where(
-    ///         Expr::val("a")
-    ///             .concatenate("b")
-    ///             .concat("c")
-    ///             .concat("d"),
-    ///     )
+    ///     .and_where(Expr::val("a").concatenate("b").concat("c").concat("d"))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -249,9 +249,7 @@ impl PgFunc {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let query = Query::select()
-    ///     .expr(PgFunc::any(vec![0, 1]))
-    ///     .to_owned();
+    /// let query = Query::select().expr(PgFunc::any(vec![0, 1])).to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
@@ -273,9 +271,7 @@ impl PgFunc {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let query = Query::select()
-    ///     .expr(PgFunc::some(vec![0, 1]))
-    ///     .to_owned();
+    /// let query = Query::select().expr(PgFunc::some(vec![0, 1])).to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
@@ -297,9 +293,7 @@ impl PgFunc {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let query = Query::select()
-    ///     .expr(PgFunc::all(vec![0, 1]))
-    ///     .to_owned();
+    /// let query = Query::select().expr(PgFunc::all(vec![0, 1])).to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
@@ -346,9 +340,7 @@ impl PgFunc {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let query = Query::select()
-    ///     .expr(PgFunc::get_random_uuid())
-    ///     .to_owned();
+    /// let query = Query::select().expr(PgFunc::get_random_uuid()).to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),

--- a/src/extension/sqlite/expr.rs
+++ b/src/extension/sqlite/expr.rs
@@ -8,7 +8,7 @@ pub trait SqliteExpr: Expression {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::sqlite::SqliteExpr};
+    /// use sea_query::{extension::sqlite::SqliteExpr, tests_cfg::*, *};
     ///
     /// let query = Query::select()
     ///     .column(Font::Name)
@@ -33,7 +33,7 @@ pub trait SqliteExpr: Expression {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::sqlite::SqliteExpr};
+    /// use sea_query::{extension::sqlite::SqliteExpr, tests_cfg::*, *};
     ///
     /// let query = Query::select()
     ///     .column(Font::Variant)
@@ -58,7 +58,7 @@ pub trait SqliteExpr: Expression {
     /// # Examples
     ///
     /// ```
-    /// use sea_query::{*, tests_cfg::*, extension::sqlite::SqliteExpr};
+    /// use sea_query::{extension::sqlite::SqliteExpr, tests_cfg::*, *};
     ///
     /// let query = Query::select()
     ///     .column(Font::Variant)

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -963,10 +963,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .column(ColumnRef::Asterisk)
-    ///     .from_function(
-    ///         Func::random(),
-    ///         Alias::new("func"),
-    ///     )
+    ///     .from_function(Func::random(), Alias::new("func"))
     ///     .to_owned();
     ///
     /// assert_eq!(


### PR DESCRIPTION
## Changes

- [x] CI: replace the use of [actions-rs/toolchain](https://github.com/actions-rs/toolchain) and [actions-rs/cargo](https://github.com/actions-rs/cargo) with [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain). Because the former projects are not actively maintained.
- [x] Eliminate the deprecated warning messages
  - https://github.com/actions-rs/toolchain/pull/220
  - https://github.com/actions-rs/cargo/pull/217
