### PR TITLE
Remove separate WithQuery to ensure it can be specified everywhere

### DIFF
--- a/sea-query-binder/src/sqlx.rs
+++ b/sea-query-binder/src/sqlx.rs
@@ -25,4 +25,3 @@ impl_sqlx_binder!(SelectStatement);
 impl_sqlx_binder!(UpdateStatement);
 impl_sqlx_binder!(InsertStatement);
 impl_sqlx_binder!(DeleteStatement);
-impl_sqlx_binder!(WithQuery);

--- a/sea-query-diesel/src/lib.rs
+++ b/sea-query-diesel/src/lib.rs
@@ -2,7 +2,6 @@ use diesel::backend::Backend;
 use diesel::result::QueryResult;
 use sea_query::{
     DeleteStatement, InsertStatement, QueryStatementWriter, SelectStatement, UpdateStatement,
-    WithQuery,
 };
 
 use self::backend::{ExtractBuilder, TransformValue};
@@ -40,4 +39,3 @@ impl_diesel_binder!(SelectStatement);
 impl_diesel_binder!(UpdateStatement);
 impl_diesel_binder!(InsertStatement);
 impl_diesel_binder!(DeleteStatement);
-impl_diesel_binder!(WithQuery);

--- a/sea-query-postgres/src/lib.rs
+++ b/sea-query-postgres/src/lib.rs
@@ -47,7 +47,6 @@ impl_postgres_binder!(SelectStatement);
 impl_postgres_binder!(UpdateStatement);
 impl_postgres_binder!(InsertStatement);
 impl_postgres_binder!(DeleteStatement);
