### PR TITLE
feat(function): Add support for GREATEST / LEAST function

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -664,6 +664,8 @@ pub trait QueryBuilder:
                     Function::Coalesce => "COALESCE",
                     Function::Count => "COUNT",
                     Function::IfNull => self.if_null_function(),
+                    Function::Greatest => self.greatest_function(),
+                    Function::Least => self.least_function(),
                     Function::CharLength => self.char_length_function(),
                     Function::Cast => "CAST",
                     Function::Lower => "LOWER",
@@ -1464,6 +1466,18 @@ pub trait QueryBuilder:
     /// The name of the function that represents the "if null" condition.
     fn if_null_function(&self) -> &str {
         "IFNULL"
+    }
+
+    #[doc(hidden)]
+    /// The name of the function that represents the "greatest" function.
+    fn greatest_function(&self) -> &str {
+        "GREATEST"
+    }
+
+    #[doc(hidden)]
+    /// The name of the function that represents the "least" function.
+    fn least_function(&self) -> &str {
+        "LEAST"
     }
 
     #[doc(hidden)]

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -76,6 +76,14 @@ impl QueryBuilder for SqliteQueryBuilder {
         sql.push_param(value.clone(), self as _);
     }
 
+    fn greatest_function(&self) -> &str {
+        "MAX"
+    }
+
+    fn least_function(&self) -> &str {
+        "MIN"
+    }
+
     fn char_length_function(&self) -> &str {
         "LENGTH"
     }

--- a/src/func.rs
+++ b/src/func.rs
@@ -15,6 +15,8 @@ pub enum Function {
     Abs,
     Count,
     IfNull,
+    Greatest,
+    Least,
     CharLength,
     Cast,
     Custom(DynIden),
@@ -390,6 +392,76 @@ impl Func {
         T: Into<SimpleExpr>,
     {
         FunctionCall::new(Function::CharLength).arg(expr)
+    }
+
+    /// Call `GREATEST` function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Func::greatest([
+    ///         Expr::col(Char::SizeW).into(),
+    ///         Expr::col(Char::SizeH).into(),
+    ///     ]))
+    ///     .from(Char::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT GREATEST(`size_w`, `size_h`) FROM `character`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT GREATEST("size_w", "size_h") FROM "character""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT MAX("size_w", "size_h") FROM "character""#
+    /// );
+    /// ```
+    pub fn greatest<I>(args: I) -> FunctionCall
+    where
+        I: IntoIterator<Item = SimpleExpr>,
+    {
+        FunctionCall::new(Function::Greatest).args(args)
+    }
+
+    /// Call `LEAST` function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Func::least([
+    ///         Expr::col(Char::SizeW).into(),
+    ///         Expr::col(Char::SizeH).into(),
+    ///     ]))
+    ///     .from(Char::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT LEAST(`size_w`, `size_h`) FROM `character`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT LEAST("size_w", "size_h") FROM "character""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT MIN("size_w", "size_h") FROM "character""#
+    /// );
+    /// ```
+    pub fn least<I>(args: I) -> FunctionCall
+    where
+        I: IntoIterator<Item = SimpleExpr>,
+    {
+        FunctionCall::new(Function::Least).args(args)
     }
 
     /// Call `IF NULL` function.


### PR DESCRIPTION
## New Features

- [ ] Add support for `GREATEST` / `LEAST` SQL functions
As those functions are not supported on SQLite, this fallback to plain MAX/MIN.