### PR TITLE
feat: support `UPDATE ... FROM ...` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 0.32.0 - Pending
+## 0.32.0 - 2024-10-17
 
 ### Releases
 

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -6,6 +6,10 @@ impl QueryBuilder for MysqlQueryBuilder {
         "ROW"
     }
 
+    fn prepare_update_from_table_refs(&self, _: &[TableRef], _: &mut dyn SqlWriter) {
+        unimplemented!(r#""UPDATE ... FROM ..." syntax not yet supported for MySQL backend"#)
+    }
+
     fn prepare_select_distinct(&self, select_distinct: &SelectDistinct, sql: &mut dyn SqlWriter) {
         match select_distinct {
             SelectDistinct::All => write!(sql, "ALL").unwrap(),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1,5 +1,6 @@
-use crate::*;
 use std::ops::Deref;
+
+use crate::*;
 
 const QUOTE: Quote = Quote(b'"', b'"');
 
@@ -211,15 +212,7 @@ pub trait QueryBuilder:
         });
 
         if !update.from.is_empty() {
-            write!(sql, " FROM ").unwrap();
-
-            update.from.iter().fold(true, |first, table_ref| {
-                if !first {
-                    write!(sql, ", ").unwrap()
-                }
-                self.prepare_table_ref(table_ref, sql);
-                false
-            });
+            self.prepare_update_from_table_refs(&update.from, sql);
         }
 
         self.prepare_output(&update.returning, sql);
@@ -231,6 +224,20 @@ pub trait QueryBuilder:
         self.prepare_update_limit(update, sql);
 
         self.prepare_returning(&update.returning, sql);
+    }
+
+    fn prepare_update_from_table_refs(&self, from: &[TableRef], sql: &mut dyn SqlWriter) {
+        write!(sql, " FROM ").unwrap();
+
+        from.iter().fold(true, |first, table_ref| {
+            if !first {
+                write!(sql, ", ").unwrap()
+            }
+
+            self.prepare_table_ref(table_ref, sql);
+
+            false
+        });
     }
 
     /// Translate ORDER BY expression in [`UpdateStatement`].

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -210,6 +210,18 @@ pub trait QueryBuilder:
             false
         });
 
+        if !update.from.is_empty() {
+            write!(sql, " FROM ").unwrap();
+
+            update.from.iter().fold(true, |first, table_ref| {
+                if !first {
+                    write!(sql, ", ").unwrap()
+                }
+                self.prepare_table_ref(table_ref, sql);
+                false
+            });
+        }
+
         self.prepare_output(&update.returning, sql);
 
         self.prepare_condition(&update.r#where, "WHERE", sql);

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -1,3 +1,5 @@
+use inherent::inherent;
+
 use crate::{
     backend::QueryBuilder,
     expr::*,
@@ -8,7 +10,6 @@ use crate::{
     QueryStatementBuilder, QueryStatementWriter, ReturningClause, SubQueryStatement, WithClause,
     WithQuery,
 };
-use inherent::inherent;
 
 /// Update existing rows in the table
 ///
@@ -99,7 +100,7 @@ impl UpdateStatement {
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     "UPDATE `glyph` SET `tokens` = `character`.`character` FROM `character` WHERE `glyph`.`image` = `character`.`user_data`"
+    ///     "UPDATE `glyph` JOIN `character` ON `glyph`.`image` = `character`.`user_data` SET `glyph`.`tokens` = `character`.`character`"
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -39,6 +39,7 @@ use inherent::inherent;
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct UpdateStatement {
     pub(crate) table: Option<Box<TableRef>>,
+    pub(crate) from: Vec<TableRef>,
     pub(crate) values: Vec<(DynIden, Box<SimpleExpr>)>,
     pub(crate) r#where: ConditionHolder,
     pub(crate) orders: Vec<OrderExpr>,
@@ -63,6 +64,62 @@ impl UpdateStatement {
         T: IntoTableRef,
     {
         self.table = Some(Box::new(tbl_ref.into_table_ref()));
+        self
+    }
+
+    /// From table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::update()
+    ///     .table(Glyph::Table)
+    ///     .value(
+    ///         Glyph::Tokens,
+    ///         SimpleExpr::Column(ColumnRef::TableColumn(
+    ///             SeaRc::new(Char::Table),
+    ///             SeaRc::new(Char::Character),
+    ///         )),
+    ///     )
+    ///     .from(Char::Table)
+    ///     .cond_where(
+    ///         SimpleExpr::Column(ColumnRef::TableColumn(
+    ///             SeaRc::new(Glyph::Table),
+    ///             SeaRc::new(Glyph::Image),
+    ///         ))
+    ///         .eq(SimpleExpr::Column(ColumnRef::TableColumn(
+    ///             SeaRc::new(Char::Table),
+    ///             SeaRc::new(Char::UserData),
+    ///         ))),
+    ///     )
+    ///     .to_owned();
+    ///
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     "UPDATE `glyph` SET `tokens` = `character`.`character` FROM `character` WHERE `glyph`.`image` = `character`.`user_data`"
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"UPDATE "glyph" SET "tokens" = "character"."character" FROM "character" WHERE "glyph"."image" = "character"."user_data""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"UPDATE "glyph" SET "tokens" = "character"."character" FROM "character" WHERE "glyph"."image" = "character"."user_data""#
+    /// );
+    /// ```
+    pub fn from<R>(&mut self, tbl_ref: R) -> &mut Self
+    where
+        R: IntoTableRef,
+    {
+        self.from_from(tbl_ref.into_table_ref())
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    fn from_from(&mut self, select: TableRef) -> &mut Self {
+        self.from.push(select);
         self
     }
 


### PR DESCRIPTION
## PR Info

- Partially addresses [#608](https://github.com/SeaQL/sea-query/issues/608#issuecomment-1441261493)

## New Features

- [ ] Adds support for explicitly specifying a `FROM` clause in an `UPDATE` query
    - e.x. `UPDATE table1 SET some_column = table2.another_column FROM table2 WHERE table1.another_column = table2.a_different_column`

