### PR TITLE
Support `INCLUDE` clause for PostgreSQL BTree index

### DIFF
--- a/src/backend/index_builder.rs
+++ b/src/backend/index_builder.rs
@@ -80,4 +80,8 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
     #[doc(hidden)]
     // Write WHERE clause for partial index. This function is not available in MySQL.
     fn prepare_filter(&self, _condition: &ConditionHolder, _sql: &mut dyn SqlWriter) {}
+
+    #[doc(hidden)]
+    // Write INCLUDE clause for index. This function is only available in PostgreSQL.
+    fn prepare_include_columns(&self, _columns: &[SeaRc<dyn Iden>], _sql: &mut dyn SqlWriter) {}
 }

--- a/tests/postgres/index.rs
+++ b/tests/postgres/index.rs
@@ -99,6 +99,22 @@ fn create_7() {
 }
 
 #[test]
+fn create_8() {
+    assert_eq!(
+        Index::create()
+            .name("idx-font-name-include-id-language")
+            .table(Font::Table)
+            .col(Font::Name)
+            .include(Font::Id)
+            .include(Font::Language)
+            .unique()
+            .nulls_not_distinct()
+            .to_string(PostgresQueryBuilder),
+        r#"CREATE UNIQUE INDEX "idx-font-name-include-id-language" ON "font" ("name") INCLUDE ("id", "language") NULLS NOT DISTINCT"#
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Index::drop()

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -611,3 +611,40 @@ fn create_16() {
         .join(" ")
     );
 }
+
+#[test]
+fn create_17() {
+    assert_eq!(
+        Table::create()
+        .table(Font::Table)
+        .col(
+            ColumnDef::new(Font::Id)
+                .integer()
+                .not_null()
+                .primary_key()
+                .auto_increment(),
+        )
+        .col(ColumnDef::new(Font::Name).string())
+        .col(ColumnDef::new(Font::Variant).string_len(255).not_null())
+        .col(ColumnDef::new(Font::Language).string_len(255).not_null())
+        .index(
+            Index::create()
+                .name("idx-font-name-include-language")
+                .unique()
+                .nulls_not_distinct()
+                .col(Font::Name)
+                .include(Font::Language),
+        )
+        .to_string(PostgresQueryBuilder),
+        [
+            r#"CREATE TABLE "font" ("#,
+            r#""id" serial NOT NULL PRIMARY KEY,"#,
+            r#""name" varchar,"#,
+            r#""variant" varchar(255) NOT NULL,"#,
+            r#""language" varchar(255) NOT NULL,"#,
+            r#"CONSTRAINT "idx-font-name-include-language" UNIQUE NULLS NOT DISTINCT ("name") INCLUDE ("language")"#,
+            r#")"#,
+        ]
+        .join(" ")
+    );
+}


### PR DESCRIPTION
## PR Info

- Closes #775 

## New Features

- [x] Support `INCLUDE` clause for PostgreSQL BTree index
