### PR TITLE
Add support for custom operators

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -55,6 +55,8 @@ impl QueryBuilder for PostgresQueryBuilder {
                     PgBinOper::StrictWordSimilarityDistance => "<<<->",
                     PgBinOper::GetJsonField => "->",
                     PgBinOper::CastJsonField => "->>",
+                    PgBinOper::Regex => "~",
+                    PgBinOper::RegexCaseInsensitive => "~*",
                 }
             )
             .unwrap(),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1389,7 +1389,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         let no_paren = matches!(op, BinOper::Equal | BinOper::NotEqual);
         let left_paren = left.need_parentheses()
             && left.is_binary()
-            && *op != left.get_bin_oper().unwrap()
+            && op != left.get_bin_oper().unwrap()
             && !no_paren;
         if left_paren {
             write!(sql, "(").unwrap();
@@ -1406,7 +1406,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             BinOper::Between | BinOper::NotBetween | BinOper::Like | BinOper::NotLike
         );
         let right_paren = (right.need_parentheses()
-            || right.is_binary() && *op != left.get_bin_oper().unwrap())
+            || right.is_binary() && op != left.get_bin_oper().unwrap())
             && !no_right_paren
             && !no_paren;
         if right_paren {

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -546,11 +546,6 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     fn prepare_bin_oper_common(&self, bin_oper: &BinOper, sql: &mut dyn SqlWriter) {
-        if let BinOper::Custom(cst) = bin_oper {
-            cst.unquoted(sql.as_writer());
-            return;
-        }
-
         write!(
             sql,
             "{}",
@@ -580,6 +575,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
                 BinOper::RShift => ">>",
                 BinOper::As => "AS",
                 BinOper::Escape => "ESCAPE",
+                BinOper::Custom(raw) => raw,
                 #[allow(unreachable_patterns)]
                 _ => unimplemented!(),
             }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -546,6 +546,11 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     }
 
     fn prepare_bin_oper_common(&self, bin_oper: &BinOper, sql: &mut dyn SqlWriter) {
+        if let BinOper::Custom(cst) = bin_oper {
+            cst.unquoted(sql.as_writer());
+            return;
+        }
+
         write!(
             sql,
             "{}",

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2519,9 +2519,9 @@ impl SimpleExpr {
         )
     }
 
-    pub(crate) fn get_bin_oper(&self) -> Option<BinOper> {
+    pub(crate) fn get_bin_oper(&self) -> Option<&BinOper> {
         match self {
-            Self::Binary(_, oper, _) => Some(oper.clone()),
+            Self::Binary(_, oper, _) => Some(oper),
             _ => None,
         }
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2521,7 +2521,7 @@ impl SimpleExpr {
 
     pub(crate) fn get_bin_oper(&self) -> Option<BinOper> {
         match self {
-            Self::Binary(_, oper, _) => Some(*oper),
+            Self::Binary(_, oper, _) => Some(oper.clone()),
             _ => None,
         }
     }

--- a/src/extension/postgres/mod.rs
+++ b/src/extension/postgres/mod.rs
@@ -29,6 +29,10 @@ pub enum PgBinOper {
     GetJsonField,
     /// `->>`. Retrieves JSON field and casts it to an appropriate SQL type.
     CastJsonField,
+    /// `~` Regex operator.
+    Regex,
+    /// `~*`. Regex operator with case insensitive matching.
+    RegexCaseInsensitive,
 }
 
 impl From<PgBinOper> for BinOper {

--- a/src/types.rs
+++ b/src/types.rs
@@ -72,8 +72,6 @@ impl Clone for SeaRc<dyn Iden> {
     }
 }
 
-impl Eq for SeaRc<dyn Iden> {}
-
 impl PartialEq for SeaRc<dyn Iden> {
     fn eq(&self, other: &Self) -> bool {
         let (self_vtable, other_vtable) = unsafe {
@@ -160,7 +158,7 @@ pub enum UnOper {
 }
 
 /// Binary operator
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinOper {
     And,
     Or,
@@ -187,7 +185,7 @@ pub enum BinOper {
     RShift,
     As,
     Escape,
-    Custom(DynIden),
+    Custom(&'static str),
     #[cfg(feature = "backend-postgres")]
     PgOperator(PgBinOper),
     #[cfg(feature = "backend-sqlite")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -72,6 +72,8 @@ impl Clone for SeaRc<dyn Iden> {
     }
 }
 
+impl Eq for SeaRc<dyn Iden> {}
+
 impl PartialEq for SeaRc<dyn Iden> {
     fn eq(&self, other: &Self) -> bool {
         let (self_vtable, other_vtable) = unsafe {
@@ -158,7 +160,7 @@ pub enum UnOper {
 }
 
 /// Binary operator
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BinOper {
     And,
     Or,
@@ -185,6 +187,7 @@ pub enum BinOper {
     RShift,
     As,
     Escape,
+    Custom(DynIden),
     #[cfg(feature = "backend-postgres")]
     PgOperator(PgBinOper),
     #[cfg(feature = "backend-sqlite")]

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1736,20 +1736,14 @@ fn select_pgtrgm_strict_word_similarity_distance() {
 fn select_custom_operator() {
     assert_eq!(
         Query::select()
-            .expr(Expr::col(Font::Name).binary(
-                BinOper::Custom(Alias::new("~*").into_iden()),
-                Expr::value("serif")
-            ))
+            .expr(Expr::col(Font::Name).binary(BinOper::Custom("~*"), Expr::value("serif")))
             .from(Font::Table)
             .to_string(PostgresQueryBuilder),
         r#"SELECT "name" ~* 'serif' FROM "font""#
     );
     assert_eq!(
         Query::select()
-            .expr(Expr::col(Font::Name).binary(
-                BinOper::Custom(Alias::new("~").into_iden()),
-                Expr::value("serif")
-            ))
+            .expr(Expr::col(Font::Name).binary(BinOper::Custom("~"), Expr::value("serif")))
             .from(Font::Table)
             .to_string(PostgresQueryBuilder),
         r#"SELECT "name" ~ 'serif' FROM "font""#


### PR DESCRIPTION
## PR Info

See SeaORM discord 

## New Features

- Add support for arbitrary custom operators
- Add `Regex` op for Postgres
- Add `RegexCaseInsensitive` op for Postgres

## Notes

This PR is still a little bit rough around the edges, but hey, I'm open to comments. :) 