### PR TITLE
Skip Rust's escaping in the enum_def macro (#793)

### DIFF
--- a/sea-query-attr/src/lib.rs
+++ b/sea-query-attr/src/lib.rs
@@ -58,10 +58,18 @@ pub fn enum_def(args: TokenStream, input: TokenStream) -> TokenStream {
         .iter()
         .map(|field| {
             let ident = &field.ident;
-            let string = ident
-                .as_ref()
-                .expect("#[enum_def] can only be used on structs with named fields")
-                .to_string();
+            let string = {
+                let mut inner = ident
+                    .as_ref()
+                    .expect("#[enum_def] can only be used on structs with named fields")
+                    .to_string();
+
+                if inner.starts_with("r#") {
+                    inner = (&inner[2..]).to_string();
+                }
+
+                inner
+            };
             let as_pascal = string.to_pascal_case();
             NamingHolder {
                 default: ident.as_ref().unwrap().clone(),

--- a/sea-query-attr/tests/pass/escaping.rs
+++ b/sea-query-attr/tests/pass/escaping.rs
@@ -1,0 +1,10 @@
+use sea_query_attr::enum_def;
+
+#[enum_def]
+pub struct Hello {
+    pub r#type: String
+}
+
+fn main() {
+    println!("{:?}", HelloIden::Type);
+}


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes: [Issue 793](https://github.com/SeaQL/sea-query/issues/793)

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies: no

<!-- any PR depends on this PR? (if applicable) -->
- Dependents: no

## New Features

No

## Bug Fixes

Yes. Please see the #793 issue

## Breaking Changes

No

## Changes

No
