### PR TITLE
On conflict do nothing for MySQL

### DIFF
--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -30,6 +30,24 @@ impl QueryBuilder for MysqlQueryBuilder {
         // MySQL doesn't support declaring materialization in SQL for with query.
     }
 
+    fn prepare_insert(
+        &self,
+        replace: bool,
+        on_conflict: &Option<OnConflict>,
+        sql: &mut dyn SqlWriter,
+    ) {
+        if replace {
+            write!(sql, "REPLACE").unwrap();
+        } else {
+            write!(sql, "INSERT").unwrap();
+        }
+        if let Some(on_conflict) = on_conflict {
+            if on_conflict.action == Some(OnConflictAction::DoNothing) {
+                write!(sql, " IGNORE").unwrap();
+            }
+        }
+    }
+
     fn prepare_join_type(&self, join_type: &JoinType, sql: &mut dyn SqlWriter) {
         match join_type {
             JoinType::FullOuterJoin => panic!("Mysql does not support FULL OUTER JOIN"),
@@ -57,6 +75,21 @@ impl QueryBuilder for MysqlQueryBuilder {
 
     fn prepare_value(&self, value: &Value, sql: &mut dyn SqlWriter) {
         sql.push_param(value.clone(), self as _);
+    }
+
+    #[doc(hidden)]
+    /// Write ON CONFLICT expression
+    fn prepare_on_conflict(&self, on_conflict: &Option<OnConflict>, sql: &mut dyn SqlWriter) {
+        if let Some(on_conflict) = on_conflict {
+            if on_conflict.action == Some(OnConflictAction::DoNothing) {
+                return;
+            }
+            self.prepare_on_conflict_keywords(sql);
+            self.prepare_on_conflict_target(&on_conflict.target, sql);
+            self.prepare_on_conflict_condition(&on_conflict.target_where, sql);
+            self.prepare_on_conflict_action(&on_conflict.action, sql);
+            self.prepare_on_conflict_condition(&on_conflict.action_where, sql);
+        }
     }
 
     fn prepare_on_conflict_target(&self, _: &Option<OnConflictTarget>, _: &mut dyn SqlWriter) {

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -16,7 +16,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
     /// Translate [`InsertStatement`] into SQL statement.
     fn prepare_insert_statement(&self, insert: &InsertStatement, sql: &mut dyn SqlWriter) {
-        self.prepare_insert(insert.replace, sql);
+        self.prepare_insert(insert.replace, &insert.on_conflict, sql);
 
         if let Some(table) = &insert.table {
             write!(sql, " INTO ").unwrap();
@@ -826,7 +826,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         }
     }
 
-    fn prepare_insert(&self, replace: bool, sql: &mut dyn SqlWriter) {
+    fn prepare_insert(&self, replace: bool, _: &Option<OnConflict>, sql: &mut dyn SqlWriter) {
         if replace {
             write!(sql, "REPLACE").unwrap();
         } else {

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -64,6 +64,51 @@ impl OnConflict {
         }
     }
 
+    /// Set ON CONFLICT do nothing
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::insert()
+    ///     .into_table(Glyph::Table)
+    ///     .columns([Glyph::Aspect, Glyph::Image])
+    ///     .values_panic(["abcd".into(), 3.1415.into()])
+    ///     .on_conflict(
+    ///         OnConflict::columns([Glyph::Id, Glyph::Aspect])
+    ///             .do_nothing()
+    ///             .to_owned(),
+    ///     )
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     [
+    ///         r#"INSERT IGNORE INTO `glyph` (`aspect`, `image`)"#,
+    ///         r#"VALUES ('abcd', 3.1415)"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     [
+    ///         r#"INSERT INTO "glyph" ("aspect", "image")"#,
+    ///         r#"VALUES ('abcd', 3.1415)"#,
+    ///         r#"ON CONFLICT ("id", "aspect") DO NOTHING"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     [
+    ///         r#"INSERT INTO "glyph" ("aspect", "image")"#,
+    ///         r#"VALUES ('abcd', 3.1415)"#,
+    ///         r#"ON CONFLICT ("id", "aspect") DO NOTHING"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    /// ```
     pub fn do_nothing(&mut self) -> &mut Self {
         self.action = Some(OnConflictAction::DoNothing);
         self

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1143,6 +1143,27 @@ fn insert_from_select() {
 
 #[test]
 #[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(OnConflict::new().do_nothing().to_owned())
+            .to_string(MysqlQueryBuilder),
+        [
+            r#"INSERT IGNORE INTO `glyph` (`aspect`, `image`)"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
 fn insert_on_conflict_0() {
     assert_eq!(
         Query::insert()

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1280,6 +1280,28 @@ fn insert_10() {
 
 #[test]
 #[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(OnConflict::column(Glyph::Id).do_nothing().to_owned())
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON CONFLICT ("id") DO NOTHING"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
 fn insert_on_conflict_1() {
     assert_eq!(
         Query::insert()

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1211,6 +1211,28 @@ fn insert_7() {
 
 #[test]
 #[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(OnConflict::column(Glyph::Id).do_nothing().to_owned())
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON CONFLICT ("id") DO NOTHING"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
 fn insert_on_conflict_1() {
     assert_eq!(
         Query::insert()


### PR DESCRIPTION
Continuing #680

However I want to gather comments here whether `INSERT IGNORE` is a good substitution for ON CONFLICT DO NOTHING

It seems a better way would be to do `ON DUPLICATE KEY UPDATE id=id`, however this requires us to add an API to the frontend to allow users to pass in the primary key.

https://stackoverflow.com/questions/4596390/insert-on-duplicate-key-do-nothing