### PR TITLE
String parameter should take generic `Into<String>`

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -410,9 +410,12 @@ impl Iden for NullAlias {
 }
 
 impl LikeExpr {
-    pub fn new(pattern: String) -> Self {
+    pub fn new<T>(pattern: T) -> Self
+    where
+        T: Into<String>,
+    {
         Self {
-            pattern,
+            pattern: pattern.into(),
             escape: None,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -441,13 +441,10 @@ impl IntoLikeExpr for LikeExpr {
     }
 }
 
-impl IntoLikeExpr for &str {
-    fn into_like_expr(self) -> LikeExpr {
-        LikeExpr::str(self)
-    }
-}
-
-impl IntoLikeExpr for String {
+impl<T> IntoLikeExpr for T
+where
+    T: Into<String>,
+{
     fn into_like_expr(self) -> LikeExpr {
         LikeExpr::new(self)
     }


### PR DESCRIPTION
## PR Info

- Dependents:
  - 

## Breaking Changes

- [ ] Changed the parameter of to `LikeExpr::new(T) where T: Into<String>`

## Changes

- [ ] Provide blanket `IntoLikeExpr` implementations to types implemented `Into<String>`
