### PR TITLE
update default value for uuid v4 on postgres

### DIFF
--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -635,7 +635,7 @@ impl ColumnDef {
     ///     .col(
     ///         ColumnDef::new(Char::Id)
     ///             .uuid()
-    ///             .extra("DEFAULT uuid_generate_v4()")
+    ///             .extra("DEFAULT gen_random_uuid()")
     ///             .primary_key()
     ///             .not_null(),
     ///     )
@@ -650,7 +650,7 @@ impl ColumnDef {
     ///     table.to_string(PostgresQueryBuilder),
     ///     [
     ///         r#"CREATE TABLE "character" ("#,
-    ///         r#""id" uuid DEFAULT uuid_generate_v4() PRIMARY KEY NOT NULL,"#,
+    ///         r#""id" uuid DEFAULT gen_random_uuid() PRIMARY KEY NOT NULL,"#,
     ///         r#""created_at" timestamp with time zone DEFAULT NOW() NOT NULL"#,
     ///         r#")"#,
     ///     ]


### PR DESCRIPTION
## Changes

- [x] Update comments related to uuid generation on postgresql

when i tried to add default value to Uuid primary key i found error
```
    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
        manager
            .create_table(
                Table::create()
                    .table(User::Table)
                    .if_not_exists()
                    .col(
                        ColumnDef::new(User::Id)
                            .uuid()
                            .extra("DEFAULT uuid_generate_v4()")
                            .not_null()
                            .primary_key(),
                    )
                    .col(ColumnDef::new(User::Name).string().not_null())
                    .col(ColumnDef::new(User::Email).string().unique_key().not_null())
                    .col(ColumnDef::new(User::Password).string().not_null())
                    .col(
                        ColumnDef::new(User::CreatedAt)
                            .date_time()
                            .unique_key()
                            .default(Expr::current_timestamp())
                            .not_null(),
                    )
                    .to_owned(),
            )
            .await
    }
```
<img width="1078" alt="Screenshot 2023-10-09 at 14 17 01" src="https://github.com/SeaQL/sea-query/assets/118413317/8f6fc901-9f2c-498a-9f1e-e2fe20ad39db">
<br>
when i search online, the function for postgres generate uuid is this <br> 

[postgres docs](https://www.postgresql.org/docs/current/functions-uuid.html)
then i changed the function and its working as expected<br>

```
impl MigrationTrait for Migration {
    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
        manager
            .create_table(
                Table::create()
                    .table(User::Table)
                    .if_not_exists()
                    .col(
                        ColumnDef::new(User::Id)
                            .uuid()
                            .extra("DEFAULT gen_random_uuid()")
                            .not_null()
                            .primary_key(),
                    )
                    .col(ColumnDef::new(User::Name).string().not_null())
                    .col(ColumnDef::new(User::Email).string().unique_key().not_null())
                    .col(ColumnDef::new(User::Password).string().not_null())
                    .col(
                        ColumnDef::new(User::CreatedAt)
                            .date_time()
                            .unique_key()
                            .default(Expr::current_timestamp())
                            .not_null(),
                    )
                    .to_owned(),
            )
            .await
    }

    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
        manager
            .drop_table(Table::drop().table(User::Table).to_owned())
            .await
    }
}
```
<img width="1144" alt="Screenshot 2023-10-09 at 14 17 08" src="https://github.com/SeaQL/sea-query/assets/118413317/661a19a8-6786-4167-9bba-af470a7e5439">
<br>
Tried it with some insert API
<br>

![Screenshot 2023-10-09 at 14 32 04](https://github.com/SeaQL/sea-query/assets/118413317/f0dde42e-2d45-49a5-a021-463226a2ce85)


