### PR TITLE
Supporting types and implementations for replacing SeaORM's `ColumnType`

### DIFF
--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -54,6 +54,42 @@ pub enum ColumnType {
     MacAddr,
 }
 
+impl PartialEq for ColumnType {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Char(l0), Self::Char(r0)) => l0 == r0,
+            (Self::String(l0), Self::String(r0)) => l0 == r0,
+            (Self::Decimal(l0), Self::Decimal(r0)) => l0 == r0,
+            (Self::Year(l0), Self::Year(r0)) => l0 == r0,
+            (Self::Interval(l0, l1), Self::Interval(r0, r1)) => l0 == r0 && l1 == r1,
+            (Self::Binary(l0), Self::Binary(r0)) => l0 == r0,
+            (Self::VarBinary(l0), Self::VarBinary(r0)) => l0 == r0,
+            (Self::Bit(l0), Self::Bit(r0)) => l0 == r0,
+            (Self::VarBit(l0), Self::VarBit(r0)) => l0 == r0,
+            (Self::Money(l0), Self::Money(r0)) => l0 == r0,
+            (Self::Custom(l0), Self::Custom(r0)) => l0.to_string() == r0.to_string(),
+            (
+                Self::Enum {
+                    name: l_name,
+                    variants: l_variants,
+                },
+                Self::Enum {
+                    name: r_name,
+                    variants: r_variants,
+                },
+            ) => {
+                l_name.to_string() == r_name.to_string()
+                    && l_variants
+                        .iter()
+                        .map(|v| v.to_string())
+                        .eq(r_variants.iter().map(|v| v.to_string()))
+            }
+            (Self::Array(l0), Self::Array(r0)) => l0 == r0,
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}
+
 /// All column specification keywords
 #[derive(Debug, Clone)]
 pub enum ColumnSpec {
@@ -85,13 +121,13 @@ pub enum PgInterval {
 }
 
 // All MySQL year type field length sizes
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum MySqlYear {
     Two,
     Four,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BlobSize {
     Tiny,
     /// MySQL & SQLite support `binary(length)` column type

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -90,6 +90,12 @@ impl PartialEq for ColumnType {
     }
 }
 
+impl ColumnType {
+    pub fn custom(ty: &str) -> ColumnType {
+        ColumnType::Custom(Alias::new(ty).into_iden())
+    }
+}
+
 /// All column specification keywords
 #[derive(Debug, Clone)]
 pub enum ColumnSpec {


### PR DESCRIPTION
## PR Info

- Dependents:
  - https://github.com/SeaQL/sea-orm/pull/1390

- [ ] Cherry pick this back to the master branch

## New Features

- [x] Implemented `PartialEq` for `ColumnType`
- [x] Derived `Eq` and `PartialEq` for `MySqlYear`
- [x] Derived `Eq` and `PartialEq` for `BlobSize`
