### PR TITLE
Allow range of versions for dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,12 @@ derivative = { version = "2.2", default-features = false, optional = true }
 chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }
 postgres-types = { version = "0", default-features = false, optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }
-bigdecimal = { version = "0.3", default-features = false, optional = true }
+bigdecimal = { version = ">=0.3,<0.5", default-features = false, optional = true }
 uuid = { version = "1", default-features = false, optional = true }
 proc-macro2 = { version = "1", default-features = false, optional = true }
 quote = { version = "1", default-features = false, optional = true }
 time = { version = "0.3", default-features = false, optional = true, features = ["macros", "formatting"] }
-ipnetwork = { version = "0.19", default-features = false, optional = true }
+ipnetwork = { version = ">=0.19,<0.21", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
 ordered-float = { version = "3.4", default-features = false, optional = true }
 


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

In my diesel integration, the version of those two dependencies is not able to be the same as the one diesel uses because diesel uses a range and we still don't have public dependencies implemented (https://github.com/rust-lang/rust/issues/44663) so it fails to build because some trait are not implemented on the same version of the children dependencies.

I think this should not impact people using sqlx, but we have to test it to be sure.

## Changes

- [x] Allowing a range of versions of dependencies pre 1
