### PR TITLE
Issue #674: Fix issues with semantics of parenthesis removal

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -85,3 +85,112 @@ pub trait EscapeBuilder {
         output
     }
 }
+
+pub trait PrecedenceDecider {
+    // This method decides which precedence relations should lead to dropped parentheses.
+    // There will be more fine grained precedence relations than the ones represented here,
+    // but dropping parentheses due to these relations can be confusing for readers.
+    fn inner_expr_well_known_greater_precedence(
+        &self,
+        inner: &SimpleExpr,
+        outer_oper: &Oper,
+    ) -> bool;
+}
+
+pub trait OperLeftAssocDecider {
+    // This method decides if the left associativity of an operator should lead to dropped parentheses.
+    // Not all known left associative operators are necessarily included here,
+    // as dropping them may in some cases be confusing to readers.
+    fn well_known_left_associative(&self, op: &BinOper) -> bool;
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Oper {
+    UnOper(UnOper),
+    BinOper(BinOper),
+}
+
+impl From<UnOper> for Oper {
+    fn from(value: UnOper) -> Self {
+        Oper::UnOper(value)
+    }
+}
+
+impl From<BinOper> for Oper {
+    fn from(value: BinOper) -> Self {
+        Oper::BinOper(value)
+    }
+}
+
+impl Oper {
+    pub(crate) fn is_logical(&self) -> bool {
+        matches!(
+            self,
+            Oper::UnOper(UnOper::Not) | Oper::BinOper(BinOper::And) | Oper::BinOper(BinOper::Or)
+        )
+    }
+
+    pub(crate) fn is_between(&self) -> bool {
+        matches!(
+            self,
+            Oper::BinOper(BinOper::Between) | Oper::BinOper(BinOper::NotBetween)
+        )
+    }
+
+    pub(crate) fn is_like(&self) -> bool {
+        matches!(
+            self,
+            Oper::BinOper(BinOper::Like) | Oper::BinOper(BinOper::NotLike)
+        )
+    }
+
+    pub(crate) fn is_in(&self) -> bool {
+        matches!(
+            self,
+            Oper::BinOper(BinOper::In) | Oper::BinOper(BinOper::NotIn)
+        )
+    }
+
+    pub(crate) fn is_is(&self) -> bool {
+        matches!(
+            self,
+            Oper::BinOper(BinOper::Is) | Oper::BinOper(BinOper::IsNot)
+        )
+    }
+
+    pub(crate) fn is_shift(&self) -> bool {
+        matches!(
+            self,
+            Oper::BinOper(BinOper::LShift) | Oper::BinOper(BinOper::RShift)
+        )
+    }
+
+    pub(crate) fn is_arithmetic(&self) -> bool {
+        match self {
+            Oper::BinOper(b) => {
+                matches!(
+                    b,
+                    BinOper::Mul | BinOper::Div | BinOper::Mod | BinOper::Add | BinOper::Sub
+                )
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn is_comparison(&self) -> bool {
+        match self {
+            Oper::BinOper(b) => {
+                matches!(
+                    b,
+                    BinOper::SmallerThan
+                        | BinOper::SmallerThanOrEqual
+                        | BinOper::Equal
+                        | BinOper::GreaterThanOrEqual
+                        | BinOper::GreaterThan
+                        | BinOper::NotEqual
+                )
+            }
+            _ => false,
+        }
+    }
+}

--- a/src/backend/mysql/mod.rs
+++ b/src/backend/mysql/mod.rs
@@ -26,3 +26,19 @@ impl QuotedBuilder for MysqlQueryBuilder {
 impl EscapeBuilder for MysqlQueryBuilder {}
 
 impl TableRefBuilder for MysqlQueryBuilder {}
+
+impl PrecedenceDecider for MysqlQueryBuilder {
+    fn inner_expr_well_known_greater_precedence(
+        &self,
+        inner: &SimpleExpr,
+        outer_oper: &Oper,
+    ) -> bool {
+        common_inner_expr_well_known_greater_precedence(inner, outer_oper)
+    }
+}
+
+impl OperLeftAssocDecider for MysqlQueryBuilder {
+    fn well_known_left_associative(&self, op: &BinOper) -> bool {
+        common_well_known_left_associative(op)
+    }
+}

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1388,6 +1388,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         right: &SimpleExpr,
         sql: &mut dyn SqlWriter,
     ) {
+        // If left has higher precedence than op, we can drop parentheses around left
         let drop_left_higher_precedence =
             simple_expr_greater_precedence_than_op(left, &op.clone().into()).unwrap_or(false);
 
@@ -1418,7 +1419,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         self.prepare_bin_oper(op, sql);
         write!(sql, " ").unwrap();
 
-        // Due to higher precedence, we can drop parentheses around NOT
+        // If right has higher precedence than op, we can drop parentheses around right
         let drop_right_higher_precedence =
             simple_expr_greater_precedence_than_op(right, &op.clone().into()).unwrap_or(false);
 

--- a/src/backend/sqlite/mod.rs
+++ b/src/backend/sqlite/mod.rs
@@ -32,3 +32,19 @@ impl EscapeBuilder for SqliteQueryBuilder {
 }
 
 impl TableRefBuilder for SqliteQueryBuilder {}
+
+impl PrecedenceDecider for SqliteQueryBuilder {
+    fn inner_expr_well_known_greater_precedence(
+        &self,
+        inner: &SimpleExpr,
+        outer_oper: &Oper,
+    ) -> bool {
+        common_inner_expr_well_known_greater_precedence(inner, outer_oper)
+    }
+}
+
+impl OperLeftAssocDecider for SqliteQueryBuilder {
+    fn well_known_left_associative(&self, op: &BinOper) -> bool {
+        common_well_known_left_associative(op)
+    }
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2488,17 +2488,6 @@ impl SimpleExpr {
         self.like_like(BinOper::NotLike, like.into_like_expr())
     }
 
-    pub(crate) fn need_parentheses(&self) -> bool {
-        match self {
-            Self::Binary(left, oper, _) => !matches!(
-                (left.as_ref(), oper),
-                (Self::Binary(_, BinOper::And, _), BinOper::And)
-                    | (Self::Binary(_, BinOper::Or, _), BinOper::Or)
-            ),
-            _ => false,
-        }
-    }
-
     pub(crate) fn is_binary(&self) -> bool {
         matches!(self, Self::Binary(_, _, _))
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -359,11 +359,11 @@ impl Expr {
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `id` = 1 AND 6 = 2 * 3"#
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `id` = 1 AND (6 = 2 * 3)"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "id" = 1 AND 6 = 2 * 3"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "id" = 1 AND (6 = 2 * 3)"#
     /// );
     /// ```
     /// ```
@@ -378,7 +378,7 @@ impl Expr {
     ///
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "id" = 1 AND 6 = 2 * 3"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "id" = 1 AND (6 = 2 * 3)"#
     /// );
     /// ```
     /// ```
@@ -2127,15 +2127,15 @@ impl SimpleExpr {
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE ((`size_w` = 1) AND (`size_h` = 2)) OR ((`size_w` = 3) AND (`size_h` = 4))"#
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE (`size_w` = 1 AND `size_h` = 2) OR (`size_w` = 3 AND `size_h` = 4)"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE (("size_w" = 1) AND ("size_h" = 2)) OR (("size_w" = 3) AND ("size_h" = 4))"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" = 1 AND "size_h" = 2) OR ("size_w" = 3 AND "size_h" = 4)"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE (("size_w" = 1) AND ("size_h" = 2)) OR (("size_w" = 3) AND ("size_h" = 4))"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" = 1 AND "size_h" = 2) OR ("size_w" = 3 AND "size_h" = 4)"#
     /// );
     /// ```
     pub fn and(self, right: SimpleExpr) -> Self {
@@ -2158,15 +2158,15 @@ impl SimpleExpr {
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE ((`size_w` = 1) OR (`size_h` = 2)) AND ((`size_w` = 3) OR (`size_h` = 4))"#
+    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE (`size_w` = 1 OR `size_h` = 2) AND (`size_w` = 3 OR `size_h` = 4)"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE (("size_w" = 1) OR ("size_h" = 2)) AND (("size_w" = 3) OR ("size_h" = 4))"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" = 1 OR "size_h" = 2) AND ("size_w" = 3 OR "size_h" = 4)"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE (("size_w" = 1) OR ("size_h" = 2)) AND (("size_w" = 3) OR ("size_h" = 4))"#
+    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE ("size_w" = 1 OR "size_h" = 2) AND ("size_w" = 3 OR "size_h" = 4)"#
     /// );
     /// ```
     pub fn or(self, right: SimpleExpr) -> Self {
@@ -2490,22 +2490,6 @@ impl SimpleExpr {
 
     pub(crate) fn is_binary(&self) -> bool {
         matches!(self, Self::Binary(_, _, _))
-    }
-
-    pub(crate) fn is_logical(&self) -> bool {
-        match self {
-            Self::Binary(_, op, _) => {
-                matches!(op, BinOper::And | BinOper::Or)
-            }
-            _ => false,
-        }
-    }
-
-    pub(crate) fn is_between(&self) -> bool {
-        matches!(
-            self,
-            Self::Binary(_, BinOper::Between, _) | Self::Binary(_, BinOper::NotBetween, _)
-        )
     }
 
     pub(crate) fn get_bin_oper(&self) -> Option<&BinOper> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@
 //!         r#"SELECT "character" FROM "character""#,
 //!         r#"WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#,
 //!         r#"AND "size_w" IN (SELECT ln(2.4 ^ 1.2))"#,
-//!         r#"AND (("character" LIKE 'D') AND ("character" LIKE 'E'))"#,
+//!         r#"AND ("character" LIKE 'D' AND "character" LIKE 'E')"#,
 //!     ]
 //!     .join(" ")
 //! );

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -326,7 +326,7 @@ fn select_22() {
                 )
             )
             .to_string(MysqlQueryBuilder),
-        "SELECT `character` FROM `character` WHERE (`character` LIKE 'C' OR ((`character` LIKE 'D') AND (`character` LIKE 'E'))) AND ((`character` LIKE 'F') OR (`character` LIKE 'G'))"
+        "SELECT `character` FROM `character` WHERE (`character` LIKE 'C' OR (`character` LIKE 'D' AND `character` LIKE 'E')) AND (`character` LIKE 'F' OR `character` LIKE 'G')"
     );
 }
 

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -138,7 +138,7 @@ fn select_10() {
                 .and(Expr::col((Char::Table, Char::FontId)).equals((Font::Table, Font::Id)))
             )
             .to_string(MysqlQueryBuilder),
-        "SELECT `character` FROM `character` LEFT JOIN `font` ON (`character`.`font_id` = `font`.`id`) AND (`character`.`font_id` = `font`.`id`)"
+        "SELECT `character` FROM `character` LEFT JOIN `font` ON `character`.`font_id` = `font`.`id` AND `character`.`font_id` = `font`.`id`"
     );
 }
 
@@ -500,8 +500,8 @@ fn select_34a() {
             .to_string(MysqlQueryBuilder),
         [
             "SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect`",
-            "HAVING ((`aspect` > 2) OR (`aspect` < 8))",
-            "OR ((`aspect` > 12) AND (`aspect` < 18))",
+            "HAVING `aspect` > 2 OR `aspect` < 8",
+            "OR (`aspect` > 12 AND `aspect` < 18)",
             "OR `aspect` > 32",
         ]
         .join(" ")
@@ -546,10 +546,7 @@ fn select_37() {
         .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
         .build(MysqlQueryBuilder);
 
-    assert_eq!(
-        statement,
-        r#"SELECT `id` FROM `glyph` WHERE (TRUE) OR (FALSE)"#
-    );
+    assert_eq!(statement, r#"SELECT `id` FROM `glyph` WHERE TRUE OR FALSE"#);
     assert_eq!(values.0, vec![]);
 }
 
@@ -688,7 +685,7 @@ fn select_44() {
 
     assert_eq!(
         statement,
-        r#"SELECT `id` FROM `glyph` WHERE NOT (`aspect` < 8)"#
+        r#"SELECT `id` FROM `glyph` WHERE NOT `aspect` < 8"#
     );
 }
 
@@ -725,7 +722,7 @@ fn select_46() {
 
     assert_eq!(
         statement,
-        r#"SELECT `id` FROM `glyph` WHERE NOT (`aspect` < 8)"#
+        r#"SELECT `id` FROM `glyph` WHERE NOT `aspect` < 8"#
     );
 }
 

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -142,7 +142,7 @@ fn select_10() {
                     .and(Expr::col((Char::Table, Char::FontId)).equals((Font::Table, Font::Id)))
             )
             .to_string(PostgresQueryBuilder),
-        r#"SELECT "character" FROM "character" LEFT JOIN "font" ON ("character"."font_id" = "font"."id") AND ("character"."font_id" = "font"."id")"#
+        r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     );
 }
 
@@ -484,8 +484,8 @@ fn select_34a() {
             .to_string(PostgresQueryBuilder),
         [
             r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect""#,
-            r#"HAVING (("aspect" > 2) OR ("aspect" < 8))"#,
-            r#"OR (("aspect" > 12) AND ("aspect" < 18))"#,
+            r#"HAVING "aspect" > 2 OR "aspect" < 8"#,
+            r#"OR ("aspect" > 12 AND "aspect" < 18)"#,
             r#"OR "aspect" > 32"#,
         ]
         .join(" ")
@@ -530,10 +530,7 @@ fn select_37() {
         .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
         .build(PostgresQueryBuilder);
 
-    assert_eq!(
-        statement,
-        r#"SELECT "id" FROM "glyph" WHERE (TRUE) OR (FALSE)"#
-    );
+    assert_eq!(statement, r#"SELECT "id" FROM "glyph" WHERE TRUE OR FALSE"#);
     assert_eq!(values.0, vec![]);
 }
 
@@ -672,7 +669,7 @@ fn select_44() {
 
     assert_eq!(
         statement,
-        r#"SELECT "id" FROM "glyph" WHERE NOT ("aspect" < 8)"#
+        r#"SELECT "id" FROM "glyph" WHERE NOT "aspect" < 8"#
     );
 }
 
@@ -709,7 +706,7 @@ fn select_46() {
 
     assert_eq!(
         statement,
-        r#"SELECT "id" FROM "glyph" WHERE NOT ("aspect" < 8)"#
+        r#"SELECT "id" FROM "glyph" WHERE NOT "aspect" < 8"#
     );
 }
 
@@ -1918,10 +1915,10 @@ fn test_issue_674_nested_logical() {
     let t = SimpleExpr::Value(true.into());
     let f = SimpleExpr::Value(false.into());
 
-    let x_op_y = |x,op,y| SimpleExpr::Binary(Box::new(x), op, Box::new(y));
-    let t_or_t = x_op_y(t.clone(),BinOper::Or, t.clone());
-    let t_or_t_or_f = x_op_y(t_or_t,BinOper::Or, f);
-    let t_or_t_or_t_and_t = x_op_y(t_or_t_or_f.clone(),BinOper::And, t);
+    let x_op_y = |x, op, y| SimpleExpr::Binary(Box::new(x), op, Box::new(y));
+    let t_or_t = x_op_y(t.clone(), BinOper::Or, t.clone());
+    let t_or_t_or_f = x_op_y(t_or_t, BinOper::Or, f);
+    let t_or_t_or_t_and_t = x_op_y(t_or_t_or_f.clone(), BinOper::And, t);
 
     assert_eq!(
         Query::select()
@@ -1939,9 +1936,9 @@ fn test_issue_674_nested_comparison() {
     let int0 = SimpleExpr::Value(0i32.into());
     let int1 = SimpleExpr::Value(1i32.into());
 
-    let x_op_y = |x,op,y| SimpleExpr::Binary(Box::new(x), op, Box::new(y));
-    let t_smaller_than_t = x_op_y(int100,BinOper::SmallerThan, int0);
-    let t_smaller_than_t_smaller_than_f = x_op_y(t_smaller_than_t,BinOper::SmallerThan, int1);
+    let x_op_y = |x, op, y| SimpleExpr::Binary(Box::new(x), op, Box::new(y));
+    let t_smaller_than_t = x_op_y(int100, BinOper::SmallerThan, int0);
+    let t_smaller_than_t_smaller_than_f = x_op_y(t_smaller_than_t, BinOper::SmallerThan, int1);
 
     assert_eq!(
         Query::select()
@@ -1958,8 +1955,8 @@ fn test_issue_674_and_inside_not() {
     let t = SimpleExpr::Value(true.into());
     let f = SimpleExpr::Value(false.into());
 
-    let op_x = |op,x| SimpleExpr::Unary(op, Box::new(x));
-    let x_op_y = |x,op,y| SimpleExpr::Binary(Box::new(x), op, Box::new(y));
+    let op_x = |op, x| SimpleExpr::Unary(op, Box::new(x));
+    let x_op_y = |x, op, y| SimpleExpr::Binary(Box::new(x), op, Box::new(y));
     let f_and_t = x_op_y(f, BinOper::And, t);
     let not_f_and_t = op_x(UnOper::Not, f_and_t);
 

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -315,7 +315,7 @@ fn select_22() {
                     )
             )
             .to_string(PostgresQueryBuilder),
-        r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR (("character" LIKE 'D') AND ("character" LIKE 'E'))) AND (("character" LIKE 'F') OR ("character" LIKE 'G'))"#
+        r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR ("character" LIKE 'D' AND "character" LIKE 'E')) AND ("character" LIKE 'F' OR "character" LIKE 'G')"#
     );
 }
 
@@ -1910,5 +1910,65 @@ fn regex_case_insensitive_bin_oper() {
             r#"SELECT "character" FROM "character" WHERE "character" ~* $1"#.to_owned(),
             Values(vec!["test".into()])
         )
+    );
+}
+
+#[test]
+fn test_issue_674_nested_logical() {
+    let t = SimpleExpr::Value(true.into());
+    let f = SimpleExpr::Value(false.into());
+
+    let x_op_y = |x,op,y| SimpleExpr::Binary(Box::new(x), op, Box::new(y));
+    let t_or_t = x_op_y(t.clone(),BinOper::Or, t.clone());
+    let t_or_t_or_f = x_op_y(t_or_t,BinOper::Or, f);
+    let t_or_t_or_t_and_t = x_op_y(t_or_t_or_f.clone(),BinOper::And, t);
+
+    assert_eq!(
+        Query::select()
+            .columns([Char::Character])
+            .from(Char::Table)
+            .and_where(t_or_t_or_t_and_t)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "character" FROM "character" WHERE (TRUE OR TRUE OR FALSE) AND TRUE"#
+    );
+}
+
+#[test]
+fn test_issue_674_nested_comparison() {
+    let int100 = SimpleExpr::Value(100i32.into());
+    let int0 = SimpleExpr::Value(0i32.into());
+    let int1 = SimpleExpr::Value(1i32.into());
+
+    let x_op_y = |x,op,y| SimpleExpr::Binary(Box::new(x), op, Box::new(y));
+    let t_smaller_than_t = x_op_y(int100,BinOper::SmallerThan, int0);
+    let t_smaller_than_t_smaller_than_f = x_op_y(t_smaller_than_t,BinOper::SmallerThan, int1);
+
+    assert_eq!(
+        Query::select()
+            .columns([Char::Character])
+            .from(Char::Table)
+            .and_where(t_smaller_than_t_smaller_than_f)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "character" FROM "character" WHERE (100 < 0) < 1"#
+    );
+}
+
+#[test]
+fn test_issue_674_and_inside_not() {
+    let t = SimpleExpr::Value(true.into());
+    let f = SimpleExpr::Value(false.into());
+
+    let op_x = |op,x| SimpleExpr::Unary(op, Box::new(x));
+    let x_op_y = |x,op,y| SimpleExpr::Binary(Box::new(x), op, Box::new(y));
+    let f_and_t = x_op_y(f, BinOper::And, t);
+    let not_f_and_t = op_x(UnOper::Not, f_and_t);
+
+    assert_eq!(
+        Query::select()
+            .columns([Char::Character])
+            .from(Char::Table)
+            .and_where(not_f_and_t)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "character" FROM "character" WHERE NOT (FALSE AND TRUE)"#
     );
 }

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1969,3 +1969,17 @@ fn test_issue_674_and_inside_not() {
         r#"SELECT "character" FROM "character" WHERE NOT (FALSE AND TRUE)"#
     );
 }
+
+#[test]
+fn test_issue_674_nested_logical_panic() {
+    let e = SimpleExpr::from(true).and(SimpleExpr::from(true).and(true.into()).and(true.into()));
+
+    assert_eq!(
+        Query::select()
+            .columns([Char::Character])
+            .from(Char::Table)
+            .and_where(e)
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT "character" FROM "character" WHERE TRUE AND (TRUE AND TRUE AND TRUE)"#
+    );
+}

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -315,7 +315,7 @@ fn select_22() {
                     )
             )
             .to_string(SqliteQueryBuilder),
-        r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR (("character" LIKE 'D') AND ("character" LIKE 'E'))) AND (("character" LIKE 'F') OR ("character" LIKE 'G'))"#
+        r#"SELECT "character" FROM "character" WHERE ("character" LIKE 'C' OR ("character" LIKE 'D' AND "character" LIKE 'E')) AND ("character" LIKE 'F' OR "character" LIKE 'G')"#
     );
 }
 

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -142,7 +142,7 @@ fn select_10() {
                     .and(Expr::col((Char::Table, Char::FontId)).equals((Font::Table, Font::Id))),
             )
             .to_string(SqliteQueryBuilder),
-        r#"SELECT "character" FROM "character" LEFT JOIN "font" ON ("character"."font_id" = "font"."id") AND ("character"."font_id" = "font"."id")"#
+        r#"SELECT "character" FROM "character" LEFT JOIN "font" ON "character"."font_id" = "font"."id" AND "character"."font_id" = "font"."id""#
     );
 }
 
@@ -484,8 +484,8 @@ fn select_34a() {
             .to_string(SqliteQueryBuilder),
         [
             r#"SELECT "aspect", MAX("image") FROM "glyph" GROUP BY "aspect""#,
-            r#"HAVING (("aspect" > 2) OR ("aspect" < 8))"#,
-            r#"OR (("aspect" > 12) AND ("aspect" < 18))"#,
+            r#"HAVING "aspect" > 2 OR "aspect" < 8"#,
+            r#"OR ("aspect" > 12 AND "aspect" < 18)"#,
             r#"OR "aspect" > 32"#,
         ]
         .join(" ")
@@ -530,10 +530,7 @@ fn select_37() {
         .cond_where(Cond::any().add(Cond::all()).add(Cond::any()))
         .build(SqliteQueryBuilder);
 
-    assert_eq!(
-        statement,
-        r#"SELECT "id" FROM "glyph" WHERE (TRUE) OR (FALSE)"#
-    );
+    assert_eq!(statement, r#"SELECT "id" FROM "glyph" WHERE TRUE OR FALSE"#);
     assert_eq!(values.0, vec![]);
 }
 
@@ -672,7 +669,7 @@ fn select_44() {
 
     assert_eq!(
         statement,
-        r#"SELECT "id" FROM "glyph" WHERE NOT ("aspect" < 8)"#
+        r#"SELECT "id" FROM "glyph" WHERE NOT "aspect" < 8"#
     );
 }
 
@@ -709,7 +706,7 @@ fn select_46() {
 
     assert_eq!(
         statement,
-        r#"SELECT "id" FROM "glyph" WHERE NOT ("aspect" < 8)"#
+        r#"SELECT "id" FROM "glyph" WHERE NOT "aspect" < 8"#
     );
 }
 


### PR DESCRIPTION
## PR Info
This is my attempt at fixing #674 
- Closes [#674](https://github.com/SeaQL/sea-query/issues/674)

## Bug Fixes
Parenthesis placement is now done based on positive matches with known associativity and precedence rules, and otherwise defaults to placing parentheses. 

- [#674](https://github.com/SeaQL/sea-query/issues/674) identified issues where SQL parenthesis omission did not respect associativity and precedence rules. sea-query only removes parentheses now where it is certain that this respects such rules. 

## Changes
- Parentheses are now dropped from expressions such as 
``` (`character` LIKE 'D') AND (`character` LIKE 'E') ``` since LIKE has stronger precedence than the logical ops. Previously this happened only some times.
