### PR TITLE
Resolving `IndexCreateStatement` not generating a valid query when no name is provided

### DIFF
--- a/src/backend/mysql/index.rs
+++ b/src/backend/mysql/index.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const MYSQL_IDENTIFIER_NAME_MAX_LENGTH: usize = 64;
+
 impl IndexBuilder for MysqlQueryBuilder {
     fn prepare_table_index_expression(
         &self,
@@ -37,16 +39,16 @@ impl IndexBuilder for MysqlQueryBuilder {
         self.prepare_index_prefix(create, sql);
         write!(sql, "INDEX ").unwrap();
 
-        if let Some(name) = &create.index.name {
-            write!(
-                sql,
-                "{}{}{}",
-                self.quote().left(),
-                name,
-                self.quote().right()
-            )
-            .unwrap();
-        }
+        let mut name = create.get_name();
+        name.truncate(MYSQL_IDENTIFIER_NAME_MAX_LENGTH);
+        write!(
+            sql,
+            "{}{}{}",
+            self.quote().left(),
+            name,
+            self.quote().right()
+        )
+        .unwrap();
 
         write!(sql, " ON ").unwrap();
         if let Some(table) = &create.table {

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -229,6 +229,16 @@ impl IndexCreateStatement {
         &self.index
     }
 
+    pub(crate) fn get_name(&self) -> String {
+        if let Some(name) = self.index.name.clone() {
+            return name;
+        }
+        let prefix = if self.is_primary_key() {
+            "pri"
+        } else if self.is_unique_key() { "uni" } else { "idx" };
+        format!("{}-{}", prefix, self.index.get_column_names().join("-"))
+    }
+
     pub fn take(&mut self) -> Self {
         Self {
             table: self.table.take(),

--- a/tests/mysql/index.rs
+++ b/tests/mysql/index.rs
@@ -54,6 +54,18 @@ fn create_4() {
 }
 
 #[test]
+fn create_without_name() {
+    assert_eq!(
+        Index::create()
+            .index_type(IndexType::Hash)
+            .table(Glyph::Table)
+            .col(Glyph::Image)
+            .to_string(MysqlQueryBuilder),
+        "CREATE INDEX `idx-image` ON `glyph` (`image`) USING HASH"
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Index::drop()


### PR DESCRIPTION
On mysql systems, the `IndexCreateStatement` will generate a name, if no name was provided, resulting in always having a valid statement regarding the name.

## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-orm/discussions/1620

## Bug Fixes

- [x] The IndexCreateStatement does not work with mysql, if the name is not provided
