### PR TITLE
Publically export FuncArgMod

### DIFF
--- a/src/func.rs
+++ b/src/func.rs
@@ -38,8 +38,8 @@ pub struct FunctionCall {
 }
 
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
-pub(crate) struct FuncArgMod {
-    pub(crate) distinct: bool,
+pub struct FuncArgMod {
+    pub distinct: bool,
 }
 
 impl FunctionCall {
@@ -84,6 +84,10 @@ impl FunctionCall {
 
     pub fn get_args(&self) -> &[SimpleExpr] {
         &self.args
+    }
+
+    pub fn get_mods(&self) -> &[FuncArgMod] {
+        &self.mods
     }
 }
 


### PR DESCRIPTION
## PR Info

Just like `#get_args` and `#get_func`, make a getter for `mods`, `#get_mods`, and make `FuncArgMod` public.

We're using sea-query with a non-supported database (Hive). The QueryBuilder interface set up in sea-query is nicely designed such that we can extend it for our purposes, but it has a problem in that many of the internals used by similar QueryBuilder structs (e.g. sqlite, postgres) make use of private APIs. This means that while the path is clear for creating a custom query builder, doing so without maintaining a fork requires duplicating lots of code to create public interfaces for our project.

`#get_mods` is one such interface that we need to write `DISTINCT` queries in our query builder.

## New Features

- Add `FunctionCall#get_mods` to get `FuncArgMod`s

## Bug Fixes

NA

## Breaking Changes

NA

## Changes

- Publically export `FuncArgMod` struct
- Add `FunctionCall#get_mods`
