### PR TITLE
MySQL: ON DUPLICATE KEY DO NOTHING

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ postgres-types = { version = "0", default-features = false, optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.3", default-features = false, optional = true }
 uuid = { version = "1", default-features = false, optional = true }
-time = { version = "0.3", default-features = false, optional = true, features = ["macros", "formatting"] }
+time = { version = "=0.3.34", default-features = false, optional = true, features = ["macros", "formatting"] }
 ipnetwork = { version = "0.20", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
 ordered-float = { version = "3.4", default-features = false, optional = true }

--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4", default-features = false, optional = true, features 
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.3", default-features = false, optional = true }
 uuid = { version = "1", default-features = false, optional = true }
-time = { version = "0.3", default-features = false, optional = true, features = ["macros", "formatting"] }
+time = { version = "=0.3.34", default-features = false, optional = true, features = ["macros", "formatting"] }
 ipnetwork = { version = "0.20", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
 

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -96,6 +96,28 @@ impl QueryBuilder for MysqlQueryBuilder {
         // MySQL doesn't support declaring ON CONFLICT target.
     }
 
+    fn prepare_on_conflict_action(
+        &self,
+        on_conflict_action: &Option<OnConflictAction>,
+        sql: &mut dyn SqlWriter,
+    ) {
+        match dbg!(on_conflict_action) {
+            Some(OnConflictAction::DoNothing(pk_cols)) => {
+                self.prepare_on_conflict_do_update_keywords(sql);
+                pk_cols.iter().fold(true, |first, pk_col| {
+                    if !first {
+                        write!(sql, ", ").unwrap()
+                    }
+                    pk_col.prepare(sql.as_writer(), self.quote());
+                    write!(sql, " = ").unwrap();
+                    pk_col.prepare(sql.as_writer(), self.quote());
+                    false
+                });
+            }
+            _ => self.prepare_on_conflict_action_common(on_conflict_action, sql),
+        }
+    }
+
     fn prepare_on_conflict_keywords(&self, sql: &mut dyn SqlWriter) {
         write!(sql, " ON DUPLICATE KEY").unwrap();
     }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1175,9 +1175,17 @@ pub trait QueryBuilder:
         on_conflict_action: &Option<OnConflictAction>,
         sql: &mut dyn SqlWriter,
     ) {
+        self.prepare_on_conflict_action_common(on_conflict_action, sql);
+    }
+
+    fn prepare_on_conflict_action_common(
+        &self,
+        on_conflict_action: &Option<OnConflictAction>,
+        sql: &mut dyn SqlWriter,
+    ) {
         if let Some(action) = on_conflict_action {
             match action {
-                OnConflictAction::DoNothing => {
+                OnConflictAction::DoNothing(_) => {
                     write!(sql, " DO NOTHING").unwrap();
                 }
                 OnConflictAction::Update(update_strats) => {

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1385,6 +1385,29 @@ fn insert_on_conflict_6() {
 }
 
 #[test]
+#[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing_on() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic(["abcd".into(), 3.1415.into()])
+            .on_conflict(
+                OnConflict::columns([Glyph::Id, Glyph::Aspect])
+                    .do_nothing_on([Glyph::Id])
+                    .to_owned(),
+            )
+            .to_string(MysqlQueryBuilder),
+        [
+            r#"INSERT INTO `glyph` (`aspect`, `image`)"#,
+            r#"VALUES ('abcd', 3.1415)"#,
+            r#"ON DUPLICATE KEY UPDATE `id` = `id`"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn update_1() {
     assert_eq!(
         Query::update()

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1519,6 +1519,52 @@ fn insert_on_conflict_9() {
 
 #[test]
 #[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic(["abcd".into(), 3.1415.into()])
+            .on_conflict(
+                OnConflict::columns([Glyph::Id, Glyph::Aspect])
+                    .do_nothing()
+                    .to_owned(),
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('abcd', 3.1415)"#,
+            r#"ON CONFLICT ("id", "aspect") DO NOTHING"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing_on() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic(["abcd".into(), 3.1415.into()])
+            .on_conflict(
+                OnConflict::columns([Glyph::Id, Glyph::Aspect])
+                    .do_nothing_on([Glyph::Id])
+                    .to_owned(),
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('abcd', 3.1415)"#,
+            r#"ON CONFLICT ("id", "aspect") DO NOTHING"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
 fn insert_returning_all_columns() {
     assert_eq!(
         Query::insert()

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1473,6 +1473,52 @@ fn insert_on_conflict_9() {
 
 #[test]
 #[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic(["abcd".into(), 3.1415.into()])
+            .on_conflict(
+                OnConflict::columns([Glyph::Id, Glyph::Aspect])
+                    .do_nothing()
+                    .to_owned(),
+            )
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('abcd', 3.1415)"#,
+            r#"ON CONFLICT ("id", "aspect") DO NOTHING"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
+fn insert_on_conflict_do_nothing_on() {
+    assert_eq!(
+        Query::insert()
+            .into_table(Glyph::Table)
+            .columns([Glyph::Aspect, Glyph::Image])
+            .values_panic(["abcd".into(), 3.1415.into()])
+            .on_conflict(
+                OnConflict::columns([Glyph::Id, Glyph::Aspect])
+                    .do_nothing_on([Glyph::Id])
+                    .to_owned(),
+            )
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"INSERT INTO "glyph" ("aspect", "image")"#,
+            r#"VALUES ('abcd', 3.1415)"#,
+            r#"ON CONFLICT ("id", "aspect") DO NOTHING"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
+#[allow(clippy::approx_constant)]
 fn insert_returning_all_columns() {
     assert_eq!(
         Query::insert()


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-orm/issues/1790
- Replaces https://github.com/SeaQL/sea-query/pull/684
- Dependencies:
  - https://github.com/SeaQL/sea-query/pull/766

## New Features

- [x] Added `OnConflict::do_nothing_on()`
- [x] Added `QueryBuilder::prepare_on_conflict_action_common()`

## Breaking Changes

- [x] Changed `OnConflictAction::DoNothing` enum variant to `OnConflictAction::DoNothing(Vec<DynIden>)`
