### PR TITLE
feat: setup `rust-toolchain.toml` to use nightly by default

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Introduces `rust-toolchain.toml` which forces `cargo` to use latest Nightly.
This is useful for users using `stable` as the default toolchain, Rustup
responds to the presence of this file as follows:

```
➜  sea-query git:(master) rustup default stable
info: using existing install for 'stable-aarch64-apple-darwin'
info: default toolchain set to 'stable-aarch64-apple-darwin'

  stable-aarch64-apple-darwin unchanged - rustc 1.72.0 (5680fa18f 2023-08-23)

info: note that the toolchain 'nightly-aarch64-apple-darwin' is currently in use (overridden by '~/Repos/sea-query/rust-toolchain.toml')
```