### PR TITLE
Fix: Dropping multiple types in Postgres

### DIFF
--- a/src/backend/postgres/types.rs
+++ b/src/backend/postgres/types.rs
@@ -35,7 +35,13 @@ impl TypeBuilder for PostgresQueryBuilder {
             write!(sql, "IF EXISTS ").unwrap();
         }
 
-        for name in drop.names.iter() {
+        let mut names_iter = drop.names.iter();
+        if let Some(name) = names_iter.next() {
+            self.prepare_type_ref(name, sql);
+        }
+
+        for name in names_iter {
+            write!(sql, ", ").unwrap();
             self.prepare_type_ref(name, sql);
         }
 

--- a/src/backend/postgres/types.rs
+++ b/src/backend/postgres/types.rs
@@ -35,15 +35,13 @@ impl TypeBuilder for PostgresQueryBuilder {
             write!(sql, "IF EXISTS ").unwrap();
         }
 
-        let mut names_iter = drop.names.iter();
-        if let Some(name) = names_iter.next() {
+        drop.names.iter().fold(true, |first, name| {
+            if !first {
+                write!(sql, ", ").unwrap();
+            }
             self.prepare_type_ref(name, sql);
-        }
-
-        for name in names_iter {
-            write!(sql, ", ").unwrap();
-            self.prepare_type_ref(name, sql);
-        }
+            false
+        });
 
         if let Some(option) = &drop.option {
             write!(sql, " ").unwrap();

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -252,18 +252,18 @@ impl TypeDropStatement {
     ///
     /// #[derive(Iden)]
     /// enum KycStatus {
-    ///    #[iden = "kyc_status"]
-    ///    Type,
-    ///    Pending,
-    ///    Approved,
+    ///     #[iden = "kyc_status"]
+    ///     Type,
+    ///     Pending,
+    ///     Approved,
     /// }
     ///
     /// #[derive(Iden)]
     /// enum FontFamily {
-    ///    #[iden = "font_family"]
-    ///    Type,
-    ///    Aerial,
-    ///    Forte,
+    ///     #[iden = "font_family"]
+    ///     Type,
+    ///     Aerial,
+    ///     Forte,
     /// }
     ///
     /// assert_eq!(

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -245,6 +245,39 @@ impl TypeDropStatement {
         self
     }
 
+    /// Drop multiple types
+    ///
+    /// ```
+    /// use sea_query::{extension::postgres::Type, *};
+    ///
+    /// #[derive(Iden)]
+    /// enum KycStatus {
+    ///    #[iden = "kyc_status"]
+    ///    Type,
+    ///    Pending,
+    ///    Approved,
+    /// }
+    ///
+    /// #[derive(Iden)]
+    /// enum FontFamily {
+    ///    #[iden = "font_family"]
+    ///    Type,
+    ///    Aerial,
+    ///    Forte,
+    /// }
+    ///
+    /// assert_eq!(
+    ///     Type::drop()
+    ///         .if_exists()
+    ///         .names([
+    ///             SeaRc::new(KycStatus::Type) as DynIden,
+    ///             SeaRc::new(FontFamily::Type) as DynIden,
+    ///         ])
+    ///         .cascade()
+    ///         .to_string(PostgresQueryBuilder),
+    ///     r#"DROP TYPE IF EXISTS "kyc_status", "font_family" CASCADE"#
+    /// );
+    /// ```
     pub fn names<T, I>(&mut self, names: I) -> &mut Self
     where
         T: IntoTypeRef,


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## Bug Fixes

- [x] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->Following code in Rust omits the comma in SQL statement, which causes error from Postgres (as of `sea-query` version `0.28.3`). This issue has been fixed.
```rust
use sea_query::{extension::postgres::Type, *};

#[derive(Iden)]
enum KycStatus {
   #[iden = "kyc_status"]
   Type,
   Pending,
   Approved,
}

#[derive(Iden)]
enum FontFamily {
   #[iden = "font_family"]
   Type,
   Aerial,
   Forte,
}

assert_eq!(
    Type::drop()
        .if_exists()
        .names([
            SeaRc::new(KycStatus::Type) as DynIden,
            SeaRc::new(FontFamily::Type) as DynIden,
        ])
        .cascade()
        .to_string(PostgresQueryBuilder),
    r#"DROP TYPE IF EXISTS "kyc_status""font_family" CASCADE"#
);
```

## Changes

- [x] <!-- any other non-breaking changes to the codebase -->Add comma if multiple names are passed to `TypeDropStatement`.
- [x] Doc-test/example for dropping multiple types in single `TypeDropStatement`.

## Other considerations
- I'm fairly new to this code and have, sort of, reverse engineered this bug to fix it. Hence, I'm not fully aware of how my code can affect other things, though all the tests passed.
- Please update the dependency in `sea-orm` crate, if you merge this.