### PR TITLE
Add `ExprTrait` (#771)

### DIFF
--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -1,7 +1,7 @@
 use super::PgBinOper;
-use crate::{expr::private::Expression, Expr, IntoLikeExpr, SimpleExpr};
+use crate::{expr::ExprTrait, IntoLikeExpr, SimpleExpr};
 
-pub trait PgExpr: Expression {
+pub trait PgExpr: ExprTrait {
     /// Express an postgres concatenate (`||`) expression.
     ///
     /// # Examples
@@ -24,7 +24,7 @@ pub trait PgExpr: Expression {
     where
         T: Into<SimpleExpr>,
     {
-        self.bin_op(PgBinOper::Concatenate, right)
+        self.binary(PgBinOper::Concatenate, right)
     }
     /// Alias of [`PgExpr::concatenate`]
     fn concat<T>(self, right: T) -> SimpleExpr
@@ -57,7 +57,7 @@ pub trait PgExpr: Expression {
     where
         T: Into<SimpleExpr>,
     {
-        self.bin_op(PgBinOper::Matches, expr)
+        self.binary(PgBinOper::Matches, expr)
     }
 
     /// Express an postgres fulltext search contains (`@>`) expression.
@@ -83,7 +83,7 @@ pub trait PgExpr: Expression {
     where
         T: Into<SimpleExpr>,
     {
-        self.bin_op(PgBinOper::Contains, expr)
+        self.binary(PgBinOper::Contains, expr)
     }
 
     /// Express an postgres fulltext search contained (`<@`) expression.
@@ -109,7 +109,7 @@ pub trait PgExpr: Expression {
     where
         T: Into<SimpleExpr>,
     {
-        self.bin_op(PgBinOper::Contained, expr)
+        self.binary(PgBinOper::Contained, expr)
     }
 
     /// Express a `ILIKE` expression.
@@ -134,7 +134,7 @@ pub trait PgExpr: Expression {
     where
         L: IntoLikeExpr,
     {
-        self.like_like(PgBinOper::ILike, like.into_like_expr())
+        self.binary(PgBinOper::ILike, like.into_like_expr())
     }
 
     /// Express a `NOT ILIKE` expression
@@ -142,7 +142,7 @@ pub trait PgExpr: Expression {
     where
         L: IntoLikeExpr,
     {
-        self.like_like(PgBinOper::NotILike, like.into_like_expr())
+        self.binary(PgBinOper::NotILike, like.into_like_expr())
     }
 
     /// Express a postgres retrieves JSON field as JSON value (`->`).
@@ -167,7 +167,7 @@ pub trait PgExpr: Expression {
     where
         T: Into<SimpleExpr>,
     {
-        self.bin_op(PgBinOper::GetJsonField, right)
+        self.binary(PgBinOper::GetJsonField, right)
     }
 
     /// Express a postgres retrieves JSON field and casts it to an appropriate SQL type (`->>`).
@@ -192,10 +192,8 @@ pub trait PgExpr: Expression {
     where
         T: Into<SimpleExpr>,
     {
-        self.bin_op(PgBinOper::CastJsonField, right)
+        self.binary(PgBinOper::CastJsonField, right)
     }
 }
 
-impl PgExpr for Expr {}
-
-impl PgExpr for SimpleExpr {}
+impl<T> PgExpr for T where T: ExprTrait {}

--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -1,5 +1,7 @@
 use super::PgBinOper;
-use crate::{expr::ExprTrait, IntoLikeExpr, SimpleExpr};
+use crate::{
+    ColumnRef, Expr, ExprTrait, FunctionCall, IntoLikeExpr, Keyword, LikeExpr, SimpleExpr, Value,
+};
 
 pub trait PgExpr: ExprTrait {
     /// Express an postgres concatenate (`||`) expression.
@@ -196,4 +198,12 @@ pub trait PgExpr: ExprTrait {
     }
 }
 
-impl<T> PgExpr for T where T: ExprTrait {}
+// TODO: https://github.com/SeaQL/sea-query/discussions/795:
+// replace all of this with `impl<T> PgExpr for T where T: ExprTrait {}`
+impl PgExpr for Expr {}
+impl PgExpr for SimpleExpr {}
+impl PgExpr for FunctionCall {}
+impl PgExpr for ColumnRef {}
+impl PgExpr for Keyword {}
+impl PgExpr for LikeExpr {}
+impl PgExpr for Value {}

--- a/src/extension/sqlite/expr.rs
+++ b/src/extension/sqlite/expr.rs
@@ -1,4 +1,4 @@
-use crate::{expr::ExprTrait, SimpleExpr};
+use crate::{ColumnRef, Expr, ExprTrait, FunctionCall, Keyword, LikeExpr, SimpleExpr, Value};
 
 use super::SqliteBinOper;
 
@@ -104,4 +104,12 @@ pub trait SqliteExpr: ExprTrait {
     }
 }
 
-impl<T> SqliteExpr for T where T: ExprTrait {}
+// TODO: https://github.com/SeaQL/sea-query/discussions/795:
+// replace all of this with `impl<T> PgExpr for T where T: ExprTrait {}`
+impl SqliteExpr for Expr {}
+impl SqliteExpr for SimpleExpr {}
+impl SqliteExpr for FunctionCall {}
+impl SqliteExpr for ColumnRef {}
+impl SqliteExpr for Keyword {}
+impl SqliteExpr for LikeExpr {}
+impl SqliteExpr for Value {}

--- a/src/extension/sqlite/expr.rs
+++ b/src/extension/sqlite/expr.rs
@@ -1,8 +1,8 @@
-use crate::{expr::private::Expression, Expr, SimpleExpr};
+use crate::{expr::ExprTrait, SimpleExpr};
 
 use super::SqliteBinOper;
 
-pub trait SqliteExpr: Expression {
+pub trait SqliteExpr: ExprTrait {
     /// Express an sqlite `GLOB` operator.
     ///
     /// # Examples
@@ -25,7 +25,7 @@ pub trait SqliteExpr: Expression {
     where
         T: Into<SimpleExpr>,
     {
-        self.bin_op(SqliteBinOper::Glob, right)
+        self.binary(SqliteBinOper::Glob, right)
     }
 
     /// Express an sqlite `MATCH` operator.
@@ -50,7 +50,7 @@ pub trait SqliteExpr: Expression {
     where
         T: Into<SimpleExpr>,
     {
-        self.bin_op(SqliteBinOper::Match, right)
+        self.binary(SqliteBinOper::Match, right)
     }
 
     /// Express an sqlite retrieves JSON field as JSON value (`->`).
@@ -75,7 +75,7 @@ pub trait SqliteExpr: Expression {
     where
         T: Into<SimpleExpr>,
     {
-        self.bin_op(SqliteBinOper::GetJsonField, right)
+        self.binary(SqliteBinOper::GetJsonField, right)
     }
 
     /// Express an sqlite retrieves JSON field and casts it to an appropriate SQL type (`->>`).
@@ -100,10 +100,8 @@ pub trait SqliteExpr: Expression {
     where
         T: Into<SimpleExpr>,
     {
-        self.bin_op(SqliteBinOper::CastJsonField, right)
+        self.binary(SqliteBinOper::CastJsonField, right)
     }
 }
 
-impl SqliteExpr for Expr {}
-
-impl SqliteExpr for SimpleExpr {}
+impl<T> SqliteExpr for T where T: ExprTrait {}


### PR DESCRIPTION
## Edited PR Info

- (partially) Closes #771
- Dependencies: none.
- Dependents: currently none, but I have plans for the following things after the merge:
  - If you don't mind a small breaking change, I'd really like to get rid of some inherent methods on `Expr` and `SimpleExpr`, which now simply forward to `ExprTrait` methods. I call it small, because all signatures are exactly the same and the compiler will simply suggest adding `use sea_query::ExprTrait`, which is enough to fix the breakage.
  - Something like `impl ExprTrait for C: ColumnTrait` in `sea_orm`.
  - If you don't mind the breakage, I'd like to then remove some similar `ColumnTrait` methods. Their signatures don't match exactly, so there's going to be more breakage than in case of `sea_query`.

## New Features

- `trait ExprTrait`
  - It gathers together `Expr`- and `SimpleExpr`-like "operator" methods.
- `impl<T> ExprTrait for T where T: Into<SimpleExpr>`
  - Implements these methods for `Expr`, `SimpleExpr`, and also all other `Into<SimpleExpr>` types, like `Value` or `FunctionCall`.
- `impl PgExpr` for `FunctionCall`, `ColumnRef`, `Keyword`, `LikeExpr`, `Value`.
  - This could be a separate PR, but it's a small change that's very in line with `ExprTrait`: adding "operator" methods to all "smaller" types.
- `impl SqliteExpr` for `FunctionCall`, `ColumnRef`, `Keyword`, `LikeExpr`, `Value`.
  - This could be a separate PR, but it's a small change that's very in line with `ExprTrait`: adding "operator" methods to all "smaller" types.
- `impl From<LikeExpr> for SimpleExpr`
  - For me, this makes a lot more sense than a private `fn like_like`. But this part is optional and I don't mind reverting this if you want.

## Bug Fixes

None

## Breaking Changes

None

## Changes

None

## Unedited original notes

This is a "draft" PR with only implementation and almost no new documentation or tests. I'd like to hear some feedback before commiting to doing that.

I added a very minimal doctest on `ExprTrait` definition, as a showcase of expressions which are now possible to write without wrapping everything in layers of `Expr::something(...)`. If it's not impressive or hard to understand, please let me know, I'll add more examples/comparisons. See also examples in #771 and #770. It's hard to understate: THIS IS A HUGE USABILITY WIN. I use SeaORM at work, I'm a relatively experienced user (and a contributor) at this point, but the `Expr`/`SimpleExpr` stuff still drives me crazy from time to time.

Apart from that doctest, there are no new tests, but note that `ExprTrait` methods are actually 100% covered by existing doctests of inherent `Expr`/`SimpleExpr` methods, which now call the trait under the hood.

This PR proposes a small breaking change, and I plan a few more, described in "PR Info". Let's also discuss this. Are you open to merging these? I'd really like to see them included. It makes things SO ELEGANT, compared to what we had. I think, now is a great time for this, as you go through unstable release candidates before major SeaORM 1.0.0.