### PR TITLE
Make `Table::truncate()` panic for Sqlite backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,10 +651,7 @@ assert_eq!(
     table.to_string(PostgresQueryBuilder),
     r#"TRUNCATE TABLE "font""#
 );
-assert_eq!(
-    table.to_string(SqliteQueryBuilder),
-    r#"TRUNCATE TABLE "font""#
-);
+// Sqlite does not support the TRUNCATE statement
 ```
 
 ### Foreign Key Create

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -100,6 +100,14 @@ impl TableBuilder for SqliteQueryBuilder {
         // SQLite does not support table drop options
     }
 
+    fn prepare_table_truncate_statement(
+        &self,
+        _truncate: &TableTruncateStatement,
+        _sql: &mut dyn SqlWriter,
+    ) {
+        panic!("Sqlite doesn't support TRUNCATE statement")
+    }
+
     fn prepare_table_alter_statement(&self, alter: &TableAlterStatement, sql: &mut dyn SqlWriter) {
         if alter.options.is_empty() {
             panic!("No alter option found")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,10 +683,7 @@
 //!     table.to_string(PostgresQueryBuilder),
 //!     r#"TRUNCATE TABLE "font""#
 //! );
-//! assert_eq!(
-//!     table.to_string(SqliteQueryBuilder),
-//!     r#"TRUNCATE TABLE "font""#
-//! );
+//! // Sqlite does not support the TRUNCATE statement
 //! ```
 //!
 //! ### Foreign Key Create

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -17,10 +17,7 @@ use crate::{backend::SchemaBuilder, types::*, SchemaStatementBuilder};
 ///     table.to_string(PostgresQueryBuilder),
 ///     r#"TRUNCATE TABLE "font""#
 /// );
-/// assert_eq!(
-///     table.to_string(SqliteQueryBuilder),
-///     r#"TRUNCATE TABLE "font""#
-/// );
+/// // Sqlite does not support the TRUNCATE statement
 /// ```
 #[derive(Default, Debug, Clone)]
 pub struct TableTruncateStatement {

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -329,16 +329,6 @@ fn drop_1() {
 }
 
 #[test]
-fn truncate_1() {
-    assert_eq!(
-        Table::truncate()
-            .table(Font::Table)
-            .to_string(SqliteQueryBuilder),
-        r#"TRUNCATE TABLE "font""#
-    );
-}
-
-#[test]
 fn alter_1() {
     assert_eq!(
         Table::alter()

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -329,6 +329,17 @@ fn drop_1() {
 }
 
 #[test]
+#[should_panic(expected = "Sqlite doesn't support TRUNCATE statement")]
+fn truncate_1() {
+    assert_eq!(
+        Table::truncate()
+            .table(Font::Table)
+            .to_string(SqliteQueryBuilder),
+        r#"TRUNCATE TABLE "font""#
+    );
+}
+
+#[test]
 fn alter_1() {
     assert_eq!(
         Table::alter()


### PR DESCRIPTION
## PR Info

- Closes #587 

## Bug Fixes

- [x] It allowed the construction of `TRUNCATE` statement even though it is not supported by Sqlite.

## Breaking Changes

- [x] Using `Table::truncate()` with Sqlite backend will now panic.
