### PR TITLE
feat: add overlap pg binary operator

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -47,6 +47,7 @@ impl QueryBuilder for PostgresQueryBuilder {
                     PgBinOper::Contains => "@>",
                     PgBinOper::Contained => "<@",
                     PgBinOper::Concatenate => "||",
+                    PgBinOper::Overlap => "&&",
                     PgBinOper::Similarity => "%",
                     PgBinOper::WordSimilarity => "<%",
                     PgBinOper::StrictWordSimilarity => "<<%",

--- a/src/extension/postgres/mod.rs
+++ b/src/extension/postgres/mod.rs
@@ -21,6 +21,7 @@ pub enum PgBinOper {
     Contains,
     Contained,
     Concatenate,
+    Overlap,
     Similarity,
     WordSimilarity,
     StrictWordSimilarity,

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1802,6 +1802,51 @@ fn sub_query_with_fn() {
 }
 
 #[test]
+fn select_array_contains_bin_oper() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).binary(PgBinOper::Contains, Expr::val("test")))
+            .build(PostgresQueryBuilder),
+        (
+            r#"SELECT "character" FROM "character" WHERE "character" @> $1"#.to_owned(),
+            Values(vec!["test".into()])
+        )
+    );
+}
+
+#[test]
+fn select_array_contained_bin_oper() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).binary(PgBinOper::Contained, Expr::val("test")))
+            .build(PostgresQueryBuilder),
+        (
+            r#"SELECT "character" FROM "character" WHERE "character" <@ $1"#.to_owned(),
+            Values(vec!["test".into()])
+        )
+    );
+}
+
+#[test]
+fn select_array_overlap_bin_oper() {
+    assert_eq!(
+        Query::select()
+            .column(Char::Character)
+            .from(Char::Table)
+            .and_where(Expr::col(Char::Character).binary(PgBinOper::Overlap, Expr::val("test")))
+            .build(PostgresQueryBuilder),
+        (
+            r#"SELECT "character" FROM "character" WHERE "character" && $1"#.to_owned(),
+            Values(vec!["test".into()])
+        )
+    );
+}
+
+#[test]
 fn get_json_field_bin_oper() {
     assert_eq!(
         Query::select()


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
Add [overlap](https://www.postgresql.org/docs/current/functions-array.html) binary operator for Postgres.
- Closes https://github.com/SeaQL/sea-query/issues/635

## New Features

- [x] Add overlap operator (`&&`). <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
