### PR TITLE
fix: Use correct notation for byte value in postgres

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -123,6 +123,15 @@ impl QueryBuilder for PostgresQueryBuilder {
         write!(buffer, "{string}").unwrap()
     }
 
+    fn write_bytes(&self, bytes: &Box<Vec<u8>>, buffer: &mut String) {
+        write!(
+            buffer,
+            "'\\x{}'",
+            bytes.iter().map(|b| format!("{b:02X}")).collect::<String>()
+        )
+        .unwrap()
+    }
+
     fn if_null_function(&self) -> &str {
         "COALESCE"
     }

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -123,7 +123,7 @@ impl QueryBuilder for PostgresQueryBuilder {
         write!(buffer, "{string}").unwrap()
     }
 
-    fn write_bytes(&self, bytes: &Vec<u8>, buffer: &mut String) {
+    fn write_bytes(&self, bytes: &[u8], buffer: &mut String) {
         write!(
             buffer,
             "'\\x{}'",

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -123,7 +123,7 @@ impl QueryBuilder for PostgresQueryBuilder {
         write!(buffer, "{string}").unwrap()
     }
 
-    fn write_bytes(&self, bytes: &Box<Vec<u8>>, buffer: &mut String) {
+    fn write_bytes(&self, bytes: &Vec<u8>, buffer: &mut String) {
         write!(
             buffer,
             "'\\x{}'",

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1417,7 +1417,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
     #[doc(hidden)]
     /// Write bytes enclosed with engine specific byte syntax
-    fn write_bytes(&self, bytes: &Vec<u8>, buffer: &mut String) {
+    fn write_bytes(&self, bytes: &[u8], buffer: &mut String) {
         write!(
             buffer,
             "x'{}'",

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1417,7 +1417,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
     #[doc(hidden)]
     /// Write bytes enclosed with engine specific byte syntax
-    fn write_bytes(&self, bytes: &Box<Vec<u8>>, buffer: &mut String) {
+    fn write_bytes(&self, bytes: &Vec<u8>, buffer: &mut String) {
         write!(
             buffer,
             "x'{}'",

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1026,12 +1026,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             Value::Char(Some(v)) => {
                 self.write_string_quoted(std::str::from_utf8(&[*v as u8]).unwrap(), &mut s)
             }
-            Value::Bytes(Some(v)) => write!(
-                s,
-                "x'{}'",
-                v.iter().map(|b| format!("{b:02X}")).collect::<String>()
-            )
-            .unwrap(),
+            Value::Bytes(Some(v)) => self.write_bytes(v, &mut s),
             #[cfg(feature = "with-json")]
             Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), &mut s),
             #[cfg(feature = "with-chrono")]
@@ -1418,6 +1413,17 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     /// Write a string surrounded by escaped quotes.
     fn write_string_quoted(&self, string: &str, buffer: &mut String) {
         write!(buffer, "'{}'", self.escape_string(string)).unwrap()
+    }
+
+    #[doc(hidden)]
+    /// Write bytes enclosed with engine specific byte syntax
+    fn write_bytes(&self, bytes: &Box<Vec<u8>>, buffer: &mut String) {
+        write!(
+            buffer,
+            "x'{}'",
+            bytes.iter().map(|b| format!("{b:02X}")).collect::<String>()
+        )
+        .unwrap()
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-query/issues/458

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - None

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - None

## New Features

None

## Bug Fixes

- [x] Binary data was being encoded incorrectly with a Postgres backend.  The fix essentially implements this suggestion: https://github.com/SeaQL/sea-query/pull/459#issuecomment-1305723796

## Breaking Changes

None

## Changes

None (aside from the bug fix described above)
