### PR TITLE
Implement Index Hints for Mysql

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -412,10 +412,15 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     /// Translate [`IndexHint`] into SQL statement.
-    fn prepare_index_hints(&self, _indexes: &[IndexHint], _sql: &mut dyn SqlWriter) {}
+    fn prepare_index_hints(&self, _hints: &[IndexHint], _sql: &mut dyn SqlWriter) {}
 
     /// Translate [`IndexHintType`] into SQL statement.
-    fn prepare_index_hint_type(&self, _index_hint_type: &IndexHintType, _sql: &mut dyn SqlWriter) {}
+    fn prepare_index_hint_scope(
+        &self,
+        _index_hint_scope: &IndexHintScope,
+        _sql: &mut dyn SqlWriter,
+    ) {
+    }
 
     /// Translate [`LockType`] into SQL statement.
     fn prepare_select_lock(&self, lock: &LockClause, sql: &mut dyn SqlWriter) {

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -115,6 +115,10 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 self.prepare_table_ref(table_ref, sql);
                 false
             });
+            if !select.index_hints.is_empty() {
+                write!(sql, " ").unwrap();
+                self.prepare_index_hints(&select.index_hints, sql);
+            }
         }
 
         if !select.join.is_empty() {
@@ -406,6 +410,12 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             _ => {}
         }
     }
