### PR TITLE
Hashable value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ path = "src/lib.rs"
 sea-query-attr = { version = "0.1.1", path = "sea-query-attr", default-features = false, optional = true }
 sea-query-derive = { version = "0.3.0", path = "sea-query-derive", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true, features = ["std"] }
+derivative = { version = "2.2", default-features = false, optional = true }
 chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }
 postgres-types = { version = "0", default-features = false, optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }
@@ -40,6 +41,7 @@ quote = { version = "1", default-features = false, optional = true }
 time = { version = "0.3", default-features = false, optional = true, features = ["macros", "formatting"] }
 ipnetwork = { version = "0.19", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
+ordered-float = { version = "3.4", default-features = false, optional = true }
 
 [dev-dependencies]
 sea-query = { path = ".", features = ["tests-cfg"] }
@@ -53,6 +55,7 @@ backend-sqlite = []
 default = ["derive", "backend-mysql", "backend-postgres", "backend-sqlite"]
 derive = ["sea-query-derive"]
 attr = ["sea-query-attr"]
+hashable-value = ["derivative", "ordered-float"]
 postgres-array = []
 postgres-interval = ["proc-macro2", "quote"]
 thread-safe = []

--- a/src/value.rs
+++ b/src/value.rs
@@ -119,7 +119,13 @@ pub enum ArrayType {
 /// Value variants
 ///
 /// We want Value to be exactly 1 pointer sized, so anything larger should be boxed.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(not(feature = "hashable-value"), derive(PartialEq))]
+#[cfg_attr(
+    feature = "hashable-value",
+    derive(derivative::Derivative),
+    derivative(Hash, PartialEq, Eq)
+)]
 pub enum Value {
     Bool(Option<bool>),
     TinyInt(Option<i8>),
@@ -130,8 +136,26 @@ pub enum Value {
     SmallUnsigned(Option<u16>),
     Unsigned(Option<u32>),
     BigUnsigned(Option<u64>),
-    Float(Option<f32>),
-    Double(Option<f64>),
+    Float(
+        #[cfg_attr(
+            feature = "hashable-value",
+            derivative(
+                Hash(hash_with = "hashable_value::hash_f32"),
+                PartialEq(compare_with = "hashable_value::cmp_f32")
+            )
+        )]
+        Option<f32>,
+    ),
+    Double(
+        #[cfg_attr(
+            feature = "hashable-value",
+            derivative(
+                Hash(hash_with = "hashable_value::hash_f64"),
+                PartialEq(compare_with = "hashable_value::cmp_f64")
+            )
+        )]
+        Option<f64>,
+    ),
     String(Option<Box<String>>),
     Char(Option<char>),
 
@@ -1872,5 +1896,107 @@ mod tests {
         let v: Value = Value::Array(ArrayType::Int, None);
         let out: Option<Vec<i32>> = v.unwrap();
         assert_eq!(out, None);
+    }
+}
+
+#[cfg(feature = "hashable-value")]
+mod hashable_value {
+    use ordered_float::{NotNan, OrderedFloat};
+    use std::hash::{Hash, Hasher};
+
+    /// Panic when value is NaN
+    pub fn hash_f32<H: Hasher>(v: &Option<f32>, state: &mut H) {
+        match v {
+            Some(v) => NotNan::new(*v).unwrap().hash(state),
+            None => OrderedFloat(std::f32::NAN).hash(state),
+        }
+    }
+
+    /// Panic when value is NaN
+    pub fn hash_f64<H: Hasher>(v: &Option<f64>, state: &mut H) {
+        match v {
+            Some(v) => NotNan::new(*v).unwrap().hash(state),
+            None => OrderedFloat(std::f64::NAN).hash(state),
+        }
+    }
+
+    /// Panic when value is NaN
+    pub fn cmp_f32(l: &Option<f32>, r: &Option<f32>) -> bool {
+        match (l, r) {
+            (Some(l), Some(r)) => NotNan::new(*l).unwrap().eq(&NotNan::new(*r).unwrap()),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    /// Panic when value is NaN
+    pub fn cmp_f64(l: &Option<f64>, r: &Option<f64>) -> bool {
+        match (l, r) {
+            (Some(l), Some(r)) => NotNan::new(*l).unwrap().eq(&NotNan::new(*r).unwrap()),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn test_hash_value_0() {
+        use super::Value;
+
+        let hash_set: std::collections::HashSet<Value> = [
+            Value::Int(None),
+            Value::Int(None),
+            Value::BigInt(None),
+            Value::BigInt(None),
+            Value::Float(None),
+            Value::Float(None),
+            Value::Double(None),
+            Value::Double(None),
+        ]
+        .into_iter()
+        .collect();
+
+        let unique: std::collections::HashSet<Value> = [
+            Value::Int(None),
+            Value::BigInt(None),
+            Value::Float(None),
+            Value::Double(None),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(hash_set, unique);
+    }
+
+    #[test]
+    fn test_hash_value_1() {
+        use super::Value;
+
+        let hash_set: std::collections::HashSet<Value> = [
+            Value::Int(None),
+            Value::Int(Some(1)),
+            Value::Int(Some(1)),
+            Value::BigInt(Some(2)),
+            Value::BigInt(Some(2)),
+            Value::Float(Some(3.0)),
+            Value::Float(Some(3.0)),
+            Value::Double(Some(3.0)),
+            Value::Double(Some(3.0)),
+            Value::BigInt(Some(5)),
+        ]
+        .into_iter()
+        .collect();
+
+        let unique: std::collections::HashSet<Value> = [
+            Value::BigInt(Some(5)),
+            Value::Double(Some(3.0)),
+            Value::Float(Some(3.0)),
+            Value::BigInt(Some(2)),
+            Value::Int(Some(1)),
+            Value::Int(None),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(hash_set, unique);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/SeaQL/sea-orm/issues/1254

I have considered different implementations, and using a derive macro seems to be the easiest to maintain.

However, there is a catch when this feature is enabled: NaN == NaN, which contradicts Rust's built-in implementation of NaN != NaN