### PR TITLE
Md5 function

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -676,6 +676,7 @@ pub trait QueryBuilder:
                     Function::Custom(_) => "",
                     Function::Random => self.random_function(),
                     Function::Round => "ROUND",
+                    Function::Md5 => "MD5",
                     #[cfg(feature = "backend-postgres")]
                     Function::PgFunction(_) => unimplemented!(),
                 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1980,7 +1980,7 @@ impl Expr {
         SimpleExpr::FunctionCall(func)
     }
 
-    /// Keyword `CURRENT_TIMESTAMP`.
+    /// Keyword `CURRENT_DATE`.
     ///
     /// # Examples
     ///

--- a/src/func.rs
+++ b/src/func.rs
@@ -723,7 +723,7 @@ impl Func {
         FunctionCall::new(Function::Random)
     }
 
-    /// Call `MD5` function.
+    /// Call `MD5` function, this is only available in Postgres and MySQL.
     ///
     /// # Examples
     ///

--- a/src/func.rs
+++ b/src/func.rs
@@ -25,7 +25,6 @@ pub enum Function {
     BitOr,
     Random,
     Round,
-    // only available in Postgres and MySQL
     Md5,
     #[cfg(feature = "backend-postgres")]
     PgFunction(PgFunction),
@@ -724,7 +723,7 @@ impl Func {
         FunctionCall::new(Function::Random)
     }
 
-    /// Call `MD5` function, this is only available in Postgres and MySQL.
+    /// Call `MD5` function.
     ///
     /// # Examples
     ///
@@ -732,18 +731,18 @@ impl Func {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///    .expr(Func::md5(Expr::col((Char::Table, Char::Character))))
-    ///   .from(Char::Table)
-    ///  .to_owned();
+    ///     .expr(Func::md5(Expr::col((Char::Table, Char::Character))))
+    ///     .from(Char::Table)
+    ///     .to_owned();
     ///
     /// assert_eq!(
-    ///    query.to_string(MysqlQueryBuilder),
-    ///   r#"SELECT MD5(`character`.`character`) FROM `character`"#
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT MD5(`character`.`character`) FROM `character`"#
     /// );
     ///
     /// assert_eq!(
-    ///   query.to_string(PostgresQueryBuilder),
-    ///   r#"SELECT MD5("character"."character") FROM "character""#
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT MD5("character"."character") FROM "character""#
     /// );
     /// ```
     pub fn md5<T>(expr: T) -> FunctionCall

--- a/src/func.rs
+++ b/src/func.rs
@@ -25,6 +25,8 @@ pub enum Function {
     BitOr,
     Random,
     Round,
+    // only available in Postgres and MySQL
+    Md5,
     #[cfg(feature = "backend-postgres")]
     PgFunction(PgFunction),
 }

--- a/src/func.rs
+++ b/src/func.rs
@@ -723,4 +723,33 @@ impl Func {
     pub fn random() -> FunctionCall {
         FunctionCall::new(Function::Random)
     }
+
+    /// Call `MD5` function, this is only available in Postgres and MySQL.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///    .expr(Func::md5(Expr::col((Char::Table, Char::Character))))
+    ///   .from(Char::Table)
+    ///  .to_owned();
+    ///
+    /// assert_eq!(
+    ///    query.to_string(MysqlQueryBuilder),
+    ///   r#"SELECT MD5(`character`.`character`) FROM `character`"#
+    /// );
+    ///
+    /// assert_eq!(
+    ///   query.to_string(PostgresQueryBuilder),
+    ///   r#"SELECT MD5("character"."character") FROM "character""#
+    /// );
+    /// ```
+    pub fn md5<T>(expr: T) -> FunctionCall
+    where
+        T: Into<SimpleExpr>,
+    {
+        FunctionCall::new(Function::Md5).arg(expr)
+    }
 }

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1062,6 +1062,16 @@ fn select_61() {
 }
 
 #[test]
+fn md5_fn() {
+    assert_eq!(
+        Query::select()
+            .expr(Func::md5(Expr::val("test")))
+            .to_string(MysqlQueryBuilder),
+        r#"SELECT MD5('test')"#
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1926,6 +1926,16 @@ fn sub_query_with_fn() {
 }
 
 #[test]
+fn md5_fn() {
+    assert_eq!(
+        Query::select()
+            .expr(Func::md5(Expr::val("test")))
+            .to_string(PostgresQueryBuilder),
+        r#"SELECT MD5('test')"#
+    );
+}
+
+#[test]
 fn select_array_contains_bin_oper() {
     assert_eq!(
         Query::select()


### PR DESCRIPTION
## PR Info

- Fixes #785.

## New Features

- Allows calling the `MD5` SQL function for Postgres and MySQL.
