### PR TITLE
feat: Remove deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ assert_eq!(
 
 ```rust
 let query = Query::select()
-    .expr(Func::sum(Expr::tbl(Char::Table, Char::SizeH)))
+    .expr(Func::sum(Expr::col((Char::Table, Char::SizeH))))
     .from(Char::Table)
     .to_owned();
 assert_eq!(

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -301,15 +301,6 @@ impl Expr {
         Self::col(ColumnRef::TableAsterisk(t.into_iden()))
     }
 
-    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::col`]")]
-    pub fn tbl<T, C>(t: T, c: C) -> Self
-    where
-        T: IntoIden,
-        C: IntoIden,
-    {
-        Self::col((t.into_iden(), c.into_iden()))
-    }
-
     /// Express a [`Value`], returning a [`Expr`].
     ///
     /// # Examples
@@ -2116,46 +2107,6 @@ impl Expr {
     {
         Expr::new_with_left(Keyword::Custom(i.into_iden()))
     }
-
-    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::gt`]")]
-    pub fn greater_than<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(BinOper::GreaterThan, expr)
-    }
-
-    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::gte`]")]
-    pub fn greater_or_equal<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(BinOper::GreaterThanOrEqual, expr)
-    }
-
-    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::lt`]")]
-    pub fn less_than<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(BinOper::SmallerThan, expr)
-    }
-
-    #[deprecated(since = "0.28.0", note = "Please use the [`Expr::lte`]")]
-    pub fn less_or_equal<T>(self, expr: T) -> SimpleExpr
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(BinOper::SmallerThanOrEqual, expr)
-    }
-
-    #[deprecated(
-        since = "0.28.0",
-        note = "Please use the [`Into::<SimpleExpr>::into()`]"
-    )]
-    pub fn into_simple_expr(self) -> SimpleExpr {
-        self.into()
-    }
 }
 
 impl From<Expr> for SimpleExpr {
@@ -2372,22 +2323,6 @@ impl SimpleExpr {
         V: Into<SimpleExpr>,
     {
         self.binary(BinOper::NotEqual, v)
-    }
-
-    #[deprecated(since = "0.28.0", note = "Please use the [`SimpleExpr::eq`]")]
-    pub fn equals<T>(self, right: T) -> Self
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(BinOper::Equal, right)
-    }
-
-    #[deprecated(since = "0.28.0", note = "Please use the [`SimpleExpr::ne`]")]
-    pub fn not_equals<T>(self, right: T) -> Self
-    where
-        T: Into<SimpleExpr>,
-    {
-        self.binary(BinOper::NotEqual, right)
     }
 
     /// Perform addition with another [`SimpleExpr`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,7 @@
 //! ```rust
 //! # use sea_query::{*, tests_cfg::*};
 //! let query = Query::select()
-//!     .expr(Func::sum(Expr::tbl(Char::Table, Char::SizeH)))
+//!     .expr(Func::sum(Expr::col((Char::Table, Char::SizeH))))
 //!     .from(Char::Table)
 //!     .to_owned();
 //! assert_eq!(

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -255,25 +255,6 @@ impl InsertStatement {
         self.values(values).unwrap()
     }
 
-    #[deprecated(since = "0.27.0", note = "Please use the [`InsertStatement::values`]")]
-    pub fn exprs<I>(&mut self, values: I) -> Result<&mut Self>
-    where
-        I: IntoIterator<Item = SimpleExpr>,
-    {
-        self.values(values)
-    }
-
-    #[deprecated(
-        since = "0.27.0",
-        note = "Please use the [`InsertStatement::values_panic`]"
-    )]
-    pub fn exprs_panic<I>(&mut self, values: I) -> &mut Self
-    where
-        I: IntoIterator<Item = SimpleExpr>,
-    {
-        self.values_panic(values)
-    }
-
     /// ON CONFLICT expression
     ///
     /// # Examples

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -115,41 +115,6 @@ impl OnConflict {
         self
     }
 
-    #[deprecated(since = "0.27.0", note = "Please use the [`OnConflict::value`]")]
-    pub fn update_value<C>(&mut self, column_value: (C, Value)) -> &mut Self
-    where
-        C: IntoIden,
-    {
-        self.value(column_value.0, column_value.1)
-    }
-
-    #[deprecated(since = "0.27.0", note = "Please use the [`OnConflict::values`]")]
-    pub fn update_values<C, I>(&mut self, column_values: I) -> &mut Self
-    where
-        C: IntoIden,
-        I: IntoIterator<Item = (C, Value)>,
-    {
-        self.values(column_values.into_iter().map(|(c, v)| (c, v.into())))
-    }
-
-    #[deprecated(since = "0.27.0", note = "Please use the [`OnConflict::value`]")]
-    pub fn update_expr<C, E>(&mut self, col_expr: (C, E)) -> &mut Self
-    where
-        C: IntoIden,
-        E: Into<SimpleExpr>,
-    {
-        self.value(col_expr.0, col_expr.1)
-    }
-
-    #[deprecated(since = "0.27.0", note = "Please use the [`OnConflict::values`]")]
-    pub fn update_exprs<C, I>(&mut self, values: I) -> &mut Self
-    where
-        C: IntoIden,
-        I: IntoIterator<Item = (C, SimpleExpr)>,
-    {
-        self.values(values)
-    }
-
     /// Set ON CONFLICT update exprs
     ///
     /// # Examples

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -1,4 +1,4 @@
-use crate::{ConditionHolder, DynIden, IntoCondition, IntoIden, SimpleExpr, Value};
+use crate::{ConditionHolder, DynIden, IntoCondition, IntoIden, SimpleExpr};
 
 #[derive(Debug, Clone, Default)]
 pub struct OnConflict {

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -141,33 +141,6 @@ impl UpdateStatement {
         self
     }
 
-    #[deprecated(since = "0.27.0", note = "Please use the [`UpdateStatement::values`]")]
-    pub fn exprs<T, I>(&mut self, values: I) -> &mut Self
-    where
-        T: IntoIden,
-        I: IntoIterator<Item = (T, SimpleExpr)>,
-    {
-        self.values(values)
-    }
-
-    #[deprecated(since = "0.27.0", note = "Please use the [`UpdateStatement::value`]")]
-    pub fn col_expr<C, T>(&mut self, col: C, expr: T) -> &mut Self
-    where
-        C: IntoIden,
-        T: Into<SimpleExpr>,
-    {
-        self.value(col, expr)
-    }
-
-    #[deprecated(since = "0.27.0", note = "Please use the [`UpdateStatement::value`]")]
-    pub fn value_expr<C, T>(&mut self, col: C, expr: T) -> &mut Self
-    where
-        C: IntoIden,
-        T: Into<SimpleExpr>,
-    {
-        self.value(col, expr)
-    }
-
     /// Limit number of updated rows.
     pub fn limit(&mut self, limit: u64) -> &mut Self {
         self.limit = Some(limit.into());


### PR DESCRIPTION
## Breaking Changes

- Removed `Expr::tbl`, `Expr::greater_than`, `Expr::greater_or_equal`, `Expr::less_than`, `Expr::less_or_equal`, `Expr::into_simple_expr`,
- Removed `SimpleExpr::equals` and `SimpleExpr::not_equals`
- Removed `InsertStatement::exprs`, `InsertStatement::exprs_panic`
- Removed `OnConflict::update_value`, `OnConflict::update_values`, `OnConflict::update_expr`, `OnConflict::update_exprs`
- Removed `UpdateStatement::exprs`, `UpdateStatement::col_expr`, `UpdateStatement::value_expr`