### PR TITLE
fix!: get_random_uuid -> gen_random_uuid

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -78,7 +78,7 @@ impl QueryBuilder for PostgresQueryBuilder {
                     PgFunction::TsRank => "TS_RANK",
                     PgFunction::TsRankCd => "TS_RANK_CD",
                     PgFunction::StartsWith => "STARTS_WITH",
-                    PgFunction::GetRandomUUID => "GET_RANDOM_UUID",
+                    PgFunction::GenRandomUUID => "GEN_RANDOM_UUID",
                     #[cfg(feature = "postgres-array")]
                     PgFunction::Any => "ANY",
                     #[cfg(feature = "postgres-array")]

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -13,7 +13,7 @@ pub enum PgFunction {
     TsRank,
     TsRankCd,
     StartsWith,
-    GetRandomUUID,
+    GenRandomUUID,
     #[cfg(feature = "postgres-array")]
     Any,
     #[cfg(feature = "postgres-array")]
@@ -333,21 +333,21 @@ impl PgFunc {
             .args([text.into(), prefix.into()])
     }
 
-    /// Call `GET_RANDOM_UUID` function. Postgres only.
+    /// Call `GEN_RANDOM_UUID` function. Postgres only.
     ///
     /// # Examples
     ///
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let query = Query::select().expr(PgFunc::get_random_uuid()).to_owned();
+    /// let query = Query::select().expr(PgFunc::gen_random_uuid()).to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT GET_RANDOM_UUID()"#
+    ///     r#"SELECT GEN_RANDOM_UUID()"#
     /// );
     /// ```
-    pub fn get_random_uuid() -> FunctionCall {
-        FunctionCall::new(Function::PgFunction(PgFunction::GetRandomUUID))
+    pub fn gen_random_uuid() -> FunctionCall {
+        FunctionCall::new(Function::PgFunction(PgFunction::GenRandomUUID))
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: get_random_uuid will be unavailable

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #568 

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

N/A

## Bug Fixes

- Resolve `PgFunc::GetRandomUUID` generates `GET_RANDOM_UUID` function which does not exist actually

## Breaking Changes

- These names were changed, and old ones will unavailable after this changes
  - `PgFunction::GetRandomUUID` -> `PgFunction::GenRandomUUID`
  - `PgFunc::get_random_uuid` -> `PgFunc::gen_random_uuid`

## Changes

N/A
