### PR TITLE
Case-sensitive enum type casts

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -41,7 +41,7 @@ impl QueryBuilder for PostgresQueryBuilder {
     fn prepare_simple_expr(&self, simple_expr: &SimpleExpr, sql: &mut dyn SqlWriter) {
         match simple_expr {
             SimpleExpr::AsEnum(type_name, expr) => {
-                let simple_expr = expr.clone().cast_as(SeaRc::clone(type_name));
+                let simple_expr = expr.clone().cast_as_quoted(SeaRc::clone(type_name), self.quote());
                 self.prepare_simple_expr_common(&simple_expr, sql);
             }
             _ => QueryBuilder::prepare_simple_expr_common(self, simple_expr, sql),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1883,7 +1883,7 @@ impl Expr {
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT CAST("font_size" AS text) FROM "character""#
+    ///     r#"SELECT CAST("font_size" AS "text") FROM "character""#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
@@ -1902,7 +1902,7 @@ impl Expr {
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"INSERT INTO "character" ("font_size") VALUES (CAST('large' AS FontSizeEnum))"#
+    ///     r#"INSERT INTO "character" ("font_size") VALUES (CAST('large' AS "FontSizeEnum"))"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
@@ -2468,6 +2468,38 @@ impl SimpleExpr {
         T: IntoIden,
     {
         let func = Func::cast_as(self, type_name);
+        Self::FunctionCall(func)
+    }
+
+    /// Express a case-sensitive `CAST AS` expression.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Expr::value("1").cast_as_quoted(Alias::new("MyType"), '"'.into()))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT CAST('1' AS "MyType")"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT CAST('1' AS "MyType")"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT CAST('1' AS "MyType")"#
+    /// );
+    /// ```
+    pub fn cast_as_quoted<T>(self, type_name: T, q: Quote) -> Self
+    where
+        T: IntoIden,
+    {
+        let func = Func::cast_as_quoted(self, type_name, q);
         Self::FunctionCall(func)
     }
 

--- a/src/func.rs
+++ b/src/func.rs
@@ -459,6 +459,44 @@ impl Func {
         ))
     }
 
+    /// Call `CAST` function with a case-sensitive custom type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Func::cast_as_quoted("hello", Alias::new("MyType"), '"'.into()))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT CAST('hello' AS "MyType")"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT CAST('hello' AS "MyType")"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT CAST('hello' AS "MyType")"#
+    /// );
+    /// ```
+    pub fn cast_as_quoted<V, I>(expr: V, iden: I, q: Quote) -> FunctionCall
+    where
+        V: Into<SimpleExpr>,
+        I: IntoIden,
+    {
+        let expr: SimpleExpr = expr.into();
+        let mut quoted_type = String::new();
+        iden.into_iden().prepare(&mut quoted_type, q);
+        FunctionCall::new(Function::Cast).arg(expr.binary(
+            BinOper::As,
+            Expr::cust(quoted_type.as_str()),
+        ))
+    }
+
     /// Call `COALESCE` function.
     ///
     /// # Examples


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-query/issues/725
- Dependents:
  - https://github.com/SeaQL/sea-orm/pull/2271

## Bug Fixes

- [x] Casting to an enum whose type name was declared case-sensitive does not crash anymore

## Breaking Changes

- [x] Enum type casts are now case sensitive, so casting to `SomeEnum` will now cast to `"SomeEnum"` on PostgreSQL, while it previously casted to `someenum`.