+
+    /// Translate [`IndexHint`] into SQL statement.
+    fn prepare_index_hints(&self, _indexes: &[IndexHint], _sql: &mut dyn SqlWriter) {}
+
+    /// Translate [`IndexHintType`] into SQL statement.
+    fn prepare_index_hint_type(&self, _index_hint_type: &IndexHintType, _sql: &mut dyn SqlWriter) {}
 
     /// Translate [`LockType`] into SQL statement.
     fn prepare_select_lock(&self, lock: &LockClause, sql: &mut dyn SqlWriter) {

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -84,14 +84,21 @@ pub struct SelectExpr {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum IndexHint {
-    Use(DynIden, IndexHintType),
-    Ignore(DynIden, IndexHintType),
-    Force(DynIden, IndexHintType),
+pub struct IndexHint {
+    pub index: DynIden,
+    pub r#type: IndexHintType,
+    pub scope: IndexHintScope,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum IndexHintType {
+    Use,
+    Ignore,
+    Force,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum IndexHintType {
+pub enum IndexHintScope {
     Join,
     OrderBy,
     GroupBy,
@@ -331,7 +338,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .use_index(IndexName::new("IDX_123456"), IndexHintType::All)
+    ///     .use_index(IndexName::new("IDX_123456"), IndexHintScope::All)
     ///     .column(Char::SizeW)
     ///     .to_owned();
     ///
@@ -340,12 +347,15 @@ impl SelectStatement {
     ///     r#"SELECT `size_w` FROM `character` USE INDEX (`IDX_123456`)"#
     /// );
     /// ```
-    pub fn use_index<I>(&mut self, index: I, hint_type: IndexHintType) -> &mut Self
+    pub fn use_index<I>(&mut self, index: I, scope: IndexHintScope) -> &mut Self
     where
         I: IntoIden,
     {
-        self.index_hints
-            .push(IndexHint::Use(index.into_iden(), hint_type));
+        self.index_hints.push(IndexHint {
+            index: index.into_iden(),
+            r#type: IndexHintType::Use,
+            scope,
+        });
         self
     }
 
@@ -361,7 +371,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .force_index(IndexName::new("IDX_123456"), IndexHintType::All)
+    ///     .force_index(IndexName::new("IDX_123456"), IndexHintScope::All)
     ///     .column(Char::SizeW)
     ///     .to_owned();
     ///
@@ -370,12 +380,15 @@ impl SelectStatement {
     ///     r#"SELECT `size_w` FROM `character` FORCE INDEX (`IDX_123456`)"#
     /// );
     /// ```
-    pub fn force_index<I>(&mut self, index: I, hint_type: IndexHintType) -> &mut Self
+    pub fn force_index<I>(&mut self, index: I, scope: IndexHintScope) -> &mut Self
     where
         I: IntoIden,
     {
-        self.index_hints
-            .push(IndexHint::Force(index.into_iden(), hint_type));
+        self.index_hints.push(IndexHint {
+            index: index.into_iden(),
+            r#type: IndexHintType::Force,
+            scope,
+        });
         self
     }
 
@@ -391,7 +404,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .ignore_index(IndexName::new("IDX_123456"), IndexHintType::All)
+    ///     .ignore_index(IndexName::new("IDX_123456"), IndexHintScope::All)
     ///     .column(Char::SizeW)
     ///     .to_owned();
     ///
@@ -400,12 +413,15 @@ impl SelectStatement {
     ///     r#"SELECT `size_w` FROM `character` IGNORE INDEX (`IDX_123456`)"#
     /// )
     /// ```
-    pub fn ignore_index<I>(&mut self, index: I, hint_type: IndexHintType) -> &mut Self
+    pub fn ignore_index<I>(&mut self, index: I, scope: IndexHintScope) -> &mut Self
     where
         I: IntoIden,
     {
-        self.index_hints
-            .push(IndexHint::Ignore(index.into_iden(), hint_type));
+        self.index_hints.push(IndexHint {
+            index: index.into_iden(),
+            r#type: IndexHintType::Ignore,
+            scope,
+        });
         self
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -243,6 +243,9 @@ pub enum Order {
 #[derive(Debug, Clone)]
 pub struct Alias(String);
 
+/// Helper for create index names
+pub type IndexName = Alias;
+
 /// Null Alias
 #[derive(Default, Debug, Copy, Clone)]
 pub struct NullAlias;

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1006,6 +1006,60 @@ fn select_58() {
 }
 
 #[test]
+fn select_59() {
+    assert_eq!(
+        Query::select()
+            .columns([Char::Character, Char::SizeW, Char::SizeH])
+            .from(Char::Table)
+            .ignore_index(IndexName::new("IDX_123456"), IndexHintType::All)
+            .limit(10)
+            .offset(100)
+            .to_string(MysqlQueryBuilder),
+        "SELECT `character`, `size_w`, `size_h` FROM `character` IGNORE INDEX (`IDX_123456`) LIMIT 10 OFFSET 100"
+    );
+}
+
+#[test]
+fn select_60() {
+    assert_eq!(
+        Query::select()
+            .columns([Char::Character, Char::SizeW, Char::SizeH])
+            .from(Char::Table)
+            .ignore_index(IndexName::new("IDX_123456"), IndexHintType::All)
+            .ignore_index(IndexName::new("IDX_789ABC"), IndexHintType::All)
+            .limit(10)
+            .offset(100)
+            .to_string(MysqlQueryBuilder),
+        "SELECT `character`, `size_w`, `size_h` FROM `character` IGNORE INDEX (`IDX_123456`) IGNORE INDEX (`IDX_789ABC`) LIMIT 10 OFFSET 100"
+    );
+}
+
+#[test]
+fn select_61() {
+    assert_eq!(
+        Query::select()
+            .columns([Char::Character, Char::SizeW, Char::SizeH])
+            .from(Char::Table)
+            .ignore_index(IndexName::new("IDX_123456"), IndexHintType::Join)
+            .use_index(IndexName::new("IDX_789ABC"), IndexHintType::GroupBy)
+            .force_index(IndexName::new("IDX_DEFGHI"), IndexHintType::OrderBy)
+            .limit(10)
+            .offset(100)
+            .to_string(MysqlQueryBuilder),
+        [
+            r#"SELECT `character`, `size_w`, `size_h`"#,
+            r#"FROM `character`"#,
+            r#"IGNORE INDEX FOR JOIN (`IDX_123456`)"#,
+            r#"USE INDEX FOR GROUP BY (`IDX_789ABC`)"#,
+            r#"FORCE INDEX FOR ORDER BY (`IDX_DEFGHI`)"#,
+            r#"LIMIT 10"#,
+            r#"OFFSET 100"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1011,7 +1011,7 @@ fn select_59() {
         Query::select()
             .columns([Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
-            .ignore_index(IndexName::new("IDX_123456"), IndexHintType::All)
+            .ignore_index(IndexName::new("IDX_123456"), IndexHintScope::All)
             .limit(10)
             .offset(100)
             .to_string(MysqlQueryBuilder),
@@ -1025,8 +1025,8 @@ fn select_60() {
         Query::select()
             .columns([Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
-            .ignore_index(IndexName::new("IDX_123456"), IndexHintType::All)
-            .ignore_index(IndexName::new("IDX_789ABC"), IndexHintType::All)
+            .ignore_index(IndexName::new("IDX_123456"), IndexHintScope::All)
+            .ignore_index(IndexName::new("IDX_789ABC"), IndexHintScope::All)
             .limit(10)
             .offset(100)
             .to_string(MysqlQueryBuilder),
@@ -1040,9 +1040,9 @@ fn select_61() {
         Query::select()
             .columns([Char::Character, Char::SizeW, Char::SizeH])
             .from(Char::Table)
-            .ignore_index(IndexName::new("IDX_123456"), IndexHintType::Join)
-            .use_index(IndexName::new("IDX_789ABC"), IndexHintType::GroupBy)
-            .force_index(IndexName::new("IDX_DEFGHI"), IndexHintType::OrderBy)
+            .ignore_index(IndexName::new("IDX_123456"), IndexHintScope::Join)
+            .use_index(IndexName::new("IDX_789ABC"), IndexHintScope::GroupBy)
+            .force_index(IndexName::new("IDX_DEFGHI"), IndexHintScope::OrderBy)
             .limit(10)
             .offset(100)
             .to_string(MysqlQueryBuilder),


### PR DESCRIPTION
## PR Info

I needed a particular feature of MySQL which is [Index Hints (Reference Manual)](https://dev.mysql.com/doc/refman/8.0/en/index-hints.html).
Since I'm working mainly with `sea_orm`, I decided to contribute in order to bring that feature in.
It's my first time contributing on this project and I discovered the source code as I worked on that feature. Please let me know if I missed anything.

I added some functions to `SelectStatement` to add index hints to the query. The default `QueryBuilder` do nothing with these hints, leaving the work to `MysqlQueryBuilder` since I believe not every DBMS supports them.
Since indexes are arbitrary strings, I chose to use a similar syntax to aliases, using `DynIden` to store the name of the index. I also added `IndexName`, which is identical to the `Alias` struct.
I also added some tests in order to verify that the syntax work correctly.

Besides that, I have a question about this project and sea_orm : Upon merge of this PR (if approved), is there anything else to do in order to be able to use these new functions in `sea_orm` ?

## New Features

- Added support for index hints (for MySQL only at the moment)
