### PR TITLE
Refactor the use of deprecated chrono methods

### DIFF
--- a/examples/postgres/src/main.rs
+++ b/examples/postgres/src/main.rs
@@ -56,7 +56,10 @@ fn main() {
                 "bla": 1
             }
         }},
-        timestamp: NaiveDate::from_ymd(2020, 1, 1).and_hms(2, 2, 2),
+        timestamp: NaiveDate::from_ymd_opt(2020, 1, 1)
+            .unwrap()
+            .and_hms_opt(2, 2, 2)
+            .unwrap(),
         timestamp_with_time_zone: DateTime::parse_from_rfc3339("2020-01-01T02:02:02+08:00")
             .unwrap(),
         decimal: Decimal::from_i128_with_scale(3141i128, 3),

--- a/examples/rusqlite/src/main.rs
+++ b/examples/rusqlite/src/main.rs
@@ -73,7 +73,13 @@ fn main() -> Result<()> {
                 "notes": "some notes here",
             })
             .into(),
-            Some(NaiveDate::from_ymd(2020, 1, 1).and_hms(2, 2, 2)).into(),
+            Some(
+                NaiveDate::from_ymd_opt(2020, 1, 1)
+                    .unwrap()
+                    .and_hms_opt(2, 2, 2)
+                    .unwrap(),
+            )
+            .into(),
         ])
         .values_panic([
             Uuid::new_v4().into(),

--- a/examples/sqlx_any/src/main.rs
+++ b/examples/sqlx_any/src/main.rs
@@ -80,7 +80,11 @@ async fn main() {
         .values_panic([
             12.into(),
             "A".into(),
-            NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
+            NaiveDate::from_ymd_opt(2020, 8, 20)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap()
+                .into(),
         ])
         .returning_col(Character::Id)
         .build_any_sqlx(query_builder);

--- a/examples/sqlx_mysql/src/main.rs
+++ b/examples/sqlx_mysql/src/main.rs
@@ -69,7 +69,11 @@ async fn main() {
                 .unwrap()
                 .with_scale(3)
                 .into(),
-            NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
+            NaiveDate::from_ymd_opt(2020, 8, 20)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap()
+                .into(),
         ])
         .values_panic([
             Uuid::new_v4().into(),

--- a/examples/sqlx_postgres/src/main.rs
+++ b/examples/sqlx_postgres/src/main.rs
@@ -78,7 +78,11 @@ async fn main() {
                 .unwrap()
                 .with_scale(3)
                 .into(),
-            NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
+            NaiveDate::from_ymd_opt(2020, 8, 20)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap()
+                .into(),
             IpNetwork::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8)
                 .unwrap()
                 .into(),

--- a/examples/sqlx_sqlite/src/main.rs
+++ b/examples/sqlx_sqlite/src/main.rs
@@ -52,7 +52,11 @@ async fn main() {
                 "notes": "some notes here",
             })
             .into(),
-            NaiveDate::from_ymd(2020, 8, 20).and_hms(0, 0, 0).into(),
+            NaiveDate::from_ymd_opt(2020, 8, 20)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap()
+                .into(),
         ])
         .values_panic([
             Uuid::new_v4().into(),

--- a/src/value.rs
+++ b/src/value.rs
@@ -1673,7 +1673,10 @@ mod tests {
     #[test]
     #[cfg(feature = "with-chrono")]
     fn test_chrono_value() {
-        let timestamp = NaiveDate::from_ymd(2020, 1, 1).and_hms(2, 2, 2);
+        let timestamp = NaiveDate::from_ymd_opt(2020, 1, 1)
+            .unwrap()
+            .and_hms_opt(2, 2, 2)
+            .unwrap();
         let value: Value = timestamp.into();
         let out: NaiveDateTime = value.unwrap();
         assert_eq!(out, timestamp);
@@ -1682,8 +1685,13 @@ mod tests {
     #[test]
     #[cfg(feature = "with-chrono")]
     fn test_chrono_utc_value() {
-        let timestamp =
-            DateTime::<Utc>::from_utc(NaiveDate::from_ymd(2022, 1, 2).and_hms(3, 4, 5), Utc);
+        let timestamp = DateTime::<Utc>::from_utc(
+            NaiveDate::from_ymd_opt(2022, 1, 2)
+                .unwrap()
+                .and_hms_opt(3, 4, 5)
+                .unwrap(),
+            Utc,
+        );
         let value: Value = timestamp.into();
         let out: DateTime<Utc> = value.unwrap();
         assert_eq!(out, timestamp);
@@ -1692,8 +1700,13 @@ mod tests {
     #[test]
     #[cfg(feature = "with-chrono")]
     fn test_chrono_local_value() {
-        let timestamp_utc =
-            DateTime::<Utc>::from_utc(NaiveDate::from_ymd(2022, 1, 2).and_hms(3, 4, 5), Utc);
+        let timestamp_utc = DateTime::<Utc>::from_utc(
+            NaiveDate::from_ymd_opt(2022, 1, 2)
+                .unwrap()
+                .and_hms_opt(3, 4, 5)
+                .unwrap(),
+            Utc,
+        );
         let timestamp_local: DateTime<Local> = timestamp_utc.into();
         let value: Value = timestamp_local.into();
         let out: DateTime<Local> = value.unwrap();


### PR DESCRIPTION
## House Keepings

- [x] Refactor the use of deprecated chrono methods
  - https://docs.rs/chrono/0.4.23/chrono/naive/struct.NaiveDate.html#method.from_ymd
  - https://docs.rs/chrono/0.4.23/chrono/naive/struct.NaiveTime.html#method.from_hms
