### PR TITLE
Replace derivative by educe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ inherent = "1.0"
 sea-query-attr = { version = "0.1.1", path = "sea-query-attr", default-features = false, optional = true }
 sea-query-derive = { version = "0.4.0", path = "sea-query-derive", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true, features = ["std"] }
-derivative = { version = "2.2", default-features = false, optional = true }
+educe = { version = "0.5.11", default-features = false, optional = true, features = ["Hash", "PartialEq", "Eq"] }
 chrono = { version = "0.4.27", default-features = false, optional = true, features = ["clock"] }
 postgres-types = { version = "0", default-features = false, optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }
@@ -56,7 +56,7 @@ backend-sqlite = []
 default = ["derive", "backend-mysql", "backend-postgres", "backend-sqlite"]
 derive = ["sea-query-derive"]
 attr = ["sea-query-attr"]
-hashable-value = ["derivative", "ordered-float"]
+hashable-value = ["educe", "ordered-float"]
 postgres-array = []
 postgres-interval = []
 thread-safe = []

--- a/src/value.rs
+++ b/src/value.rs
@@ -126,8 +126,8 @@ pub enum ArrayType {
 #[cfg_attr(not(feature = "hashable-value"), derive(PartialEq))]
 #[cfg_attr(
     feature = "hashable-value",
-    derive(derivative::Derivative),
-    derivative(Hash, PartialEq, Eq)
+    derive(educe::Educe),
+    educe(Hash, PartialEq, Eq)
 )]
 pub enum Value {
     Bool(Option<bool>),
@@ -142,9 +142,9 @@ pub enum Value {
     Float(
         #[cfg_attr(
             feature = "hashable-value",
-            derivative(
-                Hash(hash_with = "hashable_value::hash_f32"),
-                PartialEq(compare_with = "hashable_value::cmp_f32")
+            educe(
+                Hash(method(hashable_value::hash_f32)),
+                PartialEq(method(hashable_value::cmp_f32))
             )
         )]
         Option<f32>,
@@ -152,9 +152,9 @@ pub enum Value {
     Double(
         #[cfg_attr(
             feature = "hashable-value",
-            derivative(
-                Hash(hash_with = "hashable_value::hash_f64"),
-                PartialEq(compare_with = "hashable_value::cmp_f64")
+            educe(
+                Hash(method(hashable_value::hash_f64)),
+                PartialEq(method(hashable_value::cmp_f64))
             )
         )]
         Option<f64>,
@@ -170,9 +170,9 @@ pub enum Value {
     Json(
         #[cfg_attr(
             feature = "hashable-value",
-            derivative(
-                Hash(hash_with = "hashable_value::hash_json"),
-                PartialEq(compare_with = "hashable_value::cmp_json")
+            educe(
+                Hash(method(hashable_value::hash_json)),
+                PartialEq(method(hashable_value::cmp_json))
             )
         )]
         Option<Box<Json>>,


### PR DESCRIPTION
## PR Info

Digging into my `Cargo.toml` to get rid of syn v1, I saw that sea-query still depends indirectly through the `derivative` module. It hasn't been updated for a long time https://github.com/mcarton/rust-derivative/issues/117. I found a more compact alternative to `educe`.

- Closes https://github.com/SeaQL/sea-query/issues/706 (It's already closed, but I continued working)

## Changes

- [X] Replace `derivative` derive by `educe` for `Value`
