### PR TITLE
Impl prepare if all names are valid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ mac_address = { version = "1.1", default-features = false, optional = true }
 
 [dev-dependencies]
 sea-query = { path = ".", features = ["tests-cfg"] }
-criterion = { version = "0.3", features = ["html_reports"] }
+criterion = { version = "0.3" }
 pretty_assertions = { version = "1" }
 
 [features]

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -1,5 +1,12 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use sea_query::{tests_cfg::*, *};
+use sea_query::*;
+
+#[derive(Debug, Iden)]
+pub enum Char {
+    Table,
+    Id,
+    Character,
+}
 
 fn vanilla() -> String {
     format!(

--- a/sea-query-derive/src/lib.rs
+++ b/sea-query-derive/src/lib.rs
@@ -3,7 +3,7 @@ use std::convert::{TryFrom, TryInto};
 use heck::ToSnakeCase;
 use proc_macro::{self, TokenStream};
 use quote::{quote, quote_spanned};
-use syn::{parse_macro_input, Attribute, DataEnum, DataStruct, DeriveInput, Fields};
+use syn::{parse_macro_input, Attribute, DataEnum, DataStruct, DeriveInput, Fields, Variant};
 
 mod error;
 mod iden_attr;
@@ -23,10 +23,7 @@ fn find_attr(attrs: &[Attribute]) -> Option<&Attribute> {
         .find(|attr| attr.path.is_ident(&IdenPath::Iden) || attr.path.is_ident(&IdenPath::Method))
 }
 
-fn find_table_name(
-    ident: &proc_macro2::Ident,
-    attrs: Vec<Attribute>,
-) -> Result<String, syn::Error> {
+fn get_table_name(ident: &proc_macro2::Ident, attrs: Vec<Attribute>) -> Result<String, syn::Error> {
     let table_name = match find_attr(&attrs) {
         Some(att) => match att.try_into()? {
             IdenAttr::Rename(lit) => lit,
@@ -37,12 +34,94 @@ fn find_table_name(
     Ok(table_name)
 }
 
+fn must_be_valid_iden(name: &str) -> bool {
+    // can only begin with [a-z_]
+    name.chars()
+        .take(1)
+        .all(|c| c == '_' || c.is_ascii_alphabetic())
+        && name.chars().all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+fn impl_iden_for_unit_struct(
+    ident: &proc_macro2::Ident,
+    table_name: &str,
+) -> proc_macro2::TokenStream {
+    let prepare = if must_be_valid_iden(table_name) {
+        quote! {
+            fn prepare(&self, s: &mut dyn ::std::fmt::Write, q: char) {
+                write!(s, "{}", q).unwrap();
+                self.unquoted(s);
+                write!(s, "{}", q).unwrap();
+            }
+        }
+    } else {
+        quote! {}
+    };
+    quote! {
+        impl sea_query::Iden for #ident {
+            #prepare
+
+            fn unquoted(&self, s: &mut dyn ::std::fmt::Write) {
+                write!(s, #table_name).unwrap();
+            }
+        }
+    }
+}
+
+fn impl_iden_for_enum<'a, T>(
+    ident: &proc_macro2::Ident,
+    table_name: &str,
+    variants: T,
+) -> proc_macro2::TokenStream
+where
+    T: Iterator<Item = &'a Variant>,
+{
+    let mut is_all_valid = true;
+
+    let match_arms = match variants
+        .map(|v| (table_name, v))
+        .map(|v| {
+            let v = IdenVariant::<DeriveIden>::try_from(v)?;
+            is_all_valid &= v.must_be_valid_iden();
+            Ok(v)
+        })
+        .collect::<syn::Result<Vec<_>>>()
+    {
+        Ok(v) => quote! { #(#v),* },
+        Err(e) => return e.to_compile_error(),
+    };
+
+    let prepare = if is_all_valid {
+        quote! {
+            fn prepare(&self, s: &mut dyn ::std::fmt::Write, q: char) {
+                write!(s, "{}", q).unwrap();
+                self.unquoted(s);
+                write!(s, "{}", q).unwrap();
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    quote! {
+        impl sea_query::Iden for #ident {
+            #prepare
+
+            fn unquoted(&self, s: &mut dyn ::std::fmt::Write) {
+                match self {
+                    #match_arms
+                };
+            }
+        }
+    }
+}
+
 #[proc_macro_derive(Iden, attributes(iden, method))]
 pub fn derive_iden(input: TokenStream) -> TokenStream {
     let DeriveInput {
         ident, data, attrs, ..
     } = parse_macro_input!(input);
-    let table_name = match find_table_name(&ident, attrs) {
+    let table_name = match get_table_name(&ident, attrs) {
         Ok(v) => v,
         Err(e) => return e.to_compile_error().into(),
     };
@@ -54,16 +133,7 @@ pub fn derive_iden(input: TokenStream) -> TokenStream {
             syn::Data::Struct(DataStruct {
                 fields: Fields::Unit,
                 ..
-            }) => {
-                return quote! {
-                    impl sea_query::Iden for #ident {
-                        fn unquoted(&self, s: &mut dyn ::std::fmt::Write) {
-                            write!(s, #table_name).unwrap();
-                        }
-                    }
-                }
-                .into()
-            }
+            }) => return impl_iden_for_unit_struct(&ident, &table_name).into(),
             _ => return quote_spanned! {
                 ident.span() => compile_error!("you can only derive Iden on enums or unit structs");
             }
@@ -74,25 +144,7 @@ pub fn derive_iden(input: TokenStream) -> TokenStream {
         return TokenStream::new();
     }
 
-    let match_arms = match variants
-        .iter()
-        .map(|v| (table_name.as_str(), v))
-        .map(IdenVariant::<DeriveIden>::try_from)
-        .collect::<syn::Result<Vec<_>>>()
-    {
-        Ok(v) => quote! { #(#v),* },
-        Err(e) => return e.to_compile_error().into(),
-    };
-
-    let output = quote! {
-        impl sea_query::Iden for #ident {
-            fn unquoted(&self, s: &mut dyn ::std::fmt::Write) {
-                match self {
-                    #match_arms
-                };
-            }
-        }
-    };
+    let output = impl_iden_for_enum(&ident, &table_name, variants.iter());
 
     output.into()
 }
@@ -103,7 +155,7 @@ pub fn derive_iden_static(input: TokenStream) -> TokenStream {
         ident, data, attrs, ..
     } = parse_macro_input!(input);
 
-    let table_name = match find_table_name(&ident, attrs) {
+    let table_name = match get_table_name(&ident, attrs) {
         Ok(v) => v,
         Err(e) => return e.to_compile_error().into(),
     };
@@ -116,12 +168,10 @@ pub fn derive_iden_static(input: TokenStream) -> TokenStream {
                 fields: Fields::Unit,
                 ..
             }) => {
+                let impl_iden = impl_iden_for_unit_struct(&ident, &table_name);
+
                 return quote! {
-                    impl sea_query::Iden for #ident {
-                        fn unquoted(&self, s: &mut dyn ::std::fmt::Write) {
-                            write!(s, #table_name).unwrap();
-                        }
-                    }
+                    #impl_iden
 
                     impl sea_query::IdenStatic for #ident {
                         fn as_str(&self) -> &'static str {
@@ -135,7 +185,7 @@ pub fn derive_iden_static(input: TokenStream) -> TokenStream {
                         }
                     }
                 }
-                .into()
+                .into();
             }
             _ => return quote_spanned! {
                 ident.span() => compile_error!("you can only derive Iden on enums or unit structs");
@@ -146,6 +196,8 @@ pub fn derive_iden_static(input: TokenStream) -> TokenStream {
     if variants.is_empty() {
         return TokenStream::new();
     }
+
+    let impl_iden = impl_iden_for_enum(&ident, &table_name, variants.iter());
 
     let match_arms = match variants
         .iter()
@@ -158,11 +210,7 @@ pub fn derive_iden_static(input: TokenStream) -> TokenStream {
     };
 
     let output = quote! {
-        impl sea_query::Iden for #ident {
-            fn unquoted(&self, s: &mut dyn ::std::fmt::Write) {
-                write!(s, "{}", self.as_str()).unwrap();
-            }
-        }
+        #impl_iden
 
         impl sea_query::IdenStatic for #ident {
             fn as_str(&self) -> &'static str {

--- a/sea-query-derive/tests/pass-static/meta_list_renaming_everything.rs
+++ b/sea-query-derive/tests/pass-static/meta_list_renaming_everything.rs
@@ -1,7 +1,7 @@
-use sea_query::Iden;
+use sea_query::{Iden, IdenStatic};
 use strum::{EnumIter, IntoEnumIterator};
 
-#[derive(Iden, EnumIter)]
+#[derive(IdenStatic, EnumIter, Copy, Clone)]
 // Outer iden attributes overrides what's used for "Table"...
 #[iden(rename = "user")]
 enum Custom {
@@ -15,16 +15,16 @@ enum Custom {
     // Custom casing if needed
     #[iden(rename = "EM`ail")]
     // the tuple value will be ignored
-    Email(String),
+    Email(i32),
     // Custom method
     #[iden(method = "custom_to_string")]
-    Custom(String),
+    Custom,
 }
 
 impl Custom {
-    pub fn custom_to_string(&self) -> &str {
+    pub fn custom_to_string(&self) -> &'static str {
         match self {
-            Self::Custom(custom) => custom,
+            Self::Custom => "custom",
             _ => panic!("not Custom::Custom"),
         }
     }
@@ -32,17 +32,17 @@ impl Custom {
 
 fn main() {
     // custom ends up being default string which is an empty string
-    let expected = ["user", "my_id", "name", "surname", "EM`ail", ""];
+    let expected = ["user", "my_id", "name", "surname", "EM`ail", "custom"];
     Custom::iter()
         .map(|var| var.to_string())
         .zip(expected)
         .for_each(|(iden, exp)| assert_eq!(iden, exp));
     
     let mut string = String::new();
-    Custom::Email("".to_owned()).prepare(&mut string, '"');
+    Custom::Email(0).prepare(&mut string, '"');
     assert_eq!(string, "\"EM`ail\"");
 
     let mut string = String::new();
-    Custom::Email("".to_owned()).prepare(&mut string, '`');
+    Custom::Email(0).prepare(&mut string, '`');
     assert_eq!(string, "`EM``ail`");
 }

--- a/sea-query-derive/tests/pass-static/simple_unit_struct.rs
+++ b/sea-query-derive/tests/pass-static/simple_unit_struct.rs
@@ -3,7 +3,23 @@ use sea_query::{Iden, IdenStatic};
 #[derive(Copy, Clone, IdenStatic)]
 pub struct SomeType;
 
+#[derive(Copy, Clone, IdenStatic)]
+#[iden(rename = "Hel`lo")]
+pub struct SomeTypeWithRename;
+
 fn main() {
     assert_eq!(SomeType.to_string(), "some_type");
-    assert_eq!(SomeType.as_str(), "some_type");
+    assert_eq!(SomeTypeWithRename.to_string(), "Hel`lo");
+
+    let mut string = String::new();
+    SomeType.prepare(&mut string, '"');
+    assert_eq!(string, "\"some_type\"");
+
+    let mut string = String::new();
+    SomeTypeWithRename.prepare(&mut string, '"');
+    assert_eq!(string, "\"Hel`lo\"");
+
+    let mut string = String::new();
+    SomeTypeWithRename.prepare(&mut string, '`');
+    assert_eq!(string, "`Hel``lo`");
 }

--- a/sea-query-derive/tests/pass/simple_unit_struct.rs
+++ b/sea-query-derive/tests/pass/simple_unit_struct.rs
@@ -3,6 +3,23 @@ use sea_query::Iden;
 #[derive(Copy, Clone, Iden)]
 pub struct SomeType;
 
+#[derive(Copy, Clone, Iden)]
+#[iden(rename = "Hel`lo")]
+pub struct SomeTypeWithRename;
+
 fn main() {
     assert_eq!(SomeType.to_string(), "some_type");
+    assert_eq!(SomeTypeWithRename.to_string(), "Hel`lo");
+
+    let mut string = String::new();
+    SomeType.prepare(&mut string, '"');
+    assert_eq!(string, "\"some_type\"");
+
+    let mut string = String::new();
+    SomeTypeWithRename.prepare(&mut string, '"');
+    assert_eq!(string, "\"Hel`lo\"");
+
+    let mut string = String::new();
+    SomeTypeWithRename.prepare(&mut string, '`');
+    assert_eq!(string, "`Hel``lo`");
 }


### PR DESCRIPTION
This improves the Iden, IdenStatic macros to be "smarter": where all idens are statically known to be valid, provide a short-circuit implementation of prepare.

```rust
#[derive(Debug, Iden)]
pub enum Char {
    Table,
    Id,
    #[iden = "hello"]
    Character,
}

// expanded
impl sea_query::Iden for Char {
    fn prepare(&self, s: &mut dyn ::std::fmt::Write, q: char) {
        s.write_fmt(format_args!("{0}", q)).unwrap();
        self.unquoted(s);
        s.write_fmt(format_args!("{0}", q)).unwrap();
    }
    fn unquoted(&self, s: &mut dyn ::std::fmt::Write) {
        match self {
            Self::Table => s.write_fmt(format_args!("{0}", "char")).unwrap(),
            Self::Id => s.write_fmt(format_args!("{0}", "id")).unwrap(),
            Self::Character => s.write_fmt(format_args!("{0}", "hello")).unwrap(),
        };
    }
}
```

```rust
#[derive(Debug, Iden)]
pub enum Char {
    Table,
    Id,
    #[iden = "hel-lo"]
    Character,
}

// expanded
impl sea_query::Iden for Char {
    // `prepare` fallback to default impl
    fn unquoted(&self, s: &mut dyn ::std::fmt::Write) {
        match self {
            Self::Table => s.write_fmt(format_args!("{0}", "char")).unwrap(),
            Self::Id => s.write_fmt(format_args!("{0}", "id")).unwrap(),
            Self::Character => s.write_fmt(format_args!("{0}", "hel-lo")).unwrap(),
        };
    }
}
```

Tried to benchmark it, but the improvement is ~10% at best, so probably does not relevant.