### PR TITLE
Add support for `get_json_field` and `cast_json_field` in postgres

### DIFF
--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -144,6 +144,56 @@ pub trait PgExpr: Expression {
     {
         self.like_like(PgBinOper::NotILike, like.into_like_expr())
     }
+
+    /// Express a postgres retrieves JSON field as JSON value (`->`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{extension::postgres::PgExpr, tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .column(Font::Variant)
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::col(Font::Variant).get_json_field("a"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "variant" FROM "font" WHERE "variant" -> 'a'"#
+    /// );
+    /// ```
+    fn get_json_field<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.bin_op(PgBinOper::GetJsonField, right)
+    }
+
+    /// Express a postgres retrieves JSON field and casts it to an appropriate SQL type (`->>`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{extension::postgres::PgExpr, tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .column(Font::Variant)
+    ///     .from(Font::Table)
+    ///     .and_where(Expr::col(Font::Variant).cast_json_field("a"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "variant" FROM "font" WHERE "variant" ->> 'a'"#
+    /// );
+    /// ```
+    fn cast_json_field<T>(self, right: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.bin_op(PgBinOper::CastJsonField, right)
+    }
 }
 
 impl PgExpr for Expr {}


### PR DESCRIPTION

## PR Info

- Dependents:
  - https://github.com/SeaQL/sea-query/commit/8ce29cd039c60f9bf8221dfc227041becd30fde7

## New Features

- [ ] Adds support to `get_json_field` and `cast_json_field` to postgres.


## Details

With the introduction of `GetJsonField` and `CastJsonField` for postgres in https://github.com/SeaQL/sea-query/commit/8ce29cd039c60f9bf8221dfc227041becd30fde7 we should be able now to add the new APIs `get_json_field` and `cast_json_field` to the postgres extension similar to those of sqlite in https://github.com/SeaQL/sea-query/blob/4ca444643317b708615cde4a2f1b88881368f3c3/src/extension/sqlite/expr.rs#L49.