### PR TITLE
Add simple extra param for table create statement

### DIFF
--- a/src/backend/table_builder.rs
+++ b/src/backend/table_builder.rs
@@ -55,11 +55,10 @@ pub trait TableBuilder:
         write!(sql, " )").unwrap();
 
         self.prepare_table_opt(create, sql);
-      
+
         if let Some(extra) = &create.extra {
             write!(sql, " {extra}").unwrap();
         }
-
     }
 
     /// Translate [`TableRef`] into SQL statement.

--- a/src/backend/table_builder.rs
+++ b/src/backend/table_builder.rs
@@ -64,7 +64,6 @@ pub trait TableBuilder:
         if let Some(extra) = &create.extra {
             write!(sql, " {extra}").unwrap();
         }
-
     }
 
     /// Translate [`TableRef`] into SQL statement.

--- a/src/backend/table_builder.rs
+++ b/src/backend/table_builder.rs
@@ -60,6 +60,11 @@ pub trait TableBuilder:
             write!(sql, " ").unwrap();
             self.prepare_table_opt(table_opt, sql);
         }
+
+        if let Some(extra) = &create.extra {
+            write!(sql, " {extra}").unwrap();
+        }
+
     }
 
     /// Translate [`TableRef`] into SQL statement.

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -598,10 +598,41 @@ impl ColumnDef {
     }
 
     /// Some extra options in custom string
