### PR TITLE
sea-query-binder: relax the sqlx dependency range

### DIFF
--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.60"
 
 [dependencies]
 sea-query = { version = "0.32.0-rc.1", path = "..", default-features = false, features = ["thread-safe"] }
-sqlx = { version = "<0.8.1", default-features = false, optional = true }
+sqlx = { version = "<0.9.0", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true, features = ["std"] }
 chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }
 rust_decimal = { version = "1", default-features = false, optional = true }

--- a/sea-query-binder/Cargo.toml
+++ b/sea-query-binder/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.60"
 
 [dependencies]
 sea-query = { version = "0.32.0-rc.1", path = "..", default-features = false, features = ["thread-safe"] }
-sqlx = { version = "<0.9.0", default-features = false, optional = true }
+sqlx = { version = "0.8", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true, features = ["std"] }
 chrono = { version = "0.4", default-features = false, optional = true, features = ["clock"] }
 rust_decimal = { version = "1", default-features = false, optional = true }


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-query/issues/809

## Changes

- Compatibility with sqlx 0.8.1+
