### PR TITLE
Add binary operators for Postgres' JSON traversal.

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -53,6 +53,8 @@ impl QueryBuilder for PostgresQueryBuilder {
                     PgBinOper::SimilarityDistance => "<->",
                     PgBinOper::WordSimilarityDistance => "<<->",
                     PgBinOper::StrictWordSimilarityDistance => "<<<->",
+                    PgBinOper::GetJsonField => "->",
+                    PgBinOper::CastJsonField => "->>",
                 }
             )
             .unwrap(),

--- a/src/extension/postgres/mod.rs
+++ b/src/extension/postgres/mod.rs
@@ -25,6 +25,10 @@ pub enum PgBinOper {
     SimilarityDistance,
     WordSimilarityDistance,
     StrictWordSimilarityDistance,
+    /// `->`. Retrieves JSON field as JSON value.
+    GetJsonField,
+    /// `->>`. Retrieves JSON field and casts it to an appropriate SQL type.
+    CastJsonField,
 }
 
 impl From<PgBinOper> for BinOper {

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1782,3 +1782,37 @@ fn sub_query_with_fn() {
         r#"SELECT ARRAY((SELECT * FROM "character"))"#
     );
 }
+
+#[test]
+fn get_json_field_bin_oper() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(
+                Expr::col(Char::Character).binary(PgBinOper::GetJsonField, Expr::val("test"))
+            )
+            .build(PostgresQueryBuilder),
+        (
+            r#"SELECT "character" FROM "character" WHERE "character" -> $1"#.to_owned(),
+            Values(vec!["test".into()])
+        )
+    );
+}
+
+#[test]
+fn cast_json_field_bin_oper() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(
+                Expr::col(Char::Character).binary(PgBinOper::CastJsonField, Expr::val("test"))
+            )
+            .build(PostgresQueryBuilder),
+        (
+            r#"SELECT "character" FROM "character" WHERE "character" ->> $1"#.to_owned(),
+            Values(vec!["test".into()])
+        )
+    );
+}


### PR DESCRIPTION
## New Features

- Adds support for PG's JSON querying. Copied shamelessly from the mysql implementation of the same functionality.

## Breaking Changes

- Adds additional variants to the `PgBinOper` enum.
