### PR TITLE
Add from_clear to allow emptying current from tables in select statement

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -987,6 +987,38 @@ impl SelectStatement {
         self.from_from(TableRef::FunctionCall(func, alias.into_iden()))
     }
 
+    /// Clears all current from clauses.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .column(ColumnRef::Asterisk)
+    ///     .from(Char::Table)
+    ///     .from_clear()
+    ///     .from(Font::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT * FROM `font`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT * FROM "font""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT * FROM "font""#
+    /// );
+    /// ```
+    pub fn from_clear(&mut self) -> &mut Self {
+        self.from.clear();
+        self
+    }
+
     #[allow(clippy::wrong_self_convention)]
     fn from_from(&mut self, select: TableRef) -> &mut Self {
         self.from.push(select);


### PR DESCRIPTION
## PR Info
Sea-orm does allow to modify the underlying sea-query statements with can be really useful but sea-query itself doesn't have a way to change the table a `SelectStatement` is done. This can be really handy when a database has a few tables that do share the same columns but are separated for other reasons, in my use case I have tables like that: data, data_now, data_1s, data_1m. All of them are identical to each other (data_now does have different PK keys, but that isn't important in my case), with using from_clear I can avoid having separate Entities for each table and avoid a lot of boilerplate when mapping them to a single Grpc struct that my backend outputs.

## New Features

- add new function to `SelectStatement`  `from_clear()` with does remove all from statements from it

## Changes

- new function `from_clear()` added to `SelectStatement`

Let me know if anything more is need in this PR or if you have a better idea to archive what I need for my use case. Or a better name for `from_clear()` because I am myself not that happy with it.
