### PR TITLE
Add possibility to configure the Table enum variant Iden implementation with enum_def macro

### DIFF
--- a/sea-query-attr/src/lib.rs
+++ b/sea-query-attr/src/lib.rs
@@ -19,6 +19,8 @@ struct GenEnumArgs {
     pub suffix: Option<String>,
     #[darling(default)]
     pub crate_name: Option<String>,
+    #[darling(default)]
+    pub table_iden: Option<String>,
 }
 
 const DEFAULT_PREFIX: &str = "";
@@ -31,6 +33,7 @@ impl Default for GenEnumArgs {
             prefix: Some(DEFAULT_PREFIX.to_string()),
             suffix: Some(DEFAULT_SUFFIX.to_string()),
             crate_name: Some(DEFAULT_CRATE_NAME.to_string()),
+            table_iden: None,
         }
     }
 }
@@ -66,7 +69,9 @@ pub fn enum_def(args: TokenStream, input: TokenStream) -> TokenStream {
         .collect();
 
     let table_name = Ident::new(
-        input.ident.to_string().to_snake_case().as_str(),
+        args.table_iden
+            .unwrap_or_else(|| input.ident.to_string().to_snake_case())
+            .as_str(),
         input.ident.span(),
     );
 

--- a/sea-query-attr/tests/pass/table_iden.rs
+++ b/sea-query-attr/tests/pass/table_iden.rs
@@ -1,0 +1,11 @@
+use sea_query::Iden;
+use sea_query_attr::enum_def;
+
+#[enum_def(table_iden = "HelloTable")]
+pub struct Hello {
+    pub name: String,
+}
+
+fn main() {
+    println!("{:?}", HelloIden::Table.to_string());
+}

--- a/sea-query-attr/tests/pass/table_iden.rs
+++ b/sea-query-attr/tests/pass/table_iden.rs
@@ -7,5 +7,5 @@ pub struct Hello {
 }
 
 fn main() {
-    println!("{:?}", HelloIden::Table.to_string());
+    assert_eq!("HelloTable".to_string(), HelloIden::Table.to_string());
 }


### PR DESCRIPTION
Hello ! 

Add possibility to configure the Table enum variant Iden implementation with enum_def macro

Do you think it would possible to merge the PR ? 
Does the feature fit in what you are trying to do ?
