### PR TITLE
fix the CI: update bigdecimal and fix warnings

### DIFF
--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo update --manifest-path sea-query-diesel/Cargo.toml --workspace -p bigdecimal:0.4.1 --precise 0.3.1
+      - run: cargo update --manifest-path sea-query-diesel/Cargo.toml --workspace -p bigdecimal:0.4.2 --precise 0.3.1
       - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array
       - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-chrono
       - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-json
@@ -157,6 +157,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo update --manifest-path examples/${{ matrix.example }}/Cargo.toml -p bigdecimal:0.4.1 --precise 0.3.1
+      - run: cargo update --manifest-path examples/${{ matrix.example }}/Cargo.toml -p bigdecimal:0.4.2 --precise 0.3.1
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
       - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml

--- a/examples/diesel_postgres/Readme.md
+++ b/examples/diesel_postgres/Readme.md
@@ -1,7 +1,7 @@
 # SeaQuery Diesel Postgres example
 
 > WARN: If you enable `with-bigdecimal`, you HAVE to update the version used by default by `diesel`
-> otherwise it will fail to build. Use `cargo update -p bigdecimal:0.4.1 --precise 0.3.1`.
+> otherwise it will fail to build. Use `cargo update -p bigdecimal:0.4.2 --precise 0.3.1`.
 
 Running:
 

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -159,7 +159,10 @@ impl QueryBuilder for PostgresQueryBuilder {
         write!(
             buffer,
             "'\\x{}'",
-            bytes.iter().map(|b| format!("{b:02X}")).collect::<String>()
+            bytes.iter().fold(String::new(), |mut output, b| {
+                let _ = write!(output, "{b:02X}");
+                output
+            })
         )
         .unwrap()
     }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1408,7 +1408,10 @@ pub trait QueryBuilder:
         write!(
             buffer,
             "x'{}'",
-            bytes.iter().map(|b| format!("{b:02X}")).collect::<String>()
+            bytes.iter().fold(String::new(), |mut output, b| {
+                let _ = write!(output, "{b:02X}");
+                output
+            })
         )
         .unwrap()
     }

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -10,7 +10,6 @@ use crate::SqlWriter;
 use crate::SubQueryStatement;
 use crate::TableRef;
 use crate::{Alias, QueryBuilder};
-use std::ops::Deref;
 
 /// A table definition inside a WITH clause ([WithClause]).
 ///
@@ -122,7 +121,7 @@ impl CommonTableExpression {
         let mut cte = Self::default();
         cte.try_set_cols_from_selects(&select.selects);
         if let Some(from) = select.from.get(0) {
-            match from.deref() {
+            match from {
                 TableRef::Table(iden) => cte.set_table_name_from_select(iden),
                 TableRef::SchemaTable(_, iden) => cte.set_table_name_from_select(iden),
                 TableRef::DatabaseSchemaTable(_, _, iden) => cte.set_table_name_from_select(iden),


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info
This PR has two fixes for CI.

### update bigdecimal 0.4.1 -> 0.4.2
It seems that CI is failing due to `bigdecimal` being updated.
This PR updates the version of `bigdecimal`.


### fix warnings
CI is failing due to linter's warnings.
This PR  fixes the warnings.

## links

### bigdecimal
https://github.com/SeaQL/sea-query/actions/runs/6733436762/job/18302124467?pr=478

### clippy
https://github.com/SeaQL/sea-query/actions/runs/6733586499/job/18302635348?pr=718