### PR TITLE
fix: make AsEnum quoted to get the correct enum in postgres

### DIFF
--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -41,9 +41,7 @@ impl QueryBuilder for PostgresQueryBuilder {
     fn prepare_simple_expr(&self, simple_expr: &SimpleExpr, sql: &mut dyn SqlWriter) {
         match simple_expr {
             SimpleExpr::AsEnum(type_name, expr) => {
-                let simple_expr = expr
-                    .clone()
-                    .cast_as_quoted(SeaRc::clone(type_name), '"'.into());
+                let simple_expr = expr.clone().cast_as_quoted(SeaRc::clone(type_name), '"');
                 self.prepare_simple_expr_common(&simple_expr, sql);
             }
             _ => QueryBuilder::prepare_simple_expr_common(self, simple_expr, sql),

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -41,7 +41,9 @@ impl QueryBuilder for PostgresQueryBuilder {
     fn prepare_simple_expr(&self, simple_expr: &SimpleExpr, sql: &mut dyn SqlWriter) {
         match simple_expr {
             SimpleExpr::AsEnum(type_name, expr) => {
-                let simple_expr = expr.clone().cast_as(SeaRc::clone(type_name));
+                let simple_expr = expr
+                    .clone()
+                    .cast_as_quoted(SeaRc::clone(type_name), '"'.into());
                 self.prepare_simple_expr_common(&simple_expr, sql);
             }
             _ => QueryBuilder::prepare_simple_expr_common(self, simple_expr, sql),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3849,7 +3849,7 @@ impl SimpleExpr {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Expr::value("1").cast_as_quoted(Alias::new("MyType"), '"'.into()))
+    ///     .expr(Expr::value("1").cast_as_quoted(Alias::new("MyType"), '"'))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -3865,11 +3865,12 @@ impl SimpleExpr {
     ///     r#"SELECT CAST('1' AS "MyType")"#
     /// );
     /// ```
-    pub fn cast_as_quoted<T>(self, type_name: T, q: Quote) -> Self
+    pub fn cast_as_quoted<T, Q>(self, type_name: T, q: Q) -> Self
     where
         T: IntoIden,
+        Q: Into<Quote>,
     {
-        let func = Func::cast_as_quoted(self, type_name, q);
+        let func = Func::cast_as_quoted(self, type_name, q.into());
         Self::FunctionCall(func)
     }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -105,7 +105,7 @@ pub trait ExprTrait: Sized {
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"INSERT INTO "character" ("font_size") VALUES (CAST('large' AS FontSizeEnum))"#
+    ///     r#"INSERT INTO "character" ("font_size") VALUES (CAST('large' AS "FontSizeEnum"))"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
@@ -3236,7 +3236,7 @@ impl Expr {
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT CAST("font_size" AS text) FROM "character""#
+    ///     r#"SELECT CAST("font_size" AS "text") FROM "character""#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
@@ -3255,7 +3255,7 @@ impl Expr {
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"INSERT INTO "character" ("font_size") VALUES (CAST('large' AS FontSizeEnum))"#
+    ///     r#"INSERT INTO "character" ("font_size") VALUES (CAST('large' AS "FontSizeEnum"))"#
     /// );
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes [issue link ](https://github.com/SeaQL/sea-orm/issues/2087)

## Bug Fixes

- Enums are always lowercased in queries as shown in the issue example
