### PR TITLE
#676 Add getters to FunctionCall to make this information available when used as a library

### DIFF
--- a/src/func.rs
+++ b/src/func.rs
@@ -59,6 +59,14 @@ impl FunctionCall {
         self.args = args.into_iter().collect();
         self
     }
+
+    pub fn get_func(&self) -> &Function {
+        &self.func
+    }
+
+    pub fn get_args(&self) -> &Vec<SimpleExpr> {
+        &self.args
+    }
 }
 
 /// Function call helper.


### PR DESCRIPTION
## PR Info

- Closes #676 

## New Features

get_func and get_args on FunctionCall

Not sure if this merits a test case. 