### PR TITLE
Add with_cte to include WITH clauses in Statements

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -18,6 +18,10 @@ pub trait QueryBuilder:
 
     /// Translate [`InsertStatement`] into SQL statement.
     fn prepare_insert_statement(&self, insert: &InsertStatement, sql: &mut dyn SqlWriter) {
+        if let Some(with) = &insert.with {
+            self.prepare_with_clause(with, sql);
+        }
+
         self.prepare_insert(insert.replace, sql);
 
         if let Some(table) = &insert.table {
@@ -95,6 +99,10 @@ pub trait QueryBuilder:
 
     /// Translate [`SelectStatement`] into SQL statement.
     fn prepare_select_statement(&self, select: &SelectStatement, sql: &mut dyn SqlWriter) {
+        if let Some(with) = &select.with {
+            self.prepare_with_clause(with, sql);
+        }
+
         write!(sql, "SELECT ").unwrap();
 
         if let Some(distinct) = &select.distinct {
@@ -191,6 +199,10 @@ pub trait QueryBuilder:
 
     /// Translate [`UpdateStatement`] into SQL statement.
     fn prepare_update_statement(&self, update: &UpdateStatement, sql: &mut dyn SqlWriter) {
+        if let Some(with) = &update.with {
+            self.prepare_with_clause(with, sql);
+        }
+
         write!(sql, "UPDATE ").unwrap();
 
         if let Some(table) = &update.table {
@@ -245,6 +257,10 @@ pub trait QueryBuilder:
 
     /// Translate [`DeleteStatement`] into SQL statement.
     fn prepare_delete_statement(&self, delete: &DeleteStatement, sql: &mut dyn SqlWriter) {
+        if let Some(with) = &delete.with {
+            self.prepare_with_clause(with, sql);
+        }
+
         write!(sql, "DELETE ").unwrap();
 
         if let Some(table) = &delete.table {

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -44,6 +44,7 @@ pub struct DeleteStatement {
     pub(crate) orders: Vec<OrderExpr>,
     pub(crate) limit: Option<Value>,
     pub(crate) returning: Option<ReturningClause>,
+    pub(crate) with: Option<WithClause>,
 }
 
 impl DeleteStatement {
@@ -225,6 +226,48 @@ impl DeleteStatement {
     /// ```
     pub fn with(self, clause: WithClause) -> WithQuery {
         clause.query(self)
+    }
+
+    /// Create a Common Table Expression by specifying a [CommonTableExpression] or [WithClause] to execute this query with.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{*, IntoCondition, IntoIden, tests_cfg::*};
+    ///
+    /// let select = SelectStatement::new()
+    ///         .columns([Glyph::Id])
+    ///         .from(Glyph::Table)
+    ///         .and_where(Expr::col(Glyph::Image).like("0%"))
+    ///         .to_owned();
+    ///     let cte = CommonTableExpression::new()
+    ///         .query(select)
+    ///         .column(Glyph::Id)
+    ///         .table_name(Alias::new("cte"))
+    ///         .to_owned();
+    ///     let with_clause = WithClause::new().cte(cte).to_owned();
+    ///     let query = DeleteStatement::new()
+    ///         .with_cte(with_clause)
+    ///         .from_table(Glyph::Table)
+    ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from(Alias::new("cte")).to_owned()))
+    ///         .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"WITH `cte` (`id`) AS (SELECT `id` FROM `glyph` WHERE `image` LIKE '0%') DELETE FROM `glyph` WHERE `id` IN (SELECT `id` FROM `cte`)"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"WITH "cte" ("id") AS (SELECT "id" FROM "glyph" WHERE "image" LIKE '0%') DELETE FROM "glyph" WHERE "id" IN (SELECT "id" FROM "cte")"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"WITH "cte" ("id") AS (SELECT "id" FROM "glyph" WHERE "image" LIKE '0%') DELETE FROM "glyph" WHERE "id" IN (SELECT "id" FROM "cte")"#
+    /// );
+    /// ```
+    pub fn with_cte<C: Into<WithClause>>(&mut self, clause: C) -> &mut Self {
+        self.with = Some(clause.into());
+        self
     }
 }
 

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -485,6 +485,13 @@ impl WithClause {
         WithQuery::new().with_clause(self).query(query).to_owned()
     }
 }
+
+impl From<CommonTableExpression> for WithClause {
+    fn from(cte: CommonTableExpression) -> WithClause {
+        WithClause::new().cte(cte).to_owned()
+    }
+}
+
 /// A WITH query. A simple SQL query that has a WITH clause ([WithClause]).
 ///
 /// The [WithClause] can contain one or multiple common table expressions ([CommonTableExpression]).

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1093,6 +1093,33 @@ fn select_62() {
 }
 
 #[test]
+fn select_63() {
+    let select = SelectStatement::new()
+        .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
+        .from(Glyph::Table)
+        .to_owned();
+    let cte = CommonTableExpression::new()
+        .query(select)
+        .table_name(Alias::new("cte"))
+        .to_owned();
+    let select = SelectStatement::new()
+        .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
+        .from(Alias::new("cte"))
+        .with_cte(cte)
+        .to_owned();
+    assert_eq!(
+        select.to_string(PostgresQueryBuilder),
+        [
+            r#"WITH "cte" AS"#,
+            r#"(SELECT "id", "image", "aspect""#,
+            r#"FROM "glyph")"#,
+            r#"SELECT "id", "image", "aspect" FROM "cte""#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 #[allow(clippy::approx_constant)]
 fn insert_2() {
     assert_eq!(
@@ -1273,6 +1300,40 @@ fn insert_10() {
             .to_string(PostgresQueryBuilder),
         r#"INSERT INTO "glyph" ("aspect", "tokens") VALUES (3.1415, ARRAY ['Token1','Token2','Token3'])"#
     );
+}
+
+#[test]
+fn insert_11() -> error::Result<()> {
+    let select = SelectStatement::new()
+        .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
+        .from(Glyph::Table)
+        .to_owned();
+    let cte = CommonTableExpression::new()
+        .query(select)
+        .column(Glyph::Id)
+        .column(Glyph::Image)
+        .column(Glyph::Aspect)
+        .table_name(Alias::new("cte"))
+        .to_owned();
+    let select = SelectStatement::new()
+        .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
+        .from(Alias::new("cte"))
+        .to_owned();
+    let mut insert = Query::insert();
+    insert
+        .into_table(Glyph::Table)
+        .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
+        .with_cte(cte)
+        .select_from(select)?;
+    let sql = insert.to_string(PostgresQueryBuilder);
+    assert_eq!(
+        sql.as_str(),
+        [
+            r#"WITH "cte" ("id", "image", "aspect") AS (SELECT "id", "image", "aspect" FROM "glyph")"#,
+            r#"INSERT INTO "glyph" ("id", "image", "aspect") SELECT "id", "image", "aspect" FROM "cte""#,
+        ].join(" ")
+    );
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
…instead of separate WithQuery

## PR Info

- Closes #813
- Replaces #814, keeping `WithQuery` for backward compatibility

## New Features

- Adds `with_cte` method to `SelectStatement`/`UpdateStatement`/`InsertStatement`/`DeleteStatement` to allow adding WITH clauses to any query

## Notes

- I had to choose another method name to avoid breaking backward compatibiity of the existing `fn with(...) -> WithQuery`. I'm not completely happy with `with_cte` but couldn't think of anything better.
- If the intention is to eventually remove `WithQuery`, we could add `#[deprecated]` to the`with` methods to encourage users to migrate