### PR TITLE
Cleaning up dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,19 +27,19 @@ name = "sea_query"
 path = "src/lib.rs"
 
 [dependencies]
-sea-query-attr = { version = "0.1.1", path = "sea-query-attr", optional = true }
-sea-query-derive = { version = "0.3.0", path = "sea-query-derive", optional = true }
-serde_json = { version = "1", optional = true }
-chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
-postgres-types = { version = "0", optional = true }
-rust_decimal = { version = "1", optional = true }
-bigdecimal = { version = "0.3", optional = true }
-uuid = { version = "1", optional = true }
-proc-macro2 = { version = "1", optional = true }
-quote = { version = "1", optional = true }
-time = { version = "0.3", optional = true, features = ["macros", "formatting"] }
-ipnetwork = { version = "0.19", optional = true }
-mac_address = { version = "1.1", optional = true }
+sea-query-attr = { version = "0.1.1", path = "sea-query-attr", default-features = false, optional = true }
+sea-query-derive = { version = "0.3.0", path = "sea-query-derive", default-features = false, optional = true }
+serde_json = { version = "1", default-features = false, optional = true }
+chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }
+postgres-types = { version = "0", default-features = false, optional = true }
+rust_decimal = { version = "1", default-features = false, optional = true }
+bigdecimal = { version = "0.3", default-features = false, optional = true }
+uuid = { version = "1", default-features = false, optional = true }
+proc-macro2 = { version = "1", default-features = false, optional = true }
+quote = { version = "1", default-features = false, optional = true }
+time = { version = "0.3", default-features = false, optional = true, features = ["macros", "formatting"] }
+ipnetwork = { version = "0.19", default-features = false, optional = true }
+mac_address = { version = "1.1", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,23 +27,23 @@ name = "sea_query"
 path = "src/lib.rs"
 
 [dependencies]
-sea-query-attr = { version = "^0.1.1", path = "sea-query-attr", optional = true }
-sea-query-derive = { version = "^0.3.0", path = "sea-query-derive", optional = true }
-serde_json = { version = "^1", optional = true }
-chrono = { version = "^0.4", default-features = false, features = ["clock"], optional = true }
-postgres-types = { version = "^0", optional = true }
-rust_decimal = { version = "^1", optional = true }
-bigdecimal = { version = "^0.3", optional = true }
-uuid = { version = "^1", optional = true }
+sea-query-attr = { version = "0.1.1", path = "sea-query-attr", optional = true }
+sea-query-derive = { version = "0.3.0", path = "sea-query-derive", optional = true }
+serde_json = { version = "1", optional = true }
+chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
+postgres-types = { version = "0", optional = true }
+rust_decimal = { version = "1", optional = true }
+bigdecimal = { version = "0.3", optional = true }
+uuid = { version = "1", optional = true }
 proc-macro2 = { version = "1", optional = true }
-quote = { version = "^1", optional = true }
-time = { version = "^0.3", optional = true, features = ["macros", "formatting"] }
-ipnetwork = { version = "^0.19", optional = true }
-mac_address = { version = "^1.1", optional = true }
+quote = { version = "1", optional = true }
+time = { version = "0.3", optional = true, features = ["macros", "formatting"] }
+ipnetwork = { version = "0.19", optional = true }
+mac_address = { version = "1.1", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
-pretty_assertions = { version = "^1" }
+pretty_assertions = { version = "1" }
 
 [features]
 backend-mysql = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/lib.rs"
 [dependencies]
 sea-query-attr = { version = "0.1.1", path = "sea-query-attr", default-features = false, optional = true }
 sea-query-derive = { version = "0.3.0", path = "sea-query-derive", default-features = false, optional = true }
-serde_json = { version = "1", default-features = false, optional = true }
+serde_json = { version = "1", default-features = false, optional = true, features = ["std"] }
 chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }
 postgres-types = { version = "0", default-features = false, optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Join our Discord server to chat with others in the SeaQL community!
 ```toml
 # Cargo.toml
 [dependencies]
-sea-query = "^0"
+sea-query = "0"
 ```
 
 SeaQuery is very lightweight, all dependencies are optional.

--- a/examples/postgres/Cargo.toml
+++ b/examples/postgres/Cargo.toml
@@ -7,12 +7,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "^0.4", default-features = false, features = ["clock"] }
-time = { version = "^0.3", features = ["macros"] }
-uuid = { version = "^1", features = ["serde", "v4"] }
-serde_json = "^1"
-rust_decimal = { version = "^1" }
-postgres = "^0.19"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+time = { version = "0.3", features = ["macros"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+serde_json = "1"
+rust_decimal = { version = "1" }
+postgres = "0.19"
 sea-query = { path = "../../"}
 sea-query-postgres = { path = "../../sea-query-postgres", features = [
     "with-uuid",
@@ -23,5 +23,5 @@ sea-query-postgres = { path = "../../sea-query-postgres", features = [
     "with-rust_decimal"
 ] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0" }
-# sea-query-postgres = { version = "^0", features = [...] }
+# sea-query = { version = "0" }
+# sea-query-postgres = { version = "0", features = [...] }

--- a/examples/rusqlite/Cargo.toml
+++ b/examples/rusqlite/Cargo.toml
@@ -7,12 +7,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "^0.4", default-features = false, features = ["clock"] }
-time = { version = "^0.3", features = ["parsing", "macros"] }
-serde_json = { version = "^1" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+time = { version = "0.3", features = ["parsing", "macros"] }
+serde_json = { version = "1" }
 # rusqlite only supports uuid 0
-uuid = { version = "^1", features = ["serde", "v4"] }
-rusqlite = "^0.28"
+uuid = { version = "1", features = ["serde", "v4"] }
+rusqlite = "0.28"
 sea-query = { path = "../.."}
 sea-query-rusqlite = { path = "../../sea-query-rusqlite", features = [
     "with-chrono",
@@ -22,5 +22,5 @@ sea-query-rusqlite = { path = "../../sea-query-rusqlite", features = [
 ] }
 
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0"}
-# sea-query-rusqlite = { version = "^0", features = [...] }
+# sea-query = { version = "0"}
+# sea-query-rusqlite = { version = "0", features = [...] }

--- a/examples/sqlx_any/Cargo.toml
+++ b/examples/sqlx_any/Cargo.toml
@@ -7,14 +7,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "^0.4", default-features = false, features = ["clock"] }
-time = "^0.3"
-uuid = { version = "^1", features = ["serde", "v4"] }
-serde_json = "^1"
-rust_decimal = { version = "^1" }
-bigdecimal = { version = "^0.3" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+time = "0.3"
+uuid = { version = "1", features = ["serde", "v4"] }
+serde_json = "1"
+rust_decimal = { version = "1" }
+bigdecimal = { version = "0.3" }
 async-std = { version = "1.8", features = [ "attributes" ] }
-sqlx = "^0.6"
+sqlx = "0.6"
 sea-query = { path = "../../" }
 sea-query-binder = { path = "../../sea-query-binder", features = [
     "sqlx-postgres",
@@ -32,5 +32,5 @@ sea-query-binder = { path = "../../sea-query-binder", features = [
 ] }
 
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0"}
-# sea-query-binder = { version = "^0", features = [...] }
+# sea-query = { version = "0"}
+# sea-query-binder = { version = "0", features = [...] }

--- a/examples/sqlx_mysql/Cargo.toml
+++ b/examples/sqlx_mysql/Cargo.toml
@@ -7,14 +7,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "^0.4", default-features = false, features = ["clock"] }
-time = { version = "^0.3", features = ["macros"] }
-uuid = { version = "^1", features = ["serde", "v4"] }
-serde_json = "^1"
-rust_decimal = { version = "^1" }
-bigdecimal = { version = "^0.3" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+time = { version = "0.3", features = ["macros"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+serde_json = "1"
+rust_decimal = { version = "1" }
+bigdecimal = { version = "0.3" }
 async-std = { version = "1.8", features = [ "attributes" ] }
-sqlx = "^0.6"
+sqlx = "0.6"
 sea-query = { path = "../../" }
 sea-query-binder = { path = "../../sea-query-binder", features = [
     "sqlx-mysql",
@@ -28,5 +28,5 @@ sea-query-binder = { path = "../../sea-query-binder", features = [
 ] }
 
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0", features = [] }
-# # sea-query-binder = { version = "^0", features = [...] }
+# sea-query = { version = "0", features = [] }
+# # sea-query-binder = { version = "0", features = [...] }

--- a/examples/sqlx_postgres/Cargo.toml
+++ b/examples/sqlx_postgres/Cargo.toml
@@ -7,16 +7,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "^0.4", default-features = false, features = ["clock"] }
-time = { version = "^0.3", features = ["macros"] }
-uuid = { version = "^1", features = ["serde", "v4"] }
-serde_json = "^1"
-rust_decimal = { version = "^1" }
-bigdecimal = { version = "^0.3" }
-ipnetwork = { version = "^0.19" }
-mac_address = { version = "^1.1" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+time = { version = "0.3", features = ["macros"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+serde_json = "1"
+rust_decimal = { version = "1" }
+bigdecimal = { version = "0.3" }
+ipnetwork = { version = "0.19" }
+mac_address = { version = "1.1" }
 async-std = { version = "1.8", features = [ "attributes" ] }
-sqlx = "^0.6"
+sqlx = "0.6"
 sea-query = { path = "../../" }
 sea-query-binder = { path = "../../sea-query-binder", features = [
     "sqlx-postgres",
@@ -32,5 +32,5 @@ sea-query-binder = { path = "../../sea-query-binder", features = [
 ] }
 
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0" }
-# sea-query-binder = { version = "^0", features = [...] }
+# sea-query = { version = "0" }
+# sea-query-binder = { version = "0", features = [...] }

--- a/examples/sqlx_sqlite/Cargo.toml
+++ b/examples/sqlx_sqlite/Cargo.toml
@@ -7,12 +7,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "^0.4", default-features = false, features = ["clock"] }
-time = { version = "^0.3", features = ["macros"] }
-uuid = { version = "^1", features = ["serde", "v4"] }
-serde_json = "^1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+time = { version = "0.3", features = ["macros"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+serde_json = "1"
 async-std = { version = "1.8", features = [ "attributes" ] }
-sqlx = "^0.6.1"
+sqlx = "0.6.1"
 sea-query = { path = "../../" }
 sea-query-binder = { path = "../../sea-query-binder", features = [
     "sqlx-sqlite",
@@ -23,5 +23,5 @@ sea-query-binder = { path = "../../sea-query-binder", features = [
     "runtime-async-std-native-tls",
 ] }
 # NOTE: if you are copying this example into your own project, use the following line instead:
-# sea-query = { version = "^0", features = [] }
-# sea-query-binder = { version = "^0", features = [] }
+# sea-query = { version = "0", features = [] }
+# sea-query-binder = { version = "0", features = [] }

--- a/sea-query-attr/Cargo.toml
+++ b/sea-query-attr/Cargo.toml
@@ -15,10 +15,10 @@ rust-version = "1.60"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", default-features = false, features = [ "derive", "parsing", "proc-macro", "printing" ] }
-quote = "1"
-heck = "0.4"
-darling = "0.14"
+syn = { version = "1", default-features = false }
+quote = { version = "1", default-features = false }
+heck = { version = "0.4", default-features = false }
+darling = { version = "0.14", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/sea-query-attr/Cargo.toml
+++ b/sea-query-attr/Cargo.toml
@@ -15,12 +15,12 @@ rust-version = "1.60"
 proc-macro = true
 
 [dependencies]
-syn = { version = "^1", default-features = false, features = [ "derive", "parsing", "proc-macro", "printing" ] }
-quote = "^1"
-heck = "^0.4"
-darling = "^0.14"
+syn = { version = "1", default-features = false, features = [ "derive", "parsing", "proc-macro", "printing" ] }
+quote = "1"
+heck = "0.4"
+darling = "0.14"
 
 [dev-dependencies]
-trybuild = "^1.0"
-sea-query = { version = "^0", path = ".." }
-strum = { version = "^0.24", features = ["derive"] }
+trybuild = "1.0"
+sea-query = { version = "0", path = ".." }
+strum = { version = "0.24", features = ["derive"] }

--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -17,19 +17,19 @@ rust-version = "1.60"
 [lib]
 
 [dependencies]
-sea-query = { version = "^0.28", path = "..", features = ["thread-safe"] }
-sqlx = { version = "^0.6.1", default-features = false, optional = true }
-serde_json = { version = "^1", optional = true }
-chrono = { version = "^0.4", default-features = false, features = ["clock"], optional = true }
-postgres-types = { version = "^0", optional = true }
-rust_decimal = { version = "^1", optional = true }
-bigdecimal = { version = "^0.3", optional = true }
-uuid = { version = "^1", optional = true }
+sea-query = { version = "0.28", path = "..", features = ["thread-safe"] }
+sqlx = { version = "0.6.1", default-features = false, optional = true }
+serde_json = { version = "1", optional = true }
+chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
+postgres-types = { version = "0", optional = true }
+rust_decimal = { version = "1", optional = true }
+bigdecimal = { version = "0.3", optional = true }
+uuid = { version = "1", optional = true }
 proc-macro2 = { version = "1", optional = true }
-quote = { version = "^1", optional = true }
-time = { version = "^0.3", optional = true, features = ["macros", "formatting"] }
-ipnetwork = { version = "^0.19", optional = true }
-mac_address = { version = "^1.1", optional = true }
+quote = { version = "1", optional = true }
+time = { version = "0.3", optional = true, features = ["macros", "formatting"] }
+ipnetwork = { version = "0.19", optional = true }
+mac_address = { version = "1.1", optional = true }
 
 [features]
 sqlx-mysql = ["sqlx/mysql"]

--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -17,19 +17,19 @@ rust-version = "1.60"
 [lib]
 
 [dependencies]
-sea-query = { version = "0.28", path = "..", features = ["thread-safe"] }
+sea-query = { version = "0.28", path = "..", default-features = false, features = ["thread-safe"] }
 sqlx = { version = "0.6.1", default-features = false, optional = true }
-serde_json = { version = "1", optional = true }
-chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
-postgres-types = { version = "0", optional = true }
-rust_decimal = { version = "1", optional = true }
-bigdecimal = { version = "0.3", optional = true }
-uuid = { version = "1", optional = true }
-proc-macro2 = { version = "1", optional = true }
-quote = { version = "1", optional = true }
-time = { version = "0.3", optional = true, features = ["macros", "formatting"] }
-ipnetwork = { version = "0.19", optional = true }
-mac_address = { version = "1.1", optional = true }
+serde_json = { version = "1", default-features = false, optional = true }
+chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }
+postgres-types = { version = "0", default-features = false, optional = true }
+rust_decimal = { version = "1", default-features = false, optional = true }
+bigdecimal = { version = "0.3", default-features = false, optional = true }
+uuid = { version = "1", default-features = false, optional = true }
+proc-macro2 = { version = "1", default-features = false, optional = true }
+quote = { version = "1", default-features = false, optional = true }
+time = { version = "0.3", default-features = false, optional = true, features = ["macros", "formatting"] }
+ipnetwork = { version = "0.19", default-features = false, optional = true }
+mac_address = { version = "1.1", default-features = false, optional = true }
 
 [features]
 sqlx-mysql = ["sqlx/mysql"]

--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.60"
 [dependencies]
 sea-query = { version = "0.28", path = "..", default-features = false, features = ["thread-safe"] }
 sqlx = { version = "0.6.1", default-features = false, optional = true }
-serde_json = { version = "1", default-features = false, optional = true }
+serde_json = { version = "1", default-features = false, optional = true, features = ["std"] }
 chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }
 postgres-types = { version = "0", default-features = false, optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }

--- a/sea-query-derive/Cargo.toml
+++ b/sea-query-derive/Cargo.toml
@@ -19,9 +19,9 @@ syn = { version = "1", default-features = false, features = [ "derive", "parsing
 quote = "1"
 heck = "0.4"
 proc-macro2 = "1"
-thiserror = "^1.0"
+thiserror = "1.0"
 
 [dev-dependencies]
-trybuild = "^1.0"
-sea-query = { version = "^0", path = ".." }
-strum = { version = "^0.24", features = ["derive"] }
+trybuild = "1.0"
+sea-query = { version = "0", path = ".." }
+strum = { version = "0.24", features = ["derive"] }

--- a/sea-query-derive/Cargo.toml
+++ b/sea-query-derive/Cargo.toml
@@ -15,11 +15,11 @@ rust-version = "1.60"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", default-features = false, features = [ "derive", "parsing", "proc-macro", "printing" ] }
-quote = "1"
-heck = "0.4"
-proc-macro2 = "1"
-thiserror = "1.0"
+syn = { version = "1", default-features = false }
+quote = { version = "1", default-features = false }
+heck = { version = "0.4", default-features = false }
+proc-macro2 = { version = "1", default-features = false }
+thiserror = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/sea-query-postgres/Cargo.toml
+++ b/sea-query-postgres/Cargo.toml
@@ -17,15 +17,15 @@ rust-version = "1.60"
 [lib]
 
 [dependencies]
-sea-query = { version = "^0.28", path = ".." }
-postgres-types = { version = "^0.2" }
-bytes = { version = "^1" }
-rust_decimal = { version = "^1", optional = true }
-bigdecimal = { version = "^0.3", optional = true }
-ipnetwork = { version = "^0.19", optional = true }
-mac_address = { version = "^1.1", optional = true }
-eui48 = { version = "^1", optional = true }
-cidr = { version = "^0.2", optional = true }
+sea-query = { version = "0.28", path = ".." }
+postgres-types = { version = "0.2" }
+bytes = { version = "1" }
+rust_decimal = { version = "1", optional = true }
+bigdecimal = { version = "0.3", optional = true }
+ipnetwork = { version = "0.19", optional = true }
+mac_address = { version = "1.1", optional = true }
+eui48 = { version = "1", optional = true }
+cidr = { version = "0.2", optional = true }
 
 [features]
 with-chrono = ["postgres-types/with-chrono-0_4", "sea-query/with-chrono"]

--- a/sea-query-postgres/Cargo.toml
+++ b/sea-query-postgres/Cargo.toml
@@ -17,15 +17,15 @@ rust-version = "1.60"
 [lib]
 
 [dependencies]
-sea-query = { version = "0.28", path = ".." }
-postgres-types = { version = "0.2" }
-bytes = { version = "1" }
-rust_decimal = { version = "1", optional = true }
-bigdecimal = { version = "0.3", optional = true }
-ipnetwork = { version = "0.19", optional = true }
-mac_address = { version = "1.1", optional = true }
-eui48 = { version = "1", optional = true }
-cidr = { version = "0.2", optional = true }
+sea-query = { version = "0.28", path = "..", default-features = false }
+postgres-types = { version = "0.2", default-features = false }
+bytes = { version = "1", default-features = false }
+rust_decimal = { version = "1", default-features = false, optional = true }
+bigdecimal = { version = "0.3", default-features = false, optional = true }
+ipnetwork = { version = "0.19", default-features = false, optional = true }
+mac_address = { version = "1.1", default-features = false, optional = true }
+eui48 = { version = "1", default-features = false, optional = true }
+cidr = { version = "0.2", default-features = false, optional = true }
 
 [features]
 with-chrono = ["postgres-types/with-chrono-0_4", "sea-query/with-chrono"]

--- a/sea-query-rusqlite/Cargo.toml
+++ b/sea-query-rusqlite/Cargo.toml
@@ -17,8 +17,8 @@ rust-version = "1.60"
 [lib]
 
 [dependencies]
-sea-query = { version = "^0.28", path = ".." }
-rusqlite = { package = "rusqlite", version = "^0.28", features = ["bundled"] }
+sea-query = { version = "0.28", path = ".." }
+rusqlite = { package = "rusqlite", version = "0.28", features = ["bundled"] }
 
 [features]
 with-chrono = ["rusqlite/chrono", "sea-query/with-chrono"]

--- a/sea-query-rusqlite/Cargo.toml
+++ b/sea-query-rusqlite/Cargo.toml
@@ -17,8 +17,8 @@ rust-version = "1.60"
 [lib]
 
 [dependencies]
-sea-query = { version = "0.28", path = ".." }
-rusqlite = { package = "rusqlite", version = "0.28", features = ["bundled"] }
+sea-query = { version = "0.28", path = "..", default-features = false }
+rusqlite = { version = "0.28", default-features = false, features = ["bundled"] }
 
 [features]
 with-chrono = ["rusqlite/chrono", "sea-query/with-chrono"]
@@ -30,4 +30,3 @@ with-time = ["rusqlite/time", "sea-query/with-time"]
 with-ipnetwork = ["sea-query/with-ipnetwork"]
 with-mac_address = ["sea-query/with-mac_address"]
 postgres-array = ["sea-query/postgres-array"]
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! ```toml
 //! # Cargo.toml
 //! [dependencies]
-//! sea-query = "^0"
+//! sea-query = "0"
 //! ```
 //!
 //! SeaQuery is very lightweight, all dependencies are optional.


### PR DESCRIPTION
## PR Info

> Caret requirements are an alternative syntax for the default strategy, `^1.2.3` is exactly equivalent to `1.2.3`.
> 
> https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements

To make the dependency specification clear and concise, I'd like to define it all in the form of `x.y.z`.

## Changes

- [x] changed all `version = "^x.y.z"` into `version = "x.y.z"`
- [x] disable default features and enable only the needed ones
