### PR TITLE
feat: Add `IF NOT EXISTS` to type alter add statement

### DIFF
--- a/src/backend/postgres/types.rs
+++ b/src/backend/postgres/types.rs
@@ -91,7 +91,7 @@ impl PostgresQueryBuilder {
             TypeAlterOpt::Add {
                 value,
                 placement,
-                if_not_exists,
+                if_not_exists
             } => {
                 write!(sql, " ADD VALUE ").unwrap();
                 if *if_not_exists {

--- a/src/backend/postgres/types.rs
+++ b/src/backend/postgres/types.rs
@@ -91,7 +91,7 @@ impl PostgresQueryBuilder {
             TypeAlterOpt::Add {
                 value,
                 placement,
-                if_not_exists
+                if_not_exists,
             } => {
                 write!(sql, " ADD VALUE ").unwrap();
                 if *if_not_exists {

--- a/src/backend/postgres/types.rs
+++ b/src/backend/postgres/types.rs
@@ -88,22 +88,27 @@ impl PostgresQueryBuilder {
 
     fn prepare_alter_type_opt(&self, opt: &TypeAlterOpt, sql: &mut dyn SqlWriter) {
         match opt {
-            TypeAlterOpt::Add(value, placement) => {
+            TypeAlterOpt::Add {
+                value,
+                placement,
+                if_not_exists,
+            } => {
                 write!(sql, " ADD VALUE ").unwrap();
-                match placement {
-                    Some(add_option) => match add_option {
+                if *if_not_exists {
+                    write!(sql, "IF NOT EXISTS ").unwrap();
+                }
+                self.prepare_value(&value.to_string().into(), sql);
+                if let Some(add_option) = placement {
+                    match add_option {
                         TypeAlterAddOpt::Before(before_value) => {
-                            self.prepare_value(&value.to_string().into(), sql);
                             write!(sql, " BEFORE ").unwrap();
                             self.prepare_value(&before_value.to_string().into(), sql);
                         }
                         TypeAlterAddOpt::After(after_value) => {
-                            self.prepare_value(&value.to_string().into(), sql);
                             write!(sql, " AFTER ").unwrap();
                             self.prepare_value(&after_value.to_string().into(), sql);
                         }
-                    },
-                    None => self.prepare_value(&value.to_string().into(), sql),
+                    }
                 }
             }
             TypeAlterOpt::Rename(new_name) => {


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [x] Adds an `IF NOT EXISTS` to type alter add statement

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [x] I changed the `TypeAlterOpt::Add` variant to incoporate `if_not_exists`. I decided to turn it into a struct with named fields to provide clarity on what the boolean means. It's not backwards compatible, but I would assume it would affect few users considering most people would use the `TypeAlterStatement` directly and not the underlying enum.

## Changes

- [x] Adds `if_not_exists` to `TypeAlterStatement`
- [x] Adds `if_not_exists` to `TypeAlterOpt`
- [x] Refactors `prepare_alter_type_opt` for clarity and simplicity and to include `IF NOT EXISTS`
