### PR TITLE
sea-query-rusqlite - update rusqlite version to 0.32

### DIFF
--- a/examples/rusqlite/Cargo.toml
+++ b/examples/rusqlite/Cargo.toml
@@ -12,7 +12,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 time = { version = "0.3.36", features = ["parsing", "macros"] }
 serde_json = { version = "1" }
 uuid = { version = "1", features = ["serde", "v4"] }
-rusqlite = { version = "0.31" }
+rusqlite = { version = "0.32" }
 sea-query = { path = "../.."}
 sea-query-rusqlite = { path = "../../sea-query-rusqlite", features = [
     "with-chrono",

--- a/sea-query-rusqlite/Cargo.toml
+++ b/sea-query-rusqlite/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.60"
 
 [dependencies]
 sea-query = { version = "0.32.0-rc.1", path = "..", default-features = false }
-rusqlite = { version = "0.31" }
+rusqlite = { version = "0.32" }
 
 [features]
 with-chrono = ["rusqlite/chrono", "sea-query/with-chrono"]


### PR DESCRIPTION
## Changes

- [x] Upgraded the sea-query-rusqlite dependency to use [rusqlite](https://github.com/rusqlite/rusqlite) version `0.32`, which now supports SQLite 3.46.

## Note

- It would be great if we could have this work with the the latest production `sea-query 0.31`

Feel free to let me know if I need to make this PR on another branch.