### PR TITLE
fix: enable required `syn` features

### DIFF
--- a/sea-query-derive/Cargo.toml
+++ b/sea-query-derive/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.60"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", default-features = false }
+syn = { version = "1", default-features = false, features = ["parsing", "proc-macro", "derive", "printing"] }
 quote = { version = "1", default-features = false }
 heck = { version = "0.4", default-features = false }
 proc-macro2 = { version = "1", default-features = false }


### PR DESCRIPTION
## PR Info

- [ ] We need a PATCH release for this

## Bug Fixes

- [x] Enabled required `syn` v1 features. Those features were enabled implicitly by other crates that depends on `syn`. Now, they have upgraded to `syn` v2 as a result those features of `syn` v1 is not enabled.
