### PR TITLE
feat: allow a USING clause for alter table column type in postgres

### DIFF
--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -143,7 +143,9 @@ impl TableBuilder for PostgresQueryBuilder {
                         if !first
                             && !matches!(
                                 column_spec,
-                                ColumnSpec::AutoIncrement | ColumnSpec::Generated { .. }
+                                ColumnSpec::AutoIncrement
+                                    | ColumnSpec::Generated { .. }
+                                    | ColumnSpec::Using(_)
                             )
                         {
                             write!(sql, ", ").unwrap();
@@ -180,6 +182,10 @@ impl TableBuilder for PostgresQueryBuilder {
                             ColumnSpec::Generated { .. } => {}
                             ColumnSpec::Extra(string) => write!(sql, "{string}").unwrap(),
                             ColumnSpec::Comment(_) => {}
+                            ColumnSpec::Using(expr) => {
+                                write!(sql, " USING ").unwrap();
+                                QueryBuilder::prepare_simple_expr(self, expr, sql);
+                            }
                         }
                         false
                     });

--- a/src/backend/table_builder.rs
+++ b/src/backend/table_builder.rs
@@ -107,6 +107,7 @@ pub trait TableBuilder:
             }
             ColumnSpec::Extra(string) => write!(sql, "{string}").unwrap(),
             ColumnSpec::Comment(comment) => self.column_comment(comment, sql),
+            ColumnSpec::Using(_) => {}
         }
     }
 

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -180,6 +180,7 @@ pub enum ColumnSpec {
     Generated { expr: SimpleExpr, stored: bool },
     Extra(String),
     Comment(String),
+    Using(SimpleExpr),
 }
 
 // All interval fields
@@ -718,6 +719,34 @@ impl ColumnDef {
         T: Into<String>,
     {
         self.spec.push(ColumnSpec::Extra(string.into()));
+        self
+    }
+
+    /// Some extra options in custom string
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    /// let table = Table::alter()
+    ///     .table(Char::Table)
+    ///     .modify_column(
+    ///         ColumnDef::new(Char::Id)
+    ///             .integer()
+    ///             .using(Expr::col(Char::Id).cast_as(Alias::new("integer"))),
+    ///     )
+    ///     .to_owned();
+    /// assert_eq!(
+    ///     table.to_string(PostgresQueryBuilder),
+    ///     [
+    ///         r#"ALTER TABLE "character""#,
+    ///         r#"ALTER COLUMN "id" TYPE integer USING CAST("id" AS integer)"#,
+    ///     ]
+    ///     .join(" ")
+    /// );
+    /// ```
+    pub fn using<T>(&mut self, value: T) -> &mut Self
+    where
+        T: Into<SimpleExpr>,
+    {
+        self.spec.push(ColumnSpec::Using(value.into()));
         self
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes #626 

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [x] Allows a USING clause for ALTER TABLE COLUMN TYPE

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [x] This is backwards compatible

## Changes

- [x] Adds a `Using` variant to `ColumnSpec`
