### PR TITLE
feat: Add .apply_if to SelectStatement

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -214,6 +214,40 @@ impl SelectStatement {
         self
     }
 
+    /// A shorthand to express if ... else ... when constructing the select statement.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .column(Char::Character)
+    ///     .from(Char::Table)
+    ///     .apply_if(
+    ///         Some(5),
+    ///         |q, v| {
+    ///             q.and_where(Expr::col(Char::FontId).eq(v));
+    ///         }
+    ///     )
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character` FROM `character` WHERE `font_id` = 5"#
+    /// );
+    /// ```
+    pub fn apply_if<T, F>(&mut self, val: Option<T>, if_some: F) -> &mut Self
+    where
+        Self: Sized,
+        F: FnOnce(&mut Self, T),
+    {
+        if let Some(val) = val {
+            if_some(self, val);
+        }
+        self
+    }
+
     /// Construct part of the select statement in another function.
     ///
     /// # Examples

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -224,12 +224,9 @@ impl SelectStatement {
     /// let query = Query::select()
     ///     .column(Char::Character)
     ///     .from(Char::Table)
-    ///     .apply_if(
-    ///         Some(5),
-    ///         |q, v| {
-    ///             q.and_where(Expr::col(Char::FontId).eq(v));
-    ///         }
-    ///     )
+    ///     .apply_if(Some(5), |q, v| {
+    ///         q.and_where(Expr::col(Char::FontId).eq(v));
+    ///     })
     ///     .to_owned();
     ///
     /// assert_eq!(


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

The `.apply_if` method from SeaORM is 👨‍🍳 💋  in my opinion. This PR adds a similar method to the `SelectStatement` that can live beside `.conditions` as a more direct way to unpack `Option` type conditionals.

```rust
let query = Query::select()
    .column(Char::Character)
    .from(Char::Table)
    .apply_if(
        Some(5),
        |q, v| {
            q.and_where(Expr::col(Char::FontId).eq(v));
        }
    )
    .to_owned();
```

## New Features

- [x] Adds convenience function `pub fn apply_if<T, F>(&mut self, val: Option<T>, if_some: F)` to `SelectStatement` in an attempt to emulate `SeaORM`'s `.apply_if` functionality.

## Bug Fixes

N/A

## Breaking Changes

N/A

## Changes

- [x] Adds corresponding doctest