-    pub fn extra(&mut self, string: String) -> &mut Self {
-        self.spec.push(ColumnSpec::Extra(string));
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    /// let table = Table::create()
+    ///     .table(Char::Table)
+    ///     .col(
+    ///         ColumnDef::new(Char::Id)
+    ///             .uuid()
+    ///             .extra("DEFAULT uuid_generate_v4()")
+    ///             .primary_key()
+    ///             .not_null(),
+    ///     )
+    ///     .col(
+    ///         ColumnDef::new(Char::CreatedAt)
+    ///             .timestamp_with_time_zone()
+    ///             .extra("DEFAULT NOW()")
+    ///             .not_null(),
+    ///     )
+    ///     .to_owned();
+    /// assert_eq!(
+    ///     table.to_string(PostgresQueryBuilder),
+    ///     [
+    ///         r#"CREATE TABLE "character" ("#,
+    ///         r#""id" uuid DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,"#,
+    ///         r#""created_at" timestamp with time zone DEFAULT NOW() NOT NULL"#,
+    ///         r#")"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    /// ```
+    pub fn extra<T>(&mut self, string: T) -> &mut Self
+    where T: Into<String> {
+        self.spec.push(ColumnSpec::Extra(string.into()));
         self
     }
+    
     pub fn get_column_name(&self) -> String {
         self.name.to_string()
     }

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -599,7 +599,7 @@ impl ColumnDef {
 
     /// Some extra options in custom string
     /// ```
-    /// use sea_query::{*, tests_cfg::*};
+    /// use sea_query::{tests_cfg::*, *};
     /// let table = Table::create()
     ///     .table(Char::Table)
     ///     .col(
@@ -628,11 +628,13 @@ impl ColumnDef {
     /// );
     /// ```
     pub fn extra<T>(&mut self, string: T) -> &mut Self
-    where T: Into<String> {
+    where
+        T: Into<String>,
+    {
         self.spec.push(ColumnSpec::Extra(string.into()));
         self
     }
-    
+
     pub fn get_column_name(&self) -> String {
         self.name.to_string()
     }

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -276,7 +276,7 @@ impl TableCreateStatement {
     ///     .col(
     ///         ColumnDef::new(Char::Id)
     ///             .uuid()
-    ///             .extra("DEFAULT uuid_generate_v4()".into())
+    ///             .extra("DEFAULT uuid_generate_v4()")
     ///             .primary_key()
     ///             .not_null(),
     ///     )
@@ -287,7 +287,7 @@ impl TableCreateStatement {
     ///             .not_null(),
     ///     )
     ///     .col(ColumnDef::new(Char::UserData).json_binary().not_null())
-    ///     .set_extra("USING columnar")
+    ///     .extra("USING columnar")
     ///     .to_owned();
     /// assert_eq!(
     ///     table.to_string(PostgresQueryBuilder),

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -270,7 +270,7 @@ impl TableCreateStatement {
     /// Rewriting extra param. You should take care self about concat extra params. Add extra after options.
     /// Example for PostgresSQL [Citus](https://github.com/citusdata/citus) extension:
     /// ```
-    /// use sea_query::{*, tests_cfg::*};
+    /// use sea_query::{tests_cfg::*, *};
     /// let table = Table::create()
     ///     .table(Char::Table)
     ///     .col(

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -287,7 +287,7 @@ impl TableCreateStatement {
     ///             .not_null(),
     ///     )
     ///     .col(ColumnDef::new(Char::UserData).json_binary().not_null())
-    ///     .set_extra(&"USING columnar")
+    ///     .set_extra("USING columnar")
     ///     .to_owned();
     /// assert_eq!(
     ///     table.to_string(PostgresQueryBuilder),

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -283,7 +283,7 @@ impl TableCreateStatement {
     ///     .col(
     ///         ColumnDef::new(Char::CreatedAt)
     ///             .timestamp_with_time_zone()
-    ///             .extra("DEFAULT NOW()".into())
+    ///             .extra("DEFAULT NOW()")
     ///             .not_null(),
     ///     )
     ///     .col(ColumnDef::new(Char::UserData).json_binary().not_null())

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -301,7 +301,10 @@ impl TableCreateStatement {
     ///     .join(" ")
     /// );
     /// ```
-    pub fn set_extra(&mut self, extra: &str) -> &mut Self {
+    pub fn extra<T>(&mut self, extra: T) -> &mut Self
+    where
+        T: Into<String>,
+    {
         self.extra = Some(extra.into());
         self
     }

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -270,8 +270,8 @@ impl TableCreateStatement {
     /// Rewriting extra param. You should take care self about concat extra params. Add extra after options.
     /// Example for PostgresSQL [Citus](https://github.com/citusdata/citus) extension:
     /// ```
-    ///  use sea_query::{*, tests_cfg::*};
-    ///  let table = Table::create()
+    /// use sea_query::{*, tests_cfg::*};
+    /// let table = Table::create()
     ///     .table(Char::Table)
     ///     .col(
     ///         ColumnDef::new(Char::Id)
@@ -286,22 +286,19 @@ impl TableCreateStatement {
     ///             .extra("DEFAULT NOW()".into())
     ///             .not_null(),
     ///     )
-    ///     .col(
-    ///         ColumnDef::new(Char::UserData)
-    ///             .json_binary()
-    ///             .not_null(),
-    ///     )
+    ///     .col(ColumnDef::new(Char::UserData).json_binary().not_null())
     ///     .set_extra(&"USING columnar")
     ///     .to_owned();
-    ///  assert_eq!(
+    /// assert_eq!(
     ///     table.to_string(PostgresQueryBuilder),
     ///     [
     ///         r#"CREATE TABLE "character" ("#,
-    ///             r#""id" uuid DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,"#,
-    ///             r#""created_at" timestamp with time zone DEFAULT NOW() NOT NULL,"#,
-    ///             r#""user_data" jsonb NOT NULL"#,
+    ///         r#""id" uuid DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,"#,
+    ///         r#""created_at" timestamp with time zone DEFAULT NOW() NOT NULL,"#,
+    ///         r#""user_data" jsonb NOT NULL"#,
     ///         r#") USING columnar"#,
-    ///     ].join(" ")
+    ///     ]
+    ///     .join(" ")
     /// );
     /// ```
     pub fn set_extra(&mut self, extra: &str) -> &mut Self {

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -23,6 +23,7 @@ pub enum Character {
     FontId,
     Ascii,
     CreatedAt,
+    UserData,
 }
 
 /// A shorthand for [`Character`]
@@ -43,6 +44,7 @@ impl Iden for Character {
                 Self::FontId => "font_id",
                 Self::Ascii => "ascii",
                 Self::CreatedAt => "created_at",
+                Self::UserData => "user_data",
             }
         )
         .unwrap();


### PR DESCRIPTION
## PR Info

## Closes 
- [x] [Add extra](https://github.com/SeaQL/sea-query/issues/574)


## New Features

- [x] Add extra param for TableCreateStatement. 

## Changes

- [x] Added set_extra and get_extra for TableCreateStatement.
- [x] Added documentation with test example for set_extra

## Discussions 
- [x] [Different extra for different engines](https://github.com/SeaQL/sea-query/discussions/571) Not needed because you just can write code dependent on cfg features. Example: 
```rust
let table = Table::create().table(Char::Table).set_extra(
 match () {
        #[cfg(feature = "postgres")]
        () => &"POSTGRES EXTRA",
        #[cfg(feature = "mysql")]
        () => &"MYSQL EXTRA",
        #[cfg(feature="sqlite")]
        () => &"SQLLITE EXTRA",
    }
)
```

## Desciption
There are too many parameters to add them all. Moreover, the parameters depend too much on the database backend.  For now enough add simple extra param for more flexibility.
