### PR TITLE
Support uuid::fmt::Hyphenated

### DIFF
--- a/sea-query-binder/src/sqlx_any.rs
+++ b/sea-query-binder/src/sqlx_any.rs
@@ -93,6 +93,10 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::any::Any> for SqlxValues {
                 Value::Uuid(_) => {
                     panic!("UUID support not implemented for Any");
                 }
+                #[cfg(feature = "with-uuid")]
+                Value::UuidHyphenated(uuid_hyphenated) => {
+                    args.add(uuid_hyphenated.map(|hyphenated| hyphenated.to_string()))
+                }
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(_) => {
                     panic!("Sqlite doesn't support decimal arguments");

--- a/sea-query-binder/src/sqlx_mysql.rs
+++ b/sea-query-binder/src/sqlx_mysql.rs
@@ -93,6 +93,8 @@ impl sqlx::IntoArguments<'_, sqlx::mysql::MySql> for SqlxValues {
                 Value::Uuid(uuid) => {
                     args.add(uuid.as_deref());
                 }
+                #[cfg(feature = "with-uuid")]
+                Value::UuidHyphenated(uuid_hyphenated) => args.add(uuid_hyphenated.as_deref()),
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(d) => {
                     args.add(d.as_deref());

--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -93,6 +93,10 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 Value::Uuid(uuid) => {
                     args.add(uuid.map(|uuid| *uuid));
                 }
+                #[cfg(feature = "with-uuid")]
+                Value::UuidHyphenated(uuid_hyphenated) => {
+                    args.add(uuid_hyphenated.map(|hyphenated| *hyphenated));
+                }
                 #[cfg(feature = "with-rust_decimal")]
                 Value::Decimal(decimal) => {
                     use rust_decimal::prelude::ToPrimitive;

--- a/sea-query-postgres/src/lib.rs
+++ b/sea-query-postgres/src/lib.rs
@@ -107,6 +107,11 @@ impl ToSql for PostgresValue {
             }
             #[cfg(feature = "with-uuid")]
             Value::Uuid(v) => v.as_deref().to_sql(ty, out),
+            #[cfg(feature = "with-uuid")]
+            Value::UuidHyphenated(uuid_hyphenated) => uuid_hyphenated
+                .as_ref()
+                .map(|hyphenated| hyphenated.to_string())
+                .to_sql(ty, out),
             #[cfg(feature = "postgres-array")]
             Value::Array(_, Some(v)) => v
                 .iter()

--- a/sea-query-rusqlite/src/lib.rs
+++ b/sea-query-rusqlite/src/lib.rs
@@ -107,6 +107,12 @@ impl ToSql for RusqliteValue {
             }
             #[cfg(feature = "with-uuid")]
             Value::Uuid(v) => box_to_sql!(v),
+            #[cfg(feature = "with-uuid")]
+            Value::UuidHyphenated(uuid_hyphenated) => {
+                opt_string_to_sql!(uuid_hyphenated
+                    .as_ref()
+                    .map(|hyphenated| hyphenated.to_string()))
+            }
             #[cfg(feature = "with-json")]
             Value::Json(j) => box_to_sql!(j),
             #[cfg(feature = "with-rust_decimal")]

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -969,6 +969,8 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-uuid")]
+            Value::UuidHyphenated(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-ipnetwork")]
             Value::IpNetwork(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-mac_address")]
@@ -1043,6 +1045,8 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             Value::BigDecimal(Some(v)) => write!(s, "{}", v).unwrap(),
             #[cfg(feature = "with-uuid")]
             Value::Uuid(Some(v)) => write!(s, "'{}'", v).unwrap(),
+            #[cfg(feature = "with-uuid")]
+            Value::UuidHyphenated(Some(v)) => write!(s, "'{}'", v).unwrap(),
             #[cfg(feature = "postgres-array")]
             Value::Array(_, Some(v)) => write!(
                 s,

--- a/src/value.rs
+++ b/src/value.rs
@@ -99,6 +99,10 @@ pub enum ArrayType {
     #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
     Uuid,
 
+    #[cfg(feature = "with-uuid")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
+    UuidHyphenated,
+
     #[cfg(feature = "with-rust_decimal")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-rust_decimal")))]
     Decimal,
@@ -185,6 +189,10 @@ pub enum Value {
     #[cfg(feature = "with-uuid")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
     Uuid(Option<Box<Uuid>>),
+
+    #[cfg(feature = "with-uuid")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "with-uuid")))]
+    UuidHyphenated(Option<Box<uuid::fmt::Hyphenated>>),
 
     #[cfg(feature = "with-rust_decimal")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-rust_decimal")))]
@@ -667,6 +675,7 @@ mod with_uuid {
     use super::*;
 
     type_to_box_value!(Uuid, Uuid, Uuid);
+    type_to_box_value!(uuid::fmt::Hyphenated, UuidHyphenated, String(None));
 }
 
 #[cfg(feature = "with-ipnetwork")]
@@ -747,6 +756,9 @@ pub mod with_array {
 
     #[cfg(feature = "with-uuid")]
     impl NotU8 for Uuid {}
+
+    #[cfg(feature = "with-uuid")]
+    impl NotU8 for uuid::fmt::Hyphenated {}
 
     #[cfg(feature = "with-ipnetwork")]
     impl NotU8 for IpNetwork {}
@@ -1351,6 +1363,8 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::BigDecimal(None) => Json::Null,
         #[cfg(feature = "with-uuid")]
         Value::Uuid(None) => Json::Null,
+        #[cfg(feature = "with-uuid")]
+        Value::UuidHyphenated(None) => Json::Null,
         #[cfg(feature = "postgres-array")]
         Value::Array(_, None) => Json::Null,
         #[cfg(feature = "with-ipnetwork")]
@@ -1404,6 +1418,8 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         }
         #[cfg(feature = "with-uuid")]
         Value::Uuid(Some(v)) => Json::String(v.to_string()),
+        #[cfg(feature = "with-uuid")]
+        Value::UuidHyphenated(Some(v)) => Json::String(v.to_string()),
         #[cfg(feature = "postgres-array")]
         Value::Array(_, Some(v)) => {
             Json::Array(v.as_ref().iter().map(sea_value_to_json_value).collect())


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1290

- Dependents:
  - <!-- PR link -->

## New Features

- [x] Support [uuid::fmt::Hyphenated](https://docs.rs/uuid/latest/uuid/fmt/struct.Hyphenated.html)
