### PR TITLE
On conflict do nothing for MySql 

### DIFF
--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -30,10 +30,20 @@ impl QueryBuilder for MysqlQueryBuilder {
         // MySQL doesn't support declaring materialization in SQL for with query.
     }
 
-    fn prepare_ignore(&self, on_conflict: &Option<OnConflict>, sql: &mut dyn SqlWriter) {
+    fn prepare_insert(
+        &self,
+        replace: bool,
+        on_conflict: &Option<OnConflict>,
+        sql: &mut dyn SqlWriter,
+    ) {
+        if replace {
+            write!(sql, "REPLACE").unwrap();
+        } else {
+            write!(sql, "INSERT").unwrap();
+        }
         if let Some(on_conflict) = on_conflict {
             if on_conflict.action == Some(OnConflictAction::DoNothing) {
-                write!(sql, " IGNORE ").unwrap();
+                write!(sql, " IGNORE").unwrap();
             }
         }
     }

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -127,9 +127,7 @@ impl QueryBuilder for MysqlQueryBuilder {
     }
 
     fn prepare_on_conflict_excluded_table(&self, col: &DynIden, sql: &mut dyn SqlWriter) {
-        write!(sql, "VALUES(").unwrap();
         col.prepare(sql.as_writer(), self.quote());
-        write!(sql, ")").unwrap();
     }
 
     fn prepare_on_conflict_condition(&self, _: &ConditionHolder, _: &mut dyn SqlWriter) {}

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1142,7 +1142,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     ) {
         if let Some(action) = on_conflict_action {
             match action {
-                OnConflictAction::DoNothing => {
+                OnConflictAction::DoNothing(_) => {
                     write!(sql, " DO NOTHING").unwrap();
                 }
                 OnConflictAction::Update(update_strats) => {

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -16,9 +16,7 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
 
     /// Translate [`InsertStatement`] into SQL statement.
     fn prepare_insert_statement(&self, insert: &InsertStatement, sql: &mut dyn SqlWriter) {
-        self.prepare_insert(insert.replace, sql);
-
-        self.prepare_ignore(&insert.on_conflict, sql);
+        self.prepare_insert(insert.replace, &insert.on_conflict, sql);
 
         if let Some(table) = &insert.table {
             write!(sql, " INTO ").unwrap();
@@ -827,16 +825,13 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
         }
     }
 
-    fn prepare_insert(&self, replace: bool, sql: &mut dyn SqlWriter) {
+    fn prepare_insert(&self, replace: bool, _: &Option<OnConflict>, sql: &mut dyn SqlWriter) {
         if replace {
             write!(sql, "REPLACE").unwrap();
         } else {
             write!(sql, "INSERT").unwrap();
         }
     }
-
-    /// helper function, adding IGNORE in insert statement for MySQL
-    fn prepare_ignore(&self, _: &Option<OnConflict>, _: &mut dyn SqlWriter) {}
 
     fn prepare_function(&self, function: &Function, sql: &mut dyn SqlWriter) {
         self.prepare_function_common(function, sql)

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -18,6 +18,8 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
     fn prepare_insert_statement(&self, insert: &InsertStatement, sql: &mut dyn SqlWriter) {
         self.prepare_insert(insert.replace, sql);
 
+        self.prepare_ignore(&insert.on_conflict, sql);
+
         if let Some(table) = &insert.table {
             write!(sql, " INTO ").unwrap();
             self.prepare_table_ref(table, sql);
@@ -832,6 +834,9 @@ pub trait QueryBuilder: QuotedBuilder + EscapeBuilder + TableRefBuilder {
             write!(sql, "INSERT").unwrap();
         }
     }
+
+    /// helper function, adding IGNORE in insert statement for MySQL
+    fn prepare_ignore(&self, _: &Option<OnConflict>, _: &mut dyn SqlWriter) {}
 
     fn prepare_function(&self, function: &Function, sql: &mut dyn SqlWriter) {
         self.prepare_function_common(function, sql)

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -134,12 +134,14 @@ impl OnConflict {
     ///     ]
     ///     .join(" ")
     /// );
-    pub fn do_nothing_mysql<C, I>(&mut self, pk_cols: I) -> &mut Self 
+    pub fn do_nothing_mysql<C, I>(&mut self, pk_cols: I) -> &mut Self
     where
         C: IntoIden,
         I: IntoIterator<Item = C>,
     {
-        self.action = Some(OnConflictAction::DoNothing(pk_cols.into_iter().map(IntoIden::into_iden).collect()));
+        self.action = Some(OnConflictAction::DoNothing(
+            pk_cols.into_iter().map(IntoIden::into_iden).collect(),
+        ));
         self
     }
 

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -108,7 +108,7 @@ impl OnConflict {
     }
 
     /// Set ON CONFLICT do nothing specifically for MySql.
-    /// 
+    ///
     ///
     /// # Examples
     ///

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -64,6 +64,51 @@ impl OnConflict {
         }
     }
 
+    /// Set ON CONFLICT do nothing
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::insert()
+    ///     .into_table(Glyph::Table)
+    ///     .columns([Glyph::Aspect, Glyph::Image])
+    ///     .values_panic(["abcd".into(), 3.1415.into()])
+    ///     .on_conflict(
+    ///         OnConflict::columns([Glyph::Id, Glyph::Aspect])
+    ///             .do_nothing()
+    ///             .to_owned(),
+    ///     )
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     [
+    ///         r#"INSERT IGNORE INTO `glyph` (`aspect`, `image`)"#,
+    ///         r#"VALUES ('abcd', 3.1415)"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     [
+    ///         r#"INSERT INTO "glyph" ("aspect", "image")"#,
+    ///         r#"VALUES ('abcd', 3.1415)"#,
+    ///         r#"ON CONFLICT ("id", "aspect") DO NOTHING"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     [
+    ///         r#"INSERT INTO "glyph" ("aspect", "image")"#,
+    ///         r#"VALUES ('abcd', 3.1415)"#,
+    ///         r#"ON CONFLICT ("id", "aspect") DO NOTHING"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    /// ```
     pub fn do_nothing(&mut self) -> &mut Self {
         self.action = Some(OnConflictAction::DoNothing);
         self

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -107,7 +107,7 @@ impl OnConflict {
         self
     }
 
-    /// Set ON CONFLICT do nothing. 
+    /// Set ON CONFLICT do nothing.
     /// MySql only.
     ///
     /// # Examples

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -65,7 +65,7 @@ impl OnConflict {
     }
 
     /// Set ON CONFLICT do nothing.
-    /// Please use do_nothing_mysql() and provide pkcols if you are using MySql
+    /// Please use do_nothing_on() and provide primary keys if you are using MySql.
     ///
     /// # Examples
     ///
@@ -107,8 +107,8 @@ impl OnConflict {
         self
     }
 
-    /// Set ON CONFLICT do nothing specifically for MySql.
-    ///
+    /// Set ON CONFLICT do nothing. 
+    /// MySql only.
     ///
     /// # Examples
     ///
@@ -121,7 +121,7 @@ impl OnConflict {
     ///     .values_panic(["abcd".into(), 3.1415.into()])
     ///     .on_conflict(
     ///         OnConflict::columns([Glyph::Id, Glyph::Aspect])
-    ///             .do_nothing_mysql(vec![Glyph::Id])
+    ///             .do_nothing_on(vec![Glyph::Id])
     ///             .to_owned(),
     ///     )
     ///     .to_owned();
@@ -135,7 +135,8 @@ impl OnConflict {
     ///     ]
     ///     .join(" ")
     /// );
-    pub fn do_nothing_mysql<C, I>(&mut self, pk_cols: I) -> &mut Self
+    #[cfg(feature = "backend-mysql")]
+    pub fn do_nothing_on<C, I>(&mut self, pk_cols: I) -> &mut Self
     where
         C: IntoIden,
         I: IntoIterator<Item = C>,

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -108,6 +108,7 @@ impl OnConflict {
     }
 
     /// Set ON CONFLICT do nothing specifically for MySql.
+    /// 
     ///
     /// # Examples
     ///
@@ -130,7 +131,7 @@ impl OnConflict {
     ///     [
     ///         r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
     ///         r#"VALUES ('abcd', 3.1415)"#,
-    ///         r#"ON DUPLICATE KEY UPDATE `id` = VALUES(`id`)"#,
+    ///         r#"ON DUPLICATE KEY UPDATE `id` = `id`"#,
     ///     ]
     ///     .join(" ")
     /// );
@@ -172,7 +173,7 @@ impl OnConflict {
     ///     [
     ///         r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
     ///         r#"VALUES ('abcd', 3.1415)"#,
-    ///         r#"ON DUPLICATE KEY UPDATE `aspect` = VALUES(`aspect`), `image` = 1 + 2"#,
+    ///         r#"ON DUPLICATE KEY UPDATE `aspect` = `aspect`, `image` = 1 + 2"#,
     ///     ]
     ///     .join(" ")
     /// );
@@ -225,7 +226,7 @@ impl OnConflict {
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (2, 3) ON DUPLICATE KEY UPDATE `aspect` = VALUES(`aspect`), `image` = VALUES(`image`)"#
+    ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (2, 3) ON DUPLICATE KEY UPDATE `aspect` = `aspect`, `image` = `image`"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1152,11 +1152,7 @@ fn insert_on_conflict_do_nothing() {
                 "04108048005887010020060000204E0180400400".into(),
                 3.1415.into(),
             ])
-            .on_conflict(
-                OnConflict::new()
-                    .do_nothing_on(vec![Glyph::Id])
-                    .to_owned()
-            )
+            .on_conflict(OnConflict::new().do_nothing_on(vec![Glyph::Id]).to_owned())
             .to_string(MysqlQueryBuilder),
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1161,7 +1161,7 @@ fn insert_on_conflict_do_nothing() {
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
-            r#"ON DUPLICATE KEY UPDATE `id` = VALUES(`id`)"#,
+            r#"ON DUPLICATE KEY UPDATE `id` = `id`"#,
         ]
         .join(" ")
     );
@@ -1187,7 +1187,7 @@ fn insert_on_conflict_0() {
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
-            r#"ON DUPLICATE KEY UPDATE `aspect` = VALUES(`aspect`), `image` = VALUES(`image`)"#,
+            r#"ON DUPLICATE KEY UPDATE `aspect` = `aspect`, `image` = `image`"#,
         ]
         .join(" ")
     );
@@ -1213,7 +1213,7 @@ fn insert_on_conflict_1() {
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
-            r#"ON DUPLICATE KEY UPDATE `aspect` = VALUES(`aspect`)"#,
+            r#"ON DUPLICATE KEY UPDATE `aspect` = `aspect`"#,
         ]
         .join(" ")
     );
@@ -1239,7 +1239,7 @@ fn insert_on_conflict_2() {
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
-            r#"ON DUPLICATE KEY UPDATE `aspect` = VALUES(`aspect`), `image` = VALUES(`image`)"#,
+            r#"ON DUPLICATE KEY UPDATE `aspect` = `aspect`, `image` = `image`"#,
         ]
         .join(" ")
     );
@@ -1321,7 +1321,7 @@ fn insert_on_conflict_5() {
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
-            r#"ON DUPLICATE KEY UPDATE `aspect` = '04108048005887010020060000204E0180400400', `image` = VALUES(`image`)"#,
+            r#"ON DUPLICATE KEY UPDATE `aspect` = '04108048005887010020060000204E0180400400', `image` = `image`"#,
         ]
         .join(" ")
     );
@@ -1348,7 +1348,7 @@ fn insert_on_conflict_6() {
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
-            r#"ON DUPLICATE KEY UPDATE `aspect` = VALUES(`aspect`), `image` = 1 + 2"#,
+            r#"ON DUPLICATE KEY UPDATE `aspect` = `aspect`, `image` = 1 + 2"#,
         ]
         .join(" ")
     );

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1143,6 +1143,27 @@ fn insert_from_select() {
 
 #[test]
 #[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(OnConflict::new().do_nothing().to_owned())
+            .to_string(MysqlQueryBuilder),
+        [
+            r#"INSERT IGNORE INTO `glyph` (`aspect`, `image`)"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
 fn insert_on_conflict_0() {
     assert_eq!(
         Query::insert()

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1152,7 +1152,11 @@ fn insert_on_conflict_do_nothing() {
                 "04108048005887010020060000204E0180400400".into(),
                 3.1415.into(),
             ])
-            .on_conflict(OnConflict::new().do_nothing_mysql(vec![Glyph::Id]).to_owned())
+            .on_conflict(
+                OnConflict::new()
+                    .do_nothing_mysql(vec![Glyph::Id])
+                    .to_owned()
+            )
             .to_string(MysqlQueryBuilder),
         [
             r#"INSERT INTO `glyph` (`aspect`, `image`)"#,

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1154,7 +1154,7 @@ fn insert_on_conflict_do_nothing() {
             ])
             .on_conflict(
                 OnConflict::new()
-                    .do_nothing_mysql(vec![Glyph::Id])
+                    .do_nothing_on(vec![Glyph::Id])
                     .to_owned()
             )
             .to_string(MysqlQueryBuilder),

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1152,11 +1152,12 @@ fn insert_on_conflict_do_nothing() {
                 "04108048005887010020060000204E0180400400".into(),
                 3.1415.into(),
             ])
-            .on_conflict(OnConflict::new().do_nothing().to_owned())
+            .on_conflict(OnConflict::new().do_nothing_mysql(vec![Glyph::Id]).to_owned())
             .to_string(MysqlQueryBuilder),
         [
-            r#"INSERT IGNORE INTO `glyph` (`aspect`, `image`)"#,
+            r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
             r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON DUPLICATE KEY UPDATE `id` = VALUES(`id`)"#,
         ]
         .join(" ")
     );

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1280,6 +1280,28 @@ fn insert_10() {
 
 #[test]
 #[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(OnConflict::column(Glyph::Id).do_nothing().to_owned())
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON CONFLICT ("id") DO NOTHING"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
 fn insert_on_conflict_1() {
     assert_eq!(
         Query::insert()

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1211,6 +1211,28 @@ fn insert_7() {
 
 #[test]
 #[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(OnConflict::column(Glyph::Id).do_nothing().to_owned())
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON CONFLICT ("id") DO NOTHING"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
 fn insert_on_conflict_1() {
     assert_eq!(
         Query::insert()


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Partially closes https://github.com/SeaQL/sea-orm/issues/1790

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [ ] <!-- what are the new features? --> added do_nothing_mysql([pk_cols]). This is to replace do_nothing() with MySql, require user to input the primary key columns manually.

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug --> fixed a bug where do_nothing() will return syntax error with MySql. See New Features for the new function.

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
