### PR TITLE
refactor(sea-query): Fix clippy warnings on Rust 1.75

### DIFF
--- a/src/extension/postgres/mod.rs
+++ b/src/extension/postgres/mod.rs
@@ -1,8 +1,6 @@
 pub use expr::*;
 pub use extension::*;
 pub use func::*;
-#[allow(unused_imports)]
-pub use interval::*;
 pub use ltree::*;
 pub use types::*;
 

--- a/src/extension/postgres/mod.rs
+++ b/src/extension/postgres/mod.rs
@@ -1,6 +1,7 @@
 pub use expr::*;
 pub use extension::*;
 pub use func::*;
+#[allow(unused_imports)]
 pub use interval::*;
 pub use ltree::*;
 pub use types::*;

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -114,7 +114,7 @@ impl CommonTableExpression {
     pub fn from_select(select: SelectStatement) -> Self {
         let mut cte = Self::default();
         cte.try_set_cols_from_selects(&select.selects);
-        if let Some(from) = select.from.get(0) {
+        if let Some(from) = select.from.first() {
             match from {
                 TableRef::Table(iden) => cte.set_table_name_from_select(iden),
                 TableRef::SchemaTable(_, iden) => cte.set_table_name_from_select(iden),

--- a/src/types.rs
+++ b/src/types.rs
@@ -342,11 +342,11 @@ impl Quote {
     }
 
     pub fn left(&self) -> char {
-        char::try_from(self.0).unwrap()
+        char::from(self.0)
     }
 
     pub fn right(&self) -> char {
-        char::try_from(self.1).unwrap()
+        char::from(self.1)
     }
 }
 


### PR DESCRIPTION
## PR Info

- Closes N/A
- Dependencies: N/A
- Dependents: N/A

## New Features

N/A

## Bug Fixes

N/A

## Breaking Changes

N/A

## Changes

- [x] Fix clippy warnings introduced in Rust 1.75 toolchain
