### PR TITLE
Fix quoted string bug while inserting array of strings to Postgres

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1046,9 +1046,9 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             #[cfg(feature = "postgres-array")]
             Value::Array(_, Some(v)) => write!(
                 s,
-                "'{{{}}}'",
+                "ARRAY [{}]",
                 v.iter()
-                    .map(|element| self.value_to_string_in_array(element))
+                    .map(|element| self.value_to_string(element))
                     .collect::<Vec<String>>()
                     .join(",")
             )
@@ -1058,17 +1058,6 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(Some(v)) => write!(s, "'{}'", v).unwrap(),
         };
-        s
-    }
-
-    #[doc(hidden)]
-    /// Convert a SQL value inside an array into syntax-specific string
-    fn value_to_string_in_array(&self, v: &Value) -> String {
-        let mut s = String::new();
-        match v {
-            Value::String(Some(v)) => self.write_string(v, &mut s),
-            _ => s = self.value_to_string(v),
-        }
         s
     }
 
@@ -1386,12 +1375,6 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     /// Write a string surrounded by escaped quotes.
     fn write_string_quoted(&self, string: &str, buffer: &mut String) {
         write!(buffer, "'{}'", self.escape_string(string)).unwrap()
-    }
-
-    #[doc(hidden)]
-    /// Write a string without any quotes.
-    fn write_string(&self, string: &str, buffer: &mut String) {
-        write!(buffer, "{}", self.escape_string(string)).unwrap()
     }
 
     #[doc(hidden)]

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1048,7 +1048,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 s,
                 "'{{{}}}'",
                 v.iter()
-                    .map(|element| self.value_to_string(element))
+                    .map(|element| self.value_to_string_in_array(element))
                     .collect::<Vec<String>>()
                     .join(",")
             )
@@ -1058,6 +1058,19 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             #[cfg(feature = "with-mac_address")]
             Value::MacAddress(Some(v)) => write!(s, "'{}'", v).unwrap(),
         };
+        s
+    }
+
+    #[doc(hidden)]
+    /// Convert a SQL value inside an array into syntax-specific string
+    fn value_to_string_in_array(&self, v: &Value) -> String {
+        let mut s = String::new();
+        match v{
+            Value::String(Some(v)) => {
+                self.write_string(v, &mut s)
+            }
+            _ => {s = self.value_to_string(v)}
+        }
         s
     }
 
@@ -1375,6 +1388,12 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     /// Write a string surrounded by escaped quotes.
     fn write_string_quoted(&self, string: &str, buffer: &mut String) {
         write!(buffer, "'{}'", self.escape_string(string)).unwrap()
+    }
+
+    #[doc(hidden)]
+    /// Write a string without any quotes.
+    fn write_string(&self, string: &str, buffer: &mut String) {
+        write!(buffer, "{}", self.escape_string(string)).unwrap()
     }
 
     #[doc(hidden)]

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1065,11 +1065,9 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     /// Convert a SQL value inside an array into syntax-specific string
     fn value_to_string_in_array(&self, v: &Value) -> String {
         let mut s = String::new();
-        match v{
-            Value::String(Some(v)) => {
-                self.write_string(v, &mut s)
-            }
-            _ => {s = self.value_to_string(v)}
+        match v {
+            Value::String(Some(v)) => self.write_string(v, &mut s),
+            _ => s = self.value_to_string(v),
         }
         s
     }

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -253,7 +253,7 @@ impl PgFunc {
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT ANY('{0,1}')"#
+    ///     r#"SELECT ANY(ARRAY [0,1])"#
     /// );
     /// ```
     #[cfg(feature = "postgres-array")]
@@ -275,7 +275,7 @@ impl PgFunc {
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT SOME('{0,1}')"#
+    ///     r#"SELECT SOME(ARRAY [0,1])"#
     /// );
     /// ```
     #[cfg(feature = "postgres-array")]
@@ -297,7 +297,7 @@ impl PgFunc {
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT ALL('{0,1}')"#
+    ///     r#"SELECT ALL(ARRAY [0,1])"#
     /// );
     /// ```
     #[cfg(feature = "postgres-array")]

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -91,7 +91,7 @@ pub enum Glyph {
     Id,
     Image,
     Aspect,
-    Tokens
+    Tokens,
 }
 
 impl Iden for Glyph {
@@ -104,7 +104,7 @@ impl Iden for Glyph {
                 Self::Id => "id",
                 Self::Image => "image",
                 Self::Aspect => "aspect",
-                Self::Tokens => "tokens"
+                Self::Tokens => "tokens",
             }
         )
         .unwrap();

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -91,6 +91,7 @@ pub enum Glyph {
     Id,
     Image,
     Aspect,
+    Tokens
 }
 
 impl Iden for Glyph {
@@ -103,6 +104,7 @@ impl Iden for Glyph {
                 Self::Id => "id",
                 Self::Image => "image",
                 Self::Aspect => "aspect",
+                Self::Tokens => "tokens"
             }
         )
         .unwrap();

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1256,6 +1256,21 @@ fn insert_8() {
 }
 
 #[test]
+fn insert_10() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Tokens])
+            .values_panic([
+                3.1415.into(),
+                vec!["Token1".to_string(), "Token2".to_string(), "Token3".to_string()].into()
+            ])
+            .to_string(PostgresQueryBuilder),
+        r#"INSERT INTO "glyph" ("aspect", "tokens") VALUES (3.1415, '{Token1,Token2,Token3}')"#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_on_conflict_1() {
     assert_eq!(

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1271,7 +1271,7 @@ fn insert_10() {
                 .into()
             ])
             .to_string(PostgresQueryBuilder),
-        r#"INSERT INTO "glyph" ("aspect", "tokens") VALUES (3.1415, '{Token1,Token2,Token3}')"#
+        r#"INSERT INTO "glyph" ("aspect", "tokens") VALUES (3.1415, ARRAY ['Token1','Token2','Token3'])"#
     );
 }
 

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1263,7 +1263,12 @@ fn insert_10() {
             .columns([Glyph::Aspect, Glyph::Tokens])
             .values_panic([
                 3.1415.into(),
-                vec!["Token1".to_string(), "Token2".to_string(), "Token3".to_string()].into()
+                vec![
+                    "Token1".to_string(),
+                    "Token2".to_string(),
+                    "Token3".to_string()
+                ]
+                .into()
             ])
             .to_string(PostgresQueryBuilder),
         r#"INSERT INTO "glyph" ("aspect", "tokens") VALUES (3.1415, '{Token1,Token2,Token3}')"#


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #573 

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features


## Bug Fixes

- [X] Fix the bug while generating an insert query string. The result should be like `VALUES '{val}'` while now it's like `VALUES '{'val'}'`.

## Breaking Changes

## Changes

