### PR TITLE
Feat: Adds `SelectStatement::apply` method for functionally building query in another function

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -214,6 +214,44 @@ impl SelectStatement {
         self
     }
 
+    /// Construct part of the select statement in another function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let common_expr = |q: &mut SelectStatement| {
+    ///     q.and_where(Expr::col(Char::FontId).eq(5));
+    /// };
+    ///
+    /// let query = Query::select()
+    ///     .column(Char::Character)
+    ///     .from(Char::Table)
+    ///     .apply(common_expr)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "character" FROM "character" WHERE "font_id" = 5"#
+    /// );
+    /// ```
+    pub fn apply<F>(&mut self, func: F) -> &mut Self
+    where
+        F: FnOnce(&mut Self),
+    {
+        func(self);
+        self
+    }
+
     /// Clear the select list
     pub fn clear_selects(&mut self) -> &mut Self {
         self.selects = Vec::new();


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

Heya! 👋 Thanks for all your work on the library- I've really enjoyed working with it! I ran into a quality of life shortcoming with the API around the `SelectStatement` builder: I wanted a clean way of building a portion of the query in another function, similar to the pattern used by the `conditions` method, but without the actual conditional part 😁

## PR Info

<!-- mention the related issue -->
- Closes: None <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies: None

<!-- any PR depends on this PR? (if applicable) -->
- Dependents: None

## New Features

- [ ] Added `apply` method to `SelectStatement` for constructing part of the statement from another function

  This new method is essentially a shorthand form of using the `conditions` function with a hardcoded value:
  ```rust
  // a function for building up part of the query
  fn build_query(query: &mut SelectStatement) {
      query
          .column(Users::Id)
          .from(Users::Table);
  }

  // The only current option is to use the `conditions` method with a hardcoded value 
  let query_count = Query::select()
      .conditions(true, build_query, |_| {})
      .to_owned();

  // But the code is easier to grok with the new apply method:
  let query_count = Query::select()
      .apply(build_query)
      .to_owned();
  ```

  This is useful in cases where multiple queries have the same "core" expressions, like when gathering results vs counting total query size (for pagination) on a query with joins, conditional where clauses, and groupings:
  ```rust
  // a function for joining the `user` and `user_external_ids` tables and filtering users
  // based on properties of their associated external ids (in this case, the system
  // name being "foo bar baz").
  fn build_query_with_filter(query: &mut SelectStatement) {
      let filter_external = true;

      query
          .from(Users::Table)         // the Users table
          .left_join(
              UserExternalIds::Table, // a table of related external user IDs, a many-to-one relationship with Users
              Expr::col(
                  (Users::Table, Users::Id)
              ).equals(
                  (UserExternalIds::Table, UserExternalIds::UserId)
              )
          )
          .conditions(
              filter_external,
              |q| {
                  q.and_where(Expr::col(UserExternalIds::ExternalSystem).eq("foo bar baz"));
              },
              |_| {},
          )
          .add_group_by([Expr::col(Users::Id).into()]);
  }

  fn main() {
      let query_count = Query::select()
          .expr(Func::count(Expr::col((Users::Table, Users::Id))))
          .apply(build_query_with_filter)
          .to_owned();

      let query_fetch = Query::select()
          .column(Users::Id)
          .apply(build_query_with_filter)
          .order_by(Users::CreatedAt, Order::Desc)
          .limit(10)
          .offset(0)
          .to_owned();
  }
  ```

  This is somewhat contrived example to keep it as simple as possible. For my use case, the function used to build common expressions on the query is a struct method that's referencing it's own internal state to apply the conditional filters:
  
  ```rust
   let filter = UserListFilter { ... };

   let query_count = Query::select()
          .expr(Func::count(Expr::col((Users::Table, Users::Id))))
          .apply(|q| filter.apply_query(q))
          .to_owned();
  ```

## Bug Fixes

None <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

None <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

None as of initial authorship, however the `SelectStatement::conditions` method could be updated to call out to the new `apply` function if so desired, but it'd be a little pedantic:

```diff
    pub fn conditions<T, F>(&mut self, b: bool, if_true: T, if_false: F) -> &mut Self
    where
        T: FnOnce(&mut Self),
        F: FnOnce(&mut Self),
    {
        if b {
-            if_true(self)
+            self.apply(if_true); 
        } else {
-            if_false(self)
+            self.apply(if_false);
        }
        self
    }
```