### PR TITLE
added PostgreSQL Interval value variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ time = { version = "0.3", default-features = false, optional = true, features = 
 ipnetwork = { version = "0.20", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
 ordered-float = { version = "3.4", default-features = false, optional = true }
+sqlx = { git = "https://github.com/yasamoka/sqlx", branch = "pg-interval-hash", default-features = false, optional = true }
 
 [dev-dependencies]
 sea-query = { path = ".", features = ["tests-cfg"] }
@@ -60,7 +61,7 @@ derive = ["sea-query-derive"]
 attr = ["sea-query-attr"]
 hashable-value = ["derivative", "ordered-float"]
 postgres-array = []
-postgres-interval = ["proc-macro2", "quote"]
+postgres-interval = ["proc-macro2", "quote", "sqlx/postgres"]
 thread-safe = []
 with-chrono = ["chrono"]
 with-json = ["serde_json"]

--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.60"
 
 [dependencies]
 sea-query = { version = "0.31", path = "..", default-features = false, features = ["thread-safe"] }
-sqlx = { version = "0.7", default-features = false, optional = true }
+sqlx = { git = "https://github.com/yasamoka/sqlx", branch = "pg-interval-hash", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true, features = ["std"] }
 chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }
 rust_decimal = { version = "1", default-features = false, optional = true }
@@ -42,6 +42,7 @@ with-time = ["sqlx?/time", "sea-query/with-time", "time"]
 with-ipnetwork = ["sqlx?/ipnetwork", "sea-query/with-ipnetwork", "ipnetwork"]
 with-mac_address = ["sqlx?/mac_address", "sea-query/with-mac_address", "mac_address"]
 postgres-array = ["sea-query/postgres-array"]
+postgres-interval = ["sqlx-postgres", "sqlx/chrono"]
 runtime-async-std-native-tls = ["sqlx?/runtime-async-std-native-tls"]
 runtime-async-std-rustls = ["sqlx?/runtime-async-std-rustls", ]
 runtime-actix-native-tls = ["sqlx?/runtime-tokio-native-tls"]

--- a/sea-query-binder/src/sqlx_mysql.rs
+++ b/sea-query-binder/src/sqlx_mysql.rs
@@ -73,7 +73,7 @@ impl sqlx::IntoArguments<'_, sqlx::mysql::MySql> for SqlxValues {
                 Value::ChronoDateTimeWithTimeZone(t) => {
                     args.add(Value::ChronoDateTimeWithTimeZone(t).chrono_as_naive_utc_in_string());
                 }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-interval"))]
+                #[cfg(feature = "postgres-interval")]
                 Value::Interval(_) => {}
                 #[cfg(feature = "with-time")]
                 Value::TimeDate(t) => {

--- a/sea-query-binder/src/sqlx_mysql.rs
+++ b/sea-query-binder/src/sqlx_mysql.rs
@@ -73,6 +73,8 @@ impl sqlx::IntoArguments<'_, sqlx::mysql::MySql> for SqlxValues {
                 Value::ChronoDateTimeWithTimeZone(t) => {
                     args.add(Value::ChronoDateTimeWithTimeZone(t).chrono_as_naive_utc_in_string());
                 }
+                #[cfg(all(feature = "with-chrono", feature = "postgres-interval"))]
+                Value::Interval(_) => {}
                 #[cfg(feature = "with-time")]
                 Value::TimeDate(t) => {
                     args.add(t.as_deref());

--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -73,7 +73,7 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 Value::ChronoDateTimeWithTimeZone(t) => {
                     args.add(t.map(|t| *t));
                 }
-                #[cfg(all(feature = "with-chrono", feature = "postgres-interval"))]
+                #[cfg(feature = "postgres-interval")]
                 Value::Interval(_) => {}
                 #[cfg(feature = "with-time")]
                 Value::TimeDate(t) => {

--- a/sea-query-binder/src/sqlx_sqlite.rs
+++ b/sea-query-binder/src/sqlx_sqlite.rs
@@ -73,6 +73,8 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 Value::ChronoDateTimeWithTimeZone(t) => {
                     args.add(t.map(|t| *t));
                 }
+                #[cfg(all(feature = "with-chrono", feature = "postgres-interval"))]
+                Value::Interval(_) => {}
                 #[cfg(feature = "with-time")]
                 Value::TimeDate(t) => {
                     args.add(t.map(|t| *t));

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1002,6 +1002,8 @@ pub trait QueryBuilder:
             Value::ChronoDateTimeLocal(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "postgres-interval")]
+            Value::Interval(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
             Value::TimeDate(None) => write!(s, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
@@ -1059,6 +1061,34 @@ pub trait QueryBuilder:
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(Some(v)) => {
                 write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
+            }
+            #[cfg(feature = "postgres-interval")]
+            Value::Interval(Some(v)) => {
+                let mut space = false;
+
+                write!(s, "'").unwrap();
+
+                if v.months > 0 {
+                    write!(s, "{} MONTHS", v.days).unwrap();
+                    space = true;
+                }
+
+                if v.days > 0 {
+                    if space {
+                        write!(s, " ").unwrap();
+                    }
+                    write!(s, "{} DAYS", v.days).unwrap();
+                    space = true;
+                }
+
+                if v.microseconds > 0 {
+                    if space {
+                        write!(s, " ").unwrap();
+                    }
+                    write!(s, "{} MICROSECONDS", v.microseconds).unwrap();
+                }
+
+                write!(s, "'::interval").unwrap();
             }
             #[cfg(feature = "with-time")]
             Value::TimeDate(Some(v)) => {

--- a/src/value.rs
+++ b/src/value.rs
@@ -81,7 +81,7 @@ pub enum ArrayType {
     #[cfg_attr(docsrs, doc(cfg(feature = "with-chrono")))]
     ChronoDateTimeWithTimeZone,
 
-    #[cfg(all(feature = "with-chrono", feature = "postgres-interval"))]
+    #[cfg(feature = "postgres-interval")]
     Interval,
 
     #[cfg(feature = "with-time")]
@@ -1477,7 +1477,7 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         Value::ChronoDateTimeUtc(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-chrono")]
         Value::ChronoDateTimeLocal(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
-        #[cfg(all(feature = "with-chrono", feature = "postgres-interval"))]
+        #[cfg(feature = "postgres-interval")]
         Value::Interval(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-time")]
         Value::TimeDate(_) => CommonSqlQueryBuilder.value_to_string(value).into(),


### PR DESCRIPTION
First of all, thank you for this feature-filled query builder.

This PR adds the `Value::Interval` enum variant containing a `PgInterval`  provided by  SQLx. It requires [this change](https://github.com/launchbadge/sqlx/pull/2793) in SQLx and is required for [these changes](https://github.com/SeaQL/sea-orm/pull/1890) in SeaORM.

If this PR is considered relevant to the project, then I need some help with how to improve it in some aspects. I will mention the various points in further review requests.