### PR TITLE
Move Asteriks from Expr to new type

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -100,56 +100,9 @@ impl Expr {
         }
     }
 
-    /// Express the asterisk without table prefix.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select()
-    ///     .expr(Expr::asterisk())
-    ///     .from(Char::Table)
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT * FROM `character`"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT * FROM "character""#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT * FROM "character""#
-    /// );
-    /// ```
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .and_where(Expr::col((Char::Table, Char::SizeW)).eq(1))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`size_w` = 1"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" = 1"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" = 1"#
-    /// );
-    /// ```
+    #[deprecated(since = "0.29.0", note = "Please use the [`Asterisk`]")]
     pub fn asterisk() -> Self {
-        Self::col(ColumnRef::Asterisk)
+        Self::col(Asterisk)
     }
 
     /// Express the target column without table prefix.
@@ -245,60 +198,12 @@ impl Expr {
         ))
     }
 
-    /// Express the asterisk with table prefix.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select()
-    ///     .expr(Expr::asterisk())
-    ///     .from(Char::Table)
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT * FROM `character`"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT * FROM "character""#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT * FROM "character""#
-    /// );
-    /// ```
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select()
-    ///     .expr(Expr::table_asterisk(Char::Table))
-    ///     .column((Font::Table, Font::Name))
-    ///     .from(Char::Table)
-    ///     .inner_join(Font::Table, Expr::col((Char::Table, Char::FontId)).equals((Font::Table, Font::Id)))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`.*, `font`.`name` FROM `character` INNER JOIN `font` ON `character`.`font_id` = `font`.`id`"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character".*, "font"."name" FROM "character" INNER JOIN "font" ON "character"."font_id" = "font"."id""#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character".*, "font"."name" FROM "character" INNER JOIN "font" ON "character"."font_id" = "font"."id""#
-    /// );
-    /// ```
+    #[deprecated(since = "0.29.0", note = "Please use the [`Asterisk`]")]
     pub fn table_asterisk<T>(t: T) -> Self
     where
         T: IntoIden,
     {
-        Self::col(ColumnRef::TableAsterisk(t.into_iden()))
+        Self::col((t.into_iden(), Asterisk))
     }
 
     /// Express a [`Value`], returning a [`Expr`].

--- a/src/types.rs
+++ b/src/types.rs
@@ -204,6 +204,10 @@ pub struct Alias(String);
 #[derive(Default, Debug, Copy, Clone)]
 pub struct NullAlias;
 
+/// Asterisk ("*")
+#[derive(Default, Debug, Clone, Copy)]
+pub struct Asterisk;
+
 /// SQL Keywords
 #[derive(Debug, Clone)]
 pub enum Keyword {
@@ -302,6 +306,12 @@ where
     }
 }
 
+impl IntoColumnRef for Asterisk {
+    fn into_column_ref(self) -> ColumnRef {
+        ColumnRef::Asterisk
+    }
+}
+
 impl<S: 'static, T: 'static> IntoColumnRef for (S, T)
 where
     S: IntoIden,
