### PR TITLE
fix: misbehavior in FunctionCall when calling arg multiple times

### DIFF
--- a/src/func.rs
+++ b/src/func.rs
@@ -48,7 +48,7 @@ impl FunctionCall {
     where
         T: Into<SimpleExpr>,
     {
-        self.args = vec![arg.into()];
+        self.args.push(arg.into());
         self
     }
 


### PR DESCRIPTION
## Bug Fixes

- misbehaviour in `FunctionCall` when calling `.arg()` multiple times, it always overrides the previous values instead of appending them.
