### PR TITLE
Derive additional traits for sea_query::Alias

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -241,7 +241,7 @@ pub enum Order {
 }
 
 /// Helper for create name alias
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Alias(String);
 
 /// Null Alias


### PR DESCRIPTION
## Changes

Adds derivations for the `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash` traits to `sea_query::Alias`. This will greatly help those working with aliases by allowing devs to treat them like strings instead of needing to convert them first through the `Iden` trait. 