@@ -309,6 +319,15 @@ where
 {
     fn into_column_ref(self) -> ColumnRef {
         ColumnRef::TableColumn(self.0.into_iden(), self.1.into_iden())
+    }
+}
+
+impl<T: 'static> IntoColumnRef for (T, Asterisk)
+where
+    T: IntoIden,
+{
+    fn into_column_ref(self) -> ColumnRef {
+        ColumnRef::TableAsterisk(self.0.into_iden())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -205,6 +205,58 @@ pub struct Alias(String);
 pub struct NullAlias;
 
 /// Asterisk ("*")
+///
+/// Express the asterisk without table prefix.
+///
+/// # Examples
+///
+/// ```
+/// use sea_query::{tests_cfg::*, *};
+///
+/// let query = Query::select()
+///     .column(Asterisk)
+///     .from(Char::Table)
+///     .to_owned();
+///
+/// assert_eq!(
+///     query.to_string(MysqlQueryBuilder),
+///     r#"SELECT * FROM `character`"#
+/// );
+/// assert_eq!(
+///     query.to_string(PostgresQueryBuilder),
+///     r#"SELECT * FROM "character""#
+/// );
+/// assert_eq!(
+///     query.to_string(SqliteQueryBuilder),
+///     r#"SELECT * FROM "character""#
+/// );
+/// ```
+///
+/// Express the asterisk with table prefix.
+///
+/// Examples
+///
+/// ```
+/// use sea_query::{tests_cfg::*, *};
+///
+/// let query = Query::select()
+///     .column((Char::Table, Asterisk))
+///     .from(Char::Table)
+///     .to_owned();
+///
+/// assert_eq!(
+///     query.to_string(MysqlQueryBuilder),
+///     r#"SELECT `character`.* FROM `character`"#
+/// );
+/// assert_eq!(
+///     query.to_string(PostgresQueryBuilder),
+///     r#"SELECT "character".* FROM "character""#
+/// );
+/// assert_eq!(
+///     query.to_string(SqliteQueryBuilder),
+///     r#"SELECT "character".* FROM "character""#
+/// );
+/// ```
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Asterisk;
 

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -792,7 +792,7 @@ fn select_48a() {
 #[test]
 fn select_49() {
     let statement = Query::select()
-        .expr(Expr::asterisk())
+        .column(Asterisk)
         .from(Char::Table)
         .to_string(MysqlQueryBuilder);
 
@@ -802,7 +802,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = Query::select()
-        .expr(Expr::table_asterisk(Char::Table))
+        .column((Char::Table, Asterisk))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(
@@ -901,7 +901,7 @@ fn select_53() {
 #[test]
 fn select_54() {
     let statement = Query::select()
-        .expr(Expr::asterisk())
+        .column(Asterisk)
         .from(Char::Table)
         .from(Font::Table)
         .and_where(Expr::col((Font::Table, Font::Id)).equals((Char::Table, Char::FontId)))
@@ -1418,7 +1418,7 @@ fn sub_query_with_fn() {
     pub struct ArrayFunc;
 
     let sub_select = Query::select()
-        .expr(Expr::asterisk())
+        .column(Asterisk)
         .from(Char::Table)
         .to_owned();
 

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -776,7 +776,7 @@ fn select_48a() {
 #[test]
 fn select_49() {
     let statement = Query::select()
-        .expr(Expr::asterisk())
+        .column(Asterisk)
         .from(Char::Table)
         .to_string(PostgresQueryBuilder);
 
@@ -786,7 +786,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = Query::select()
-        .expr(Expr::table_asterisk(Char::Table))
+        .column((Char::Table, Asterisk))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(
@@ -907,7 +907,7 @@ fn select_54() {
 #[test]
 fn select_55() {
     let statement = Query::select()
-        .expr(Expr::asterisk())
+        .column(Asterisk)
         .from(Char::Table)
         .from(Font::Table)
         .and_where(Expr::col((Font::Table, Font::Id)).equals((Char::Table, Char::FontId)))
@@ -1071,7 +1071,7 @@ fn select_61() {
 #[test]
 fn select_62() {
     let select = SelectStatement::new()
-        .expr(Expr::asterisk())
+        .column(Asterisk)
         .from_values([(1i32, "hello"), (2, "world")], Alias::new("x"))
         .to_owned();
     let cte = CommonTableExpression::new()
@@ -1711,7 +1711,7 @@ fn sub_query_with_fn() {
     pub struct ArrayFunc;
 
     let sub_select = Query::select()
-        .expr(Expr::asterisk())
+        .column(Asterisk)
         .from(Char::Table)
         .to_owned();
 

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -776,7 +776,7 @@ fn select_48a() {
 #[test]
 fn select_49() {
     let statement = Query::select()
-        .expr(Expr::asterisk())
+        .column(Asterisk)
         .from(Char::Table)
         .to_string(SqliteQueryBuilder);
 
@@ -786,7 +786,7 @@ fn select_49() {
 #[test]
 fn select_50() {
     let statement = Query::select()
-        .expr(Expr::table_asterisk(Char::Table))
+        .column((Character::Table, Asterisk))
         .column((Font::Table, Font::Name))
         .from(Char::Table)
         .inner_join(
@@ -879,7 +879,7 @@ fn select_53() {
 #[test]
 fn select_54() {
     let statement = Query::select()
-        .expr(Expr::asterisk())
+        .column(Asterisk)
         .from(Char::Table)
         .from(Font::Table)
         .and_where(Expr::col((Font::Table, Font::Id)).equals((Char::Table, Char::FontId)))
@@ -1560,7 +1560,7 @@ fn sub_query_with_fn() {
     pub struct ArrayFunc;
 
     let sub_select = Query::select()
-        .expr(Expr::asterisk())
+        .column(Asterisk)
         .from(Char::Table)
         .to_owned();
 


### PR DESCRIPTION
## New Features

- Create new type: `Asteriks`

## Breaking Changes

- Deprecated `Expr::asteriks` and `Expr::table_asteriks`
