### PR TITLE
Pin `time` to version 0.3.34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ postgres-types = { version = "0", default-features = false, optional = true }
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.3", default-features = false, optional = true }
 uuid = { version = "1", default-features = false, optional = true }
-time = { version = "0.3", default-features = false, optional = true, features = ["macros", "formatting"] }
+time = { version = "=0.3.34", default-features = false, optional = true, features = ["macros", "formatting"] }
 ipnetwork = { version = "0.20", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
 ordered-float = { version = "3.4", default-features = false, optional = true }

--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4", default-features = false, optional = true, features 
 rust_decimal = { version = "1", default-features = false, optional = true }
 bigdecimal = { version = "0.3", default-features = false, optional = true }
 uuid = { version = "1", default-features = false, optional = true }
-time = { version = "0.3", default-features = false, optional = true, features = ["macros", "formatting"] }
+time = { version = "=0.3.34", default-features = false, optional = true, features = ["macros", "formatting"] }
 ipnetwork = { version = "0.20", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
 


### PR DESCRIPTION
## PR Info

- Dependents:
  - https://github.com/SeaQL/sea-query/pull/765

## Changes

- [x] Pin `time` to version 0.3.34, because the breaking changes released in version 0.3.35 isn't handled in our upstream crates such as `sqlx` https://github.com/launchbadge/sqlx/issues/3189.
