### PR TITLE
Add support for `COUNT(DISTINCT a)`

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1430,6 +1430,35 @@ impl Expr {
         Func::count(self.left).into()
     }
 
+    /// Express a `COUNT` function with the DISTINCT modifier.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Expr::col((Char::Table, Char::SizeW)).count_distinct())
+    ///     .from(Char::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT COUNT(DISTINCT `character`.`size_w`) FROM `character`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT COUNT(DISTINCT "character"."size_w") FROM "character""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT COUNT(DISTINCT "character"."size_w") FROM "character""#
+    /// );
+    /// ```
+    pub fn count_distinct(self) -> SimpleExpr {
+        Func::count_distinct(self.left).into()
+    }
+
     /// Express a `IF NULL` function.
     ///
     /// # Examples


### PR DESCRIPTION
## PR Info

- Closes #600 

## New Features

- Add `count_distinct` in `Expr` and `Func` which corresponds to `COUNT(DISTINCT a)`

## Changes

- Add a new `bool` parameter to `FunctionCall` named `distinct` which will keep track if the `DISTINCT` modifier needs to be applied for the first argument.

### Note: 

For now, adding the `distinct` parameter to `FunctionCall` may seem like an overkill to support just one use case, but in the future more functions could be added that support the `DISTINCT` modifier. Technically every aggregate function actually supports it but they are rarely used except for `COUNT`.