### PR TITLE
sea-query-rusqlite - update rusqlite version to 0.31

### DIFF
--- a/examples/rusqlite/Cargo.toml
+++ b/examples/rusqlite/Cargo.toml
@@ -13,7 +13,7 @@ time = { version = "0.3", features = ["parsing", "macros"] }
 serde_json = { version = "1" }
 # rusqlite only supports uuid 0
 uuid = { version = "1", features = ["serde", "v4"] }
-rusqlite = "0.30"
+rusqlite = "0.31"
 sea-query = { path = "../.."}
 sea-query-rusqlite = { path = "../../sea-query-rusqlite", features = [
     "with-chrono",

--- a/sea-query-rusqlite/Cargo.toml
+++ b/sea-query-rusqlite/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.60"
 
 [dependencies]
 sea-query = { version = "0.31.0-rc.4", path = "..", default-features = false }
-rusqlite = { version = "0.30", default-features = false, features = ["bundled"] }
+rusqlite = { version = "0.31", default-features = false, features = ["bundled"] }
 
 [features]
 with-chrono = ["rusqlite/chrono", "sea-query/with-chrono"]


### PR DESCRIPTION
## Changes

- [x] Upgraded the sea-query-rusqlite dependency to use [rusqlite](https://github.com/rusqlite/rusqlite) version `0.31`, which now supports SQLite 3.45 with `jsonb` functionality.

## Notes

- This is my first PR for this project. If I've overlooked anything, please feel free to let me know.
- I conducted some site testing, including tests with `jsonb`, and everything has worked nicely so far.