### PR TITLE
Compile test_cfg when needed and hide it from docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ ipnetwork = { version = "0.19", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
 
 [dev-dependencies]
+sea-query = { path = ".", features = ["tests-cfg"] }
 criterion = { version = "0.3", features = ["html_reports"] }
 pretty_assertions = { version = "1" }
 
@@ -63,6 +64,7 @@ with-uuid = ["uuid"]
 with-time = ["time"]
 with-ipnetwork = ["ipnetwork"]
 with-mac_address = ["mac_address"]
+tests-cfg = []
 
 [[test]]
 name = "test-derive"
@@ -72,22 +74,22 @@ required-features = ["derive"]
 [[test]]
 name = "test-error"
 path = "tests/error/mod.rs"
-required-features = []
+required-features = ["tests-cfg"]
 
 [[test]]
 name = "test-mysql"
 path = "tests/mysql/mod.rs"
-required-features = ["backend-mysql"]
+required-features = ["tests-cfg", "backend-mysql"]
 
 [[test]]
 name = "test-postgres"
 path = "tests/postgres/mod.rs"
-required-features = ["backend-postgres"]
+required-features = ["tests-cfg", "backend-postgres"]
 
 [[test]]
 name = "test-sqlite"
 path = "tests/sqlite/mod.rs"
-required-features = ["backend-sqlite"]
+required-features = ["tests-cfg", "backend-sqlite"]
 
 [[bench]]
 name = "basic"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -828,24 +828,23 @@ pub mod query;
 pub mod schema;
 mod shim;
 pub mod table;
-pub mod tests_cfg;
 pub mod token;
 pub mod types;
 pub mod value;
 
+#[doc(hidden)]
+#[cfg(feature = "tests-cfg")]
+pub mod tests_cfg;
+
 pub use backend::*;
-//pub use extension::*;
-pub use foreign_key::*;
-pub use index::*;
-pub use query::*;
-pub use table::*;
-// pub use error::*;
 pub use expr::*;
+pub use foreign_key::*;
 pub use func::*;
+pub use index::*;
 pub use prepare::*;
+pub use query::*;
 pub use schema::*;
-//pub use shim::*;
-//pub use tests_cfg::*;
+pub use table::*;
 pub use token::*;
 pub use types::*;
 pub use value::*;


### PR DESCRIPTION
## Breaking Changes

- [x] `tests_cfg` module available if and only if you enabled `tests-cfg` feature

Hide implementors that are purely for testing purposes:

> <img width="1552" alt="image" src="https://user-images.githubusercontent.com/30400950/212240606-ec5495e2-667a-493c-a264-7fe2496aaf61.png">
> 
> https://docs.rs/sea-query/latest/sea_query/types/trait.Iden.html#implementors