### PR TITLE
Fix incorrect behavior when adding an autoincrement column to a Postg…

### DIFF
--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -112,7 +112,11 @@ impl TableBuilder for PostgresQueryBuilder {
                     let f = |column_def: &ColumnDef, sql: &mut dyn SqlWriter| {
                         if let Some(column_type) = &column_def.types {
                             write!(sql, " ").unwrap();
-                            if column_def.spec.iter().any(|v| matches!(v, ColumnSpec::AutoIncrement)) {
+                            if column_def
+                                .spec
+                                .iter()
+                                .any(|v| matches!(v, ColumnSpec::AutoIncrement))
+                            {
                                 self.prepare_column_auto_increment(column_type, sql);
                             } else {
                                 self.prepare_column_type(column_type, sql);

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -112,7 +112,11 @@ impl TableBuilder for PostgresQueryBuilder {
                     let f = |column_def: &ColumnDef, sql: &mut dyn SqlWriter| {
                         if let Some(column_type) = &column_def.types {
                             write!(sql, " ").unwrap();
-                            self.prepare_column_type(column_type, sql);
+                            if column_def.spec.iter().any(|v| matches!(v, ColumnSpec::AutoIncrement)) {
+                                self.prepare_column_auto_increment(column_type, sql);
+                            } else {
+                                self.prepare_column_type(column_type, sql);
+                            }
                         }
                     };
                     self.prepare_column_def_common(column, sql, f);

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -519,7 +519,7 @@ fn alter_9() {
 
 #[test]
 fn alter_10() {
-    // https://dbfiddle.uk/PQksflGf
+    // https://dbfiddle.uk/BeiZPvBe
     assert_eq!(
         Table::alter()
             .table(Glyph::Table)
@@ -534,7 +534,7 @@ fn alter_10() {
             .to_string(PostgresQueryBuilder),
         [
             r#"ALTER TABLE "glyph""#,
-            r#"ADD COLUMN "aspect" integer NOT NULL UNIQUE PRIMARY KEY"#,
+            r#"ADD COLUMN "aspect" serial NOT NULL UNIQUE PRIMARY KEY"#,
         ]
         .join(" ")
     );


### PR DESCRIPTION
## PR Info

## Bug Fixes

Using the `PostgresQueryBuilder` I would've expected this:
```rs
Table::alter()
	.table(Test::Table)
	.add_column(
		ColumnDef::new(Test::Id)
			.integer()
			.auto_increment()
			.primary_key(),
	)
```

to give me: (This behavior is true if you use `Table::create`)
```ALTER TABLE "test" ADD COLUMN "id" serial PRIMARY KEY```

Instead it gave me:
```ALTER TABLE "test" ADD COLUMN "id" integer PRIMARY KEY```

## Breaking Changes

If someone was using `auto_increment()` on anything but an `integer`, `smallinteger`, or `biginteger` it would cause a panic.

## Changes

Modified the postgres `alter_10` test to test against the correct behavior.