-impl_postgres_binder!(WithQuery);
 
 impl ToSql for PostgresValue {
     fn to_sql(

--- a/sea-query-rbatis/src/lib.rs
+++ b/sea-query-rbatis/src/lib.rs
@@ -26,7 +26,7 @@ impl_rbs_binder!(SelectStatement);
 impl_rbs_binder!(UpdateStatement);
 impl_rbs_binder!(InsertStatement);
 impl_rbs_binder!(DeleteStatement);
-impl_rbs_binder!(WithQuery);
+
 trait ToRbV {
     fn to(self) -> RbValue;
 }
@@ -79,19 +79,35 @@ fn to_rb_values(values: Values) -> Vec<rbs::Value> {
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTime(t) => {
-                args.push(Value::ChronoDateTime(t).chrono_as_naive_utc_in_string().to());
+                args.push(
+                    Value::ChronoDateTime(t)
+                        .chrono_as_naive_utc_in_string()
+                        .to(),
+                );
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeUtc(t) => {
-                args.push(Value::ChronoDateTimeUtc(t).chrono_as_naive_utc_in_string().to());
+                args.push(
+                    Value::ChronoDateTimeUtc(t)
+                        .chrono_as_naive_utc_in_string()
+                        .to(),
+                );
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeLocal(t) => {
-                args.push(Value::ChronoDateTimeLocal(t).chrono_as_naive_utc_in_string().to());
+                args.push(
+                    Value::ChronoDateTimeLocal(t)
+                        .chrono_as_naive_utc_in_string()
+                        .to(),
+                );
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(t) => {
-                args.push(Value::ChronoDateTimeWithTimeZone(t).chrono_as_naive_utc_in_string().to());
+                args.push(
+                    Value::ChronoDateTimeWithTimeZone(t)
+                        .chrono_as_naive_utc_in_string()
+                        .to(),
+                );
             }
             #[cfg(feature = "with-time")]
             Value::TimeDate(t) => {
@@ -107,7 +123,11 @@ fn to_rb_values(values: Values) -> Vec<rbs::Value> {
             }
             #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(t) => {
-                args.push(Value::TimeDateTimeWithTimeZone(t).time_as_naive_utc_in_string().to());
+                args.push(
+                    Value::TimeDateTimeWithTimeZone(t)
+                        .time_as_naive_utc_in_string()
+                        .to(),
+                );
             }
             #[cfg(feature = "with-uuid")]
             Value::Uuid(uuid) => {

--- a/sea-query-rusqlite/src/lib.rs
+++ b/sea-query-rusqlite/src/lib.rs
@@ -47,7 +47,6 @@ impl_rusqlite_binder!(SelectStatement);
 impl_rusqlite_binder!(UpdateStatement);
 impl_rusqlite_binder!(InsertStatement);
 impl_rusqlite_binder!(DeleteStatement);
-impl_rusqlite_binder!(WithQuery);
 
 impl ToSql for RusqliteValue {
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -5,7 +5,7 @@ use crate::{
     types::*,
     value::*,
     QueryStatementBuilder, QueryStatementWriter, ReturningClause, SimpleExpr, SubQueryStatement,
-    WithClause, WithQuery,
+    WithClause,
 };
 use inherent::inherent;
 
@@ -44,6 +44,7 @@ pub struct DeleteStatement {
     pub(crate) orders: Vec<OrderExpr>,
     pub(crate) limit: Option<Value>,
     pub(crate) returning: Option<ReturningClause>,
+    pub(crate) with: Option<WithClause>,
 }
 
 impl DeleteStatement {
@@ -186,7 +187,7 @@ impl DeleteStatement {
         self.returning(ReturningClause::All)
     }
 
-    /// Create a [WithQuery] by specifying a [WithClause] to execute this query with.
+    /// Specify a [WithClause] to execute this query with.
     ///
     /// # Examples
     ///
@@ -204,11 +205,11 @@ impl DeleteStatement {
     ///         .table_name(Alias::new("cte"))
     ///         .to_owned();
     ///     let with_clause = WithClause::new().cte(cte).to_owned();
-    ///     let update = DeleteStatement::new()
+    ///     let query = DeleteStatement::new()
     ///         .from_table(Glyph::Table)
     ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from(Alias::new("cte")).to_owned()))
+    ///         .with(with_clause)
     ///         .to_owned();
-    ///     let query = update.with(with_clause);
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
@@ -223,8 +224,9 @@ impl DeleteStatement {
     ///     r#"WITH "cte" ("id") AS (SELECT "id" FROM "glyph" WHERE "image" LIKE '0%') DELETE FROM "glyph" WHERE "id" IN (SELECT "id" FROM "cte")"#
     /// );
     /// ```
-    pub fn with(self, clause: WithClause) -> WithQuery {
-        clause.query(self)
+    pub fn with(&mut self, clause: WithClause) -> &mut Self {
+        self.with = Some(clause);
+        self
     }
 }
 

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::QueryBuilder, error::*, prepare::*, types::*, OnConflict, QueryStatementBuilder,
     QueryStatementWriter, ReturningClause, SelectStatement, SimpleExpr, SubQueryStatement, Values,
-    WithClause, WithQuery,
+    WithClause,
 };
 use inherent::inherent;
 
@@ -51,6 +51,7 @@ pub struct InsertStatement {
     pub(crate) on_conflict: Option<OnConflict>,
     pub(crate) returning: Option<ReturningClause>,
     pub(crate) default_values: Option<u32>,
+    pub(crate) with: Option<WithClause>,
 }
 
 impl InsertStatement {
@@ -425,7 +426,7 @@ impl InsertStatement {
         self.returning(ReturningClause::All)
     }
 
-    /// Create a [WithQuery] by specifying a [WithClause] to execute this query with.
+    /// Specify a [WithClause] to execute this query with.
     ///
     /// # Examples
     ///
@@ -448,13 +449,13 @@ impl InsertStatement {
     ///         .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
     ///         .from(Alias::new("cte"))
     ///         .to_owned();
-    ///     let mut insert = Query::insert();
-    ///     insert
+    ///     let mut query = Query::insert();
+    ///     query
     ///         .into_table(Glyph::Table)
     ///         .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
     ///         .select_from(select)
-    ///         .unwrap();
-    ///     let query = insert.with(with_clause);
+    ///         .unwrap()
+    ///         .with(with_clause);
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
@@ -469,8 +470,9 @@ impl InsertStatement {
     ///     r#"WITH "cte" ("id", "image", "aspect") AS (SELECT "id", "image", "aspect" FROM "glyph") INSERT INTO "glyph" ("id", "image", "aspect") SELECT "id", "image", "aspect" FROM "cte""#
     /// );
     /// ```
-    pub fn with(self, clause: WithClause) -> WithQuery {
-        clause.query(self)
+    pub fn with(&mut self, clause: WithClause) -> &mut Self {
+        self.with = Some(clause);
+        self
     }
 
     /// Insert with default values if columns and values are not supplied.

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -52,7 +52,6 @@ pub enum SubQueryStatement {
     InsertStatement(InsertStatement),
     UpdateStatement(UpdateStatement),
     DeleteStatement(DeleteStatement),
-    WithStatement(WithQuery),
 }
 
 impl Query {

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -6,7 +6,6 @@ use crate::{
     types::*,
     value::*,
     QueryStatementBuilder, QueryStatementWriter, ReturningClause, SubQueryStatement, WithClause,
-    WithQuery,
 };
 use inherent::inherent;
 
@@ -44,6 +43,7 @@ pub struct UpdateStatement {
     pub(crate) orders: Vec<OrderExpr>,
     pub(crate) limit: Option<Value>,
     pub(crate) returning: Option<ReturningClause>,
+    pub(crate) with: Option<WithClause>,
 }
 
 impl UpdateStatement {
@@ -247,7 +247,7 @@ impl UpdateStatement {
         self.returning(ReturningClause::All)
     }
 
-    /// Create a [WithQuery] by specifying a [WithClause] to execute this query with.
+    /// Specify a [WithClause] to execute this query with.
     ///
     /// # Examples
     ///
@@ -265,12 +265,12 @@ impl UpdateStatement {
     ///         .table_name(Alias::new("cte"))
     ///         .to_owned();
     ///     let with_clause = WithClause::new().cte(cte).to_owned();
-    ///     let update = UpdateStatement::new()
+    ///     let query = UpdateStatement::new()
     ///         .table(Glyph::Table)
     ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from(Alias::new("cte")).to_owned()))
     ///         .value(Glyph::Aspect, Expr::cust("60 * 24 * 24"))
+    ///         .with(with_clause)
     ///         .to_owned();
-    ///     let query = update.with(with_clause);
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
@@ -285,8 +285,9 @@ impl UpdateStatement {
     ///     r#"WITH "cte" ("id") AS (SELECT "id" FROM "glyph" WHERE "image" LIKE '0%') UPDATE "glyph" SET "aspect" = 60 * 24 * 24 WHERE "id" IN (SELECT "id" FROM "cte")"#
     /// );
     /// ```
-    pub fn with(self, clause: WithClause) -> WithQuery {
-        clause.query(self)
+    pub fn with(&mut self, clause: WithClause) -> &mut Self {
+        self.with = Some(clause);
+        self
     }
 
     /// Get column values

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -994,12 +994,12 @@ fn select_58() {
         .table_name(Alias::new("cte"))
         .to_owned();
     let with_clause = WithClause::new().cte(cte).to_owned();
-    let select = SelectStatement::new()
-        .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
-        .from(Alias::new("cte"))
-        .to_owned();
     assert_eq!(
-        select.with(with_clause).to_string(PostgresQueryBuilder),
+        SelectStatement::new()
+            .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
+            .from(Alias::new("cte"))
+            .with(with_clause)
+            .to_string(PostgresQueryBuilder),
         [
             r#"WITH "cte" AS"#,
             r#"(SELECT "id", "image", "aspect""#,
@@ -1076,12 +1076,12 @@ fn select_62() {
         .table_name(Alias::new("cte"))
         .to_owned();
     let with_clause = WithClause::new().cte(cte).to_owned();
-    let select = SelectStatement::new()
-        .columns([Alias::new("column1"), Alias::new("column2")])
-        .from(Alias::new("cte"))
-        .to_owned();
     assert_eq!(
-        select.with(with_clause).to_string(PostgresQueryBuilder),
+        SelectStatement::new()
+            .columns([Alias::new("column1"), Alias::new("column2")])
+            .from(Alias::new("cte"))
+            .with(with_clause)
+            .to_string(PostgresQueryBuilder),
         [
             r#"WITH "cte" AS"#,
             r#"(SELECT * FROM (VALUES (1, 'hello'), (2, 'world')) AS "x")"#,


### PR DESCRIPTION
Instead, move the with clause into insert/update/select/delete. This makes sure you can specify with WITH clause to any method that takes a `SelectStatement`/`UpdateStatement`/`InsertStatement`/`DeleteStatement`.

## PR Info

<!-- mention the related issue -->
- Closes #813

## Breaking Changes

- [x] This removes `WithQuery` and changes the signature of `.with()`
