### PR TITLE
Added `ValueType::enum_type_name()` to signify enum types

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -237,6 +237,10 @@ pub trait ValueType: Sized {
     fn array_type() -> ArrayType;
 
     fn column_type() -> ColumnType;
+
+    fn enum_type_name() -> Option<&'static str> {
+        None
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## PR Info

- Dependents:
  - 

## New Features

- [x] Added `ValueType::enum_type_name()` to signify enum types
