### PR TITLE
insert builder supports values from iterator

### DIFF
--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -278,6 +278,44 @@ impl InsertStatement {
         self.values(values).unwrap()
     }
 
+    /// Add rows to be inserted from an iterator, variation of [`InsertStatement::values_panic`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let rows = vec![[2.1345.into(), "24B".into()], [5.15.into(), "12A".into()]];
+    ///
+    /// let query = Query::insert()
+    ///     .into_table(Glyph::Table)
+    ///     .columns([Glyph::Aspect, Glyph::Image])
+    ///     .values_from_panic(rows)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"INSERT INTO `glyph` (`aspect`, `image`) VALUES (2.1345, '24B'), (5.15, '12A')"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2.1345, '24B'), (5.15, '12A')"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"INSERT INTO "glyph" ("aspect", "image") VALUES (2.1345, '24B'), (5.15, '12A')"#
+    /// );
+    /// ```
+    pub fn values_from_panic<I>(&mut self, values_iter: impl IntoIterator<Item = I>) -> &mut Self
+    where
+        I: IntoIterator<Item = SimpleExpr>,
+    {
+        values_iter.into_iter().for_each(|values| {
+            self.values_panic(values);
+        });
+        self
+    }
+
     /// ON CONFLICT expression
     ///
     /// # Examples


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.
-->

## PR Info

Hey again! 👋

The `InsertStatement` builder doesn't seem to support adding a dynamic number of items without breaking the functional pattern exhibited throughout the docs. I went ahead and added a method for it since it was pretty simple and was a nice quality of life feature.

Though I've got a PR here, there are a few points that I'd like to ask about:
- [ ] I'm not sure I've chosen a good name for the function. If you have any suggestions or preferences for a better name, please let me know and I can update the PR.

- [ ] The method I've added wraps `.values_panic`, but I've not added an equivalent method for wrapping `.values`. I wasn't sure what behavior would be expected of such a function, so I figured I should ask first.
  The two options I see are:
  - proceeds on `Ok` and early exits on first `Err`
    ```rust
    pub fn values_from<I>(&mut self, values_iter: impl IntoIterator<Item = I>) -> Result<&mut Self>
    where
        I: IntoIterator<Item = SimpleExpr>,
    {
    ```
  - continues iterating when `.values` returns an `Err`, but collects the failing items and their errors so that all failures can be returned. I thought briefly about what this interface might look like but I'm not really sure (not sure if that means it's just a bad idea? 😅 )


## New Features

- [ ] Added the `values_from_panic` method to `InsertStatement` for adding multiple rows at once from something that implements `IntoIterator`.
  ```rust
  let rows = vec![
      [2.1345.into(), "24B".into()],
      [5.15.into(), "12A".into()],
  ];

  let query = Query::insert()
      .into_table(Glyph::Table)
      .columns([Glyph::Aspect, Glyph::Image])
      .values_from_panic(rows)
      .to_owned();
  ```

## Bug Fixes

- [ ] none <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] none <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] none <!-- any other non-breaking changes to the codebase -->
