### PR TITLE
Support adding expressions for  ON CONFLICT targets

### DIFF
--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -59,7 +59,7 @@ impl QueryBuilder for MysqlQueryBuilder {
         sql.push_param(value.clone(), self as _);
     }
 
-    fn prepare_on_conflict_target(&self, _: &Option<OnConflictTarget>, _: &mut dyn SqlWriter) {
+    fn prepare_on_conflict_target(&self, _: &[OnConflictTarget], _: &mut dyn SqlWriter) {
         // MySQL doesn't support declaring ON CONFLICT target.
     }
 

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -57,7 +57,10 @@ impl OnConflict {
         I: IntoIterator<Item = C>,
     {
         Self {
-            targets: columns.into_iter().map(|c| OnConflictTarget::ConflictColumn(c.into_iden())).collect(),
+            targets: columns
+                .into_iter()
+                .map(|c| OnConflictTarget::ConflictColumn(c.into_iden()))
+                .collect(),
             target_where: ConditionHolder::new(),
             action: None,
             action_where: ConditionHolder::new(),
@@ -128,7 +131,12 @@ impl OnConflict {
         T: Into<SimpleExpr>,
         I: IntoIterator<Item = T>,
     {
-        self.targets.append(&mut exprs.into_iter().map(|e: T| OnConflictTarget::ConflictExpr(e.into())).collect());
+        self.targets.append(
+            &mut exprs
+                .into_iter()
+                .map(|e: T| OnConflictTarget::ConflictExpr(e.into()))
+                .collect(),
+        );
         self
     }
 

--- a/src/query/on_conflict.rs
+++ b/src/query/on_conflict.rs
@@ -77,16 +77,13 @@ impl OnConflict {
     /// let query = Query::insert()
     ///     .into_table(Glyph::Table)
     ///     .columns([Glyph::Aspect, Glyph::Image])
-    ///     .values_panic([
-    ///         "abcd".into(),
-    ///         3.1415.into(),
-    ///     ])
+    ///     .values_panic(["abcd".into(), 3.1415.into()])
     ///     .on_conflict(
     ///         OnConflict::new()
     ///             .expr(Expr::col(Glyph::Id))
     ///             .update_column(Glyph::Aspect)
     ///             .value(Glyph::Image, Expr::val(1).add(2))
-    ///             .to_owned()
+    ///             .to_owned(),
     ///     )
     ///     .to_owned();
     ///

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1438,6 +1438,87 @@ fn insert_on_conflict_6() {
 
 #[test]
 #[allow(clippy::approx_constant)]
+fn insert_on_conflict_7() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(
+                OnConflict::new()
+                    .expr(Expr::col(Glyph::Id))
+                    .update_column(Glyph::Aspect)
+                    .to_owned()
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON CONFLICT ("id") DO UPDATE SET "aspect" = "excluded"."aspect""#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
+fn insert_on_conflict_8() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(
+                OnConflict::new()
+                    .exprs([Expr::col(Glyph::Id), Expr::col(Glyph::Aspect)])
+                    .update_column(Glyph::Aspect)
+                    .to_owned()
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON CONFLICT ("id", "aspect") DO UPDATE SET "aspect" = "excluded"."aspect""#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
+fn insert_on_conflict_9() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(
+                OnConflict::column(Glyph::Id)
+                    .expr(Func::lower(Expr::col(Glyph::Tokens)))
+                    .update_column(Glyph::Aspect)
+                    .to_owned()
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON CONFLICT ("id", LOWER("tokens")) DO UPDATE SET "aspect" = "excluded"."aspect""#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
 fn insert_returning_all_columns() {
     assert_eq!(
         Query::insert()

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1369,6 +1369,87 @@ fn insert_on_conflict_6() {
 
 #[test]
 #[allow(clippy::approx_constant)]
+fn insert_on_conflict_7() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(
+                OnConflict::new()
+                    .expr(Expr::col(Glyph::Id))
+                    .update_column(Glyph::Aspect)
+                    .to_owned()
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON CONFLICT ("id") DO UPDATE SET "aspect" = "excluded"."aspect""#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
+fn insert_on_conflict_8() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(
+                OnConflict::new()
+                    .exprs([Expr::col(Glyph::Id), Expr::col(Glyph::Aspect)])
+                    .update_column(Glyph::Aspect)
+                    .to_owned()
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON CONFLICT ("id", "aspect") DO UPDATE SET "aspect" = "excluded"."aspect""#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
+fn insert_on_conflict_9() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic([
+                "04108048005887010020060000204E0180400400".into(),
+                3.1415.into(),
+            ])
+            .on_conflict(
+                OnConflict::column(Glyph::Id)
+                    .expr(Func::lower(Expr::col(Glyph::Tokens)))
+                    .update_column(Glyph::Aspect)
+                    .to_owned()
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('04108048005887010020060000204E0180400400', 3.1415)"#,
+            r#"ON CONFLICT ("id", LOWER("tokens")) DO UPDATE SET "aspect" = "excluded"."aspect""#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
 fn insert_returning_all_columns() {
     assert_eq!(
         Query::insert()


### PR DESCRIPTION
## PR Info

Supports adding expressions to `ON CONFLICT` targets on supported databases (postgres, and sqlite);
```sql
INSERT ... ON CONFLICT ("id", LOWER("email")) DO UPDATE SET "name" = "excluded"."name"
```
- Closes #678 

## New Features

- [x] Added an `OnConflict::expr()` and `OnConflict::exprs()` impls to support adding custom expressions to on_conflict targets

## Breaking Changes

None

## Changes

None
