### PR TITLE
Migrate sea-query-derive to syn 2

### DIFF
--- a/sea-query-derive/Cargo.toml
+++ b/sea-query-derive/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.60"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", default-features = false, features = ["parsing", "proc-macro", "derive", "printing"] }
+syn = { version = "2", default-features = false, features = ["parsing", "proc-macro", "derive", "printing"] }
 quote = { version = "1", default-features = false }
 heck = { version = "0.4", default-features = false }
 proc-macro2 = { version = "1", default-features = false }

--- a/sea-query-derive/src/iden_attr.rs
+++ b/sea-query-derive/src/iden_attr.rs
@@ -1,6 +1,7 @@
 use std::convert::{TryFrom, TryInto};
 
-use syn::{Attribute, Error, Ident, Lit, Meta, MetaNameValue, NestedMeta};
+use syn::spanned::Spanned;
+use syn::{Attribute, Error, Expr, ExprLit, Ident, Lit, LitStr, Meta};
 
 use crate::{error::ErrorMsg, iden_path::IdenPath};
 
@@ -14,8 +15,13 @@ pub(crate) enum IdenAttr {
 impl IdenAttr {
     fn extract_method(meta: Meta) -> syn::Result<Self> {
         match meta {
-            Meta::NameValue(nv) => match nv.lit {
-                Lit::Str(name) => Ok(Self::Method(Ident::new(name.value().as_str(), name.span()))),
+            Meta::NameValue(nv) => match nv.value {
+                Expr::Lit(ExprLit { lit, .. }) => match lit {
+                    Lit::Str(name) => {
+                        Ok(Self::Method(Ident::new(name.value().as_str(), name.span())))
+                    }
+                    _ => Err(Error::new_spanned(nv.eq_token, ErrorMsg::WrongLiteral)),
+                },
                 _ => Err(Error::new_spanned(nv, ErrorMsg::WrongLiteral)),
             },
             a => Err(Error::new_spanned(
@@ -27,37 +33,39 @@ impl IdenAttr {
 
     fn extract_iden(meta: Meta) -> syn::Result<Self> {
         match &meta {
-            Meta::NameValue(nv) => match &nv.lit {
-                Lit::Str(lit) => Ok(IdenAttr::Rename(lit.value())),
-                _ => Err(Error::new_spanned(&nv.lit, ErrorMsg::WrongLiteral)),
+            Meta::NameValue(nv) => match &nv.value {
+                Expr::Lit(ExprLit { lit, .. }) => match lit {
+                    Lit::Str(lit) => Ok(IdenAttr::Rename(lit.value())),
+                    _ => Err(Error::new_spanned(&nv.value, ErrorMsg::WrongLiteral)),
+                },
+                _ => Err(Error::new_spanned(nv, ErrorMsg::WrongLiteral)),
             },
-            Meta::List(list) => match list.nested.first() {
-                Some(NestedMeta::Meta(Meta::Path(p))) if p.is_ident(&IdenPath::Flatten) => {
-                    Ok(IdenAttr::Flatten)
-                }
-                Some(NestedMeta::Meta(Meta::NameValue(nv))) => Self::extract_named_value_iden(nv),
-                _ => Err(Error::new_spanned(meta, ErrorMsg::WrongListFormat)),
-            },
-            a => Err(Error::new_spanned(a, ErrorMsg::WrongAttributeFormat)),
-        }
-    }
-
-    fn extract_named_value_iden(nv: &MetaNameValue) -> syn::Result<Self> {
-        match &nv.lit {
-            Lit::Str(name) => {
-                // Don't match "iden" since that would mean `#[iden(iden = "name")]` would be accepted
-                if nv.path.is_ident(&IdenPath::Rename) {
-                    Ok(Self::Rename(name.value()))
-                } else if nv.path.is_ident(&IdenPath::Method) {
-                    Ok(Self::Method(Ident::new(name.value().as_str(), name.span())))
-                } else {
-                    Err(Error::new_spanned(
-                        nv,
-                        ErrorMsg::UnsupportedKeyword(nv.path.get_ident().unwrap().clone()),
-                    ))
-                }
+            Meta::List(list) if list.path.is_ident("iden") => {
+                let mut iden_attr: Option<Self> = None;
+                list.parse_nested_meta(|nested| {
+                    if nested.path.is_ident(&IdenPath::Flatten) {
+                        iden_attr = Some(IdenAttr::Flatten);
+                        Ok(())
+                    } else if nested.path.is_ident(&IdenPath::Rename) {
+                        let value = nested.value()?;
+                        let value: LitStr = value.parse()?;
+                        iden_attr = Some(IdenAttr::Rename(value.value()));
+                        Ok(())
+                    } else if nested.path.is_ident(&IdenPath::Method) {
+                        let value = nested.value()?;
+                        let value: LitStr = value.parse()?;
+                        iden_attr = Some(IdenAttr::Method(Ident::new(&value.value(), meta.span())));
+                        Ok(())
+                    } else {
+                        Err(Error::new_spanned(
+                            &meta,
+                            ErrorMsg::UnsupportedKeyword(nested.path.get_ident().unwrap().clone()),
+                        ))
+                    }
+                })?;
+                iden_attr.ok_or(Error::new_spanned(meta, ErrorMsg::WrongListFormat))
             }
-            _ => Err(Error::new_spanned(&nv.lit, ErrorMsg::WrongLiteral)),
+            a => Err(Error::new_spanned(a, ErrorMsg::WrongAttributeFormat)),
         }
     }
 }
@@ -66,7 +74,7 @@ impl TryFrom<&Attribute> for IdenAttr {
     type Error = Error;
 
     fn try_from(value: &Attribute) -> Result<Self, Self::Error> {
-        value.parse_meta()?.try_into()
+        value.meta.clone().try_into()
     }
 }
 

--- a/sea-query-derive/src/lib.rs
+++ b/sea-query-derive/src/lib.rs
@@ -18,9 +18,9 @@ use self::{
 };
 
 fn find_attr(attrs: &[Attribute]) -> Option<&Attribute> {
-    attrs
-        .iter()
-        .find(|attr| attr.path.is_ident(&IdenPath::Iden) || attr.path.is_ident(&IdenPath::Method))
+    attrs.iter().find(|attr| {
+        attr.path().is_ident(&IdenPath::Iden) || attr.path().is_ident(&IdenPath::Method)
+    })
 }
 
 fn get_table_name(ident: &proc_macro2::Ident, attrs: Vec<Attribute>) -> Result<String, syn::Error> {


### PR DESCRIPTION
## PR Info

Closes #706 

## Changes
Migrates the proc macro to syn 2 which in [some](https://github.com/SeaQL/sea-query/issues/706#issuecomment-1722275323) codebases may help compile time.
