### PR TITLE
Support for creating functional indexes in PostgreSQL and MySQL

### DIFF
--- a/src/backend/index_builder.rs
+++ b/src/backend/index_builder.rs
@@ -57,6 +57,23 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
     }
 
     #[doc(hidden)]
+    /// Write the index column with table column.
+    fn prepare_index_column_with_table_column(
+        &self,
+        column: &IndexColumnTableColumn,
+        sql: &mut dyn SqlWriter,
+    ) {
+        column.name.prepare(sql.as_writer(), self.quote());
+        self.write_column_index_prefix(&column.prefix, sql);
+        if let Some(order) = &column.order {
+            match order {
+                IndexOrder::Asc => write!(sql, " ASC").unwrap(),
+                IndexOrder::Desc => write!(sql, " DESC").unwrap(),
+            }
+        }
+    }
+
+    #[doc(hidden)]
     /// Write the column index prefix.
     fn prepare_index_columns(&self, columns: &[IndexColumn], sql: &mut dyn SqlWriter) {
         write!(sql, "(").unwrap();
@@ -64,15 +81,11 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            if let Some(name) = &col.name {
-                name.prepare(sql.as_writer(), self.quote());
-                self.write_column_index_prefix(&col.prefix, sql);
-                if let Some(order) = &col.order {
-                    match order {
-                        IndexOrder::Asc => write!(sql, " ASC").unwrap(),
-                        IndexOrder::Desc => write!(sql, " DESC").unwrap(),
-                    }
+            match col {
+                IndexColumn::TableColumn(column) => {
+                    self.prepare_index_column_with_table_column(column, sql);
                 }
+                IndexColumn::Expr(_) => panic!("Not supported"),
             }
             false
         });

--- a/src/backend/index_builder.rs
+++ b/src/backend/index_builder.rs
@@ -64,12 +64,14 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            col.name.prepare(sql.as_writer(), self.quote());
-            self.write_column_index_prefix(&col.prefix, sql);
-            if let Some(order) = &col.order {
-                match order {
-                    IndexOrder::Asc => write!(sql, " ASC").unwrap(),
-                    IndexOrder::Desc => write!(sql, " DESC").unwrap(),
+            if let Some(name) = &col.name {
+                name.prepare(sql.as_writer(), self.quote());
+                self.write_column_index_prefix(&col.prefix, sql);
+                if let Some(order) = &col.order {
+                    match order {
+                        IndexOrder::Asc => write!(sql, " ASC").unwrap(),
+                        IndexOrder::Desc => write!(sql, " DESC").unwrap(),
+                    }
                 }
             }
             false

--- a/src/backend/mysql/index.rs
+++ b/src/backend/mysql/index.rs
@@ -125,38 +125,20 @@ impl IndexBuilder for MysqlQueryBuilder {
                 write!(sql, ", ").unwrap();
             }
             match col {
-                IndexColumn {
-                    name: Some(name),
-                    prefix,
-                    order,
-                    expr: None,
-                } => {
-                    name.prepare(sql.as_writer(), self.quote());
-                    self.write_column_index_prefix(prefix, sql);
-                    if let Some(order) = order {
-                        match order {
-                            IndexOrder::Asc => write!(sql, " ASC").unwrap(),
-                            IndexOrder::Desc => write!(sql, " DESC").unwrap(),
-                        }
-                    }
+                IndexColumn::TableColumn(column) => {
+                    self.prepare_index_column_with_table_column(column, sql);
                 }
-                IndexColumn {
-                    name: None,
-                    prefix: _,
-                    order,
-                    expr: Some(expr),
-                } => {
+                IndexColumn::Expr(column) => {
                     write!(sql, "(").unwrap();
-                    self.prepare_simple_expr(expr, sql);
+                    self.prepare_simple_expr(&column.expr, sql);
                     write!(sql, ")").unwrap();
-                    if let Some(order) = order {
+                    if let Some(order) = &column.order {
                         match order {
                             IndexOrder::Asc => write!(sql, " ASC").unwrap(),
                             IndexOrder::Desc => write!(sql, " DESC").unwrap(),
                         }
                     }
                 }
-                _ => panic!("Not supported"),
             }
             false
         });

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -140,6 +140,51 @@ impl IndexBuilder for PostgresQueryBuilder {
         }
     }
 
+    fn prepare_index_columns(&self, columns: &[IndexColumn], sql: &mut dyn SqlWriter) {
+        write!(sql, "(").unwrap();
+        columns.iter().fold(true, |first, col| {
+            if !first {
+                write!(sql, ", ").unwrap();
+            }
+            match col {
+                IndexColumn {
+                    name: Some(name),
+                    prefix,
+                    order,
+                    expr: None,
+                } => {
+                    name.prepare(sql.as_writer(), self.quote());
+                    self.write_column_index_prefix(prefix, sql);
+                    if let Some(order) = order {
+                        match order {
+                            IndexOrder::Asc => write!(sql, " ASC").unwrap(),
+                            IndexOrder::Desc => write!(sql, " DESC").unwrap(),
+                        }
+                    }
+                }
+                IndexColumn {
+                    name: None,
+                    prefix: None,
+                    order,
+                    expr: Some(expr),
+                } => {
+                    write!(sql, "(").unwrap();
+                    self.prepare_simple_expr(expr, sql);
+                    write!(sql, ")").unwrap();
+                    if let Some(order) = order {
+                        match order {
+                            IndexOrder::Asc => write!(sql, " ASC").unwrap(),
+                            IndexOrder::Desc => write!(sql, " DESC").unwrap(),
+                        }
+                    }
+                }
+                _ => panic!("Not supported"),
+            }
+            false
+        });
+        write!(sql, ")").unwrap();
+    }
+
     fn prepare_filter(&self, condition: &ConditionHolder, sql: &mut dyn SqlWriter) {
         self.prepare_condition(condition, "WHERE", sql);
     }

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -147,38 +147,20 @@ impl IndexBuilder for PostgresQueryBuilder {
                 write!(sql, ", ").unwrap();
             }
             match col {
-                IndexColumn {
-                    name: Some(name),
-                    prefix,
-                    order,
-                    expr: None,
-                } => {
-                    name.prepare(sql.as_writer(), self.quote());
-                    self.write_column_index_prefix(prefix, sql);
-                    if let Some(order) = order {
-                        match order {
-                            IndexOrder::Asc => write!(sql, " ASC").unwrap(),
-                            IndexOrder::Desc => write!(sql, " DESC").unwrap(),
-                        }
-                    }
+                IndexColumn::TableColumn(column) => {
+                    self.prepare_index_column_with_table_column(column, sql);
                 }
-                IndexColumn {
-                    name: None,
-                    prefix: None,
-                    order,
-                    expr: Some(expr),
-                } => {
+                IndexColumn::Expr(column) => {
                     write!(sql, "(").unwrap();
-                    self.prepare_simple_expr(expr, sql);
+                    self.prepare_simple_expr(&column.expr, sql);
                     write!(sql, ")").unwrap();
-                    if let Some(order) = order {
+                    if let Some(order) = &column.order {
                         match order {
                             IndexOrder::Asc => write!(sql, " ASC").unwrap(),
                             IndexOrder::Desc => write!(sql, " DESC").unwrap(),
                         }
                     }
                 }
-                _ => panic!("Not supported"),
             }
             false
         });

--- a/src/index/common.rs
+++ b/src/index/common.rs
@@ -31,7 +31,7 @@ impl IndexColumn {
     pub(crate) fn name(&self) -> Option<&DynIden> {
         match self {
             IndexColumn::TableColumn(IndexColumnTableColumn { name, .. }) => Some(name),
-            _ => None,
+            IndexColumn::Expr(_) => None,
         }
     }
 }

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -187,6 +187,22 @@ use super::common::*;
 ///     r#"CREATE INDEX "idx-font-name-include-language" ON "font" ("name") INCLUDE ("language")"#
 /// )
 /// ```
+///
+/// Functional Index
+/// ```
+/// use sea_query::{tests_cfg::*, *};
+///
+/// let index = Index::create()
+///     .name("idx-character-area")
+///     .table(Character::Table)
+///     .col(Expr::col(Character::SizeH).mul(Expr::col(Character::SizeW)))
+///     .to_owned();
+///
+/// assert_eq!(
+///     index.to_string(PostgresQueryBuilder),
+///     r#"CREATE INDEX "idx-character-area" ON "character" (("size_h" * "size_w"))"#
+/// )
+/// ```
 #[derive(Default, Debug, Clone)]
 pub struct IndexCreateStatement {
     pub(crate) table: Option<TableRef>,

--- a/tests/mysql/index.rs
+++ b/tests/mysql/index.rs
@@ -54,6 +54,35 @@ fn create_4() {
 }
 
 #[test]
+fn create_5() {
+    assert_eq!(
+        Index::create()
+            .name("idx-character-area")
+            .table(Character::Table)
+            .col(Expr::col(Character::SizeH).mul(Expr::col(Character::SizeW)))
+            .to_string(MysqlQueryBuilder),
+        "CREATE INDEX `idx-character-area` ON `character` ((`size_h` * `size_w`))"
+    )
+}
+
+#[test]
+fn create_6() {
+    assert_eq!(
+        Index::create()
+            .name("idx-character-character-area-desc-created_at")
+            .table(Character::Table)
+            .col(Func::upper(Expr::col(Character::Character)))
+            .col((
+                Expr::col(Character::SizeH).mul(Expr::col(Character::SizeW)),
+                IndexOrder::Desc,
+            ))
+            .col(Character::CreatedAt)
+            .to_string(MysqlQueryBuilder),
+        "CREATE INDEX `idx-character-character-area-desc-created_at` ON `character` ((UPPER(`character`)), (`size_h` * `size_w`) DESC, `created_at`)"
+    )
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Index::drop()

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -243,6 +243,60 @@ fn create_10() {
 }
 
 #[test]
+fn create_11() {
+    assert_eq!(
+        Table::create()
+            .table(Char::Table)
+            .if_not_exists()
+            .col(
+                ColumnDef::new(Char::Id)
+                    .integer()
+                    .not_null()
+                    .auto_increment()
+                    .primary_key(),
+            )
+            .col(ColumnDef::new(Char::FontSize).integer().not_null())
+            .col(ColumnDef::new(Char::Character).string_len(255).not_null())
+            .col(ColumnDef::new(Char::SizeW).unsigned().not_null())
+            .col(ColumnDef::new(Char::SizeH).unsigned().not_null())
+            .col(
+                ColumnDef::new(Char::FontId)
+                    .integer()
+                    .default(Value::Int(None)),
+            )
+            .col(
+                ColumnDef::new(Char::CreatedAt)
+                    .timestamp()
+                    .default(Expr::current_timestamp())
+                    .not_null(),
+            )
+            .index(
+                Index::create()
+                    .name("idx-character-area")
+                    .table(Character::Table)
+                    .col(Expr::col(Character::SizeH).mul(Expr::col(Character::SizeW))),
+            )
+            .engine("InnoDB")
+            .character_set("utf8mb4")
+            .collate("utf8mb4_unicode_ci")
+            .to_string(MysqlQueryBuilder),
+        [
+            "CREATE TABLE IF NOT EXISTS `character` (",
+            "`id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,",
+            "`font_size` int NOT NULL,",
+            "`character` varchar(255) NOT NULL,",
+            "`size_w` int UNSIGNED NOT NULL,",
+            "`size_h` int UNSIGNED NOT NULL,",
+            "`font_id` int DEFAULT NULL,",
+            "`created_at` timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,",
+            "KEY `idx-character-area` ((`size_h` * `size_w`))",
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Table::drop()

--- a/tests/postgres/index.rs
+++ b/tests/postgres/index.rs
@@ -116,19 +116,6 @@ fn create_8() {
 
 #[test]
 fn create_9() {
-    let stmt = [
-        r#"CREATE TABLE IF NOT EXISTS "character" ("#,
-        r#""id" serial NOT NULL PRIMARY KEY,"#,
-        r#""created_at" timestamp with time zone NOT NULL"#,
-        r#""font_size" integer NOT NULL,"#,
-        r#""character" varchar(255) NOT NULL,"#,
-        r#""size_w" integer NOT NULL,"#,
-        r#""size_h" integer NOT NULL,"#,
-        r#""font_id" integer DEFAULT NULL,"#,
-        r#")"#,
-    ]
-    .join(" ");
-    println!("{}", stmt);
     assert_eq!(
         Index::create()
             .name("idx-character-area")

--- a/tests/postgres/index.rs
+++ b/tests/postgres/index.rs
@@ -115,6 +115,48 @@ fn create_8() {
 }
 
 #[test]
+fn create_9() {
+    let stmt = [
+        r#"CREATE TABLE IF NOT EXISTS "character" ("#,
+        r#""id" serial NOT NULL PRIMARY KEY,"#,
+        r#""created_at" timestamp with time zone NOT NULL"#,
+        r#""font_size" integer NOT NULL,"#,
+        r#""character" varchar(255) NOT NULL,"#,
+        r#""size_w" integer NOT NULL,"#,
+        r#""size_h" integer NOT NULL,"#,
+        r#""font_id" integer DEFAULT NULL,"#,
+        r#")"#,
+    ]
+    .join(" ");
+    println!("{}", stmt);
+    assert_eq!(
+        Index::create()
+            .name("idx-character-area")
+            .table(Character::Table)
+            .col(Expr::col(Character::SizeH).mul(Expr::col(Character::SizeW)))
+            .to_string(PostgresQueryBuilder),
+        r#"CREATE INDEX "idx-character-area" ON "character" (("size_h" * "size_w"))"#
+    )
+}
+
+#[test]
+fn create_10() {
+    assert_eq!(
+        Index::create()
+            .name("idx-character-character-area-desc-created_at")
+            .table(Character::Table)
+            .col(Func::upper(Expr::col(Character::Character)))
+            .col((
+                Expr::col(Character::SizeH).mul(Expr::col(Character::SizeW)),
+                IndexOrder::Desc,
+            ))
+            .col(Character::CreatedAt)
+            .to_string(PostgresQueryBuilder),
+        r#"CREATE INDEX "idx-character-character-area-desc-created_at" ON "character" ((UPPER("character")), ("size_h" * "size_w") DESC, "created_at")"#
+    )
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Index::drop()

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -648,3 +648,47 @@ fn create_17() {
         .join(" ")
     );
 }
+
+#[test]
+fn create_18() {
+    assert_eq!(
+        Table::create()
+            .table(Char::Table)
+            .if_not_exists()
+            .col(
+                ColumnDef::new(Char::Id)
+                    .integer()
+                    .not_null()
+                    .primary_key()
+                    .auto_increment(),
+            )
+            .col(ColumnDef::new(Char::FontSize).integer().not_null())
+            .col(ColumnDef::new(Char::Character).string_len(255).not_null())
+            .col(ColumnDef::new(Char::SizeW).unsigned().not_null())
+            .col(ColumnDef::new(Char::SizeH).unsigned().not_null())
+            .col(
+                ColumnDef::new(Char::FontId)
+                    .integer()
+                    .default(Value::Int(None)),
+            )
+            .index(
+                Index::create()
+                    .name("idx-character-area")
+                    .table(Character::Table)
+                    .col(Expr::col(Character::SizeH).mul(Expr::col(Character::SizeW))),
+            )
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"CREATE TABLE IF NOT EXISTS "character" ("#,
+            r#""id" serial NOT NULL PRIMARY KEY,"#,
+            r#""font_size" integer NOT NULL,"#,
+            r#""character" varchar(255) NOT NULL,"#,
+            r#""size_w" integer NOT NULL,"#,
+            r#""size_h" integer NOT NULL,"#,
+            r#""font_id" integer DEFAULT NULL,"#,
+            r#"CONSTRAINT "idx-character-area" (("size_h" * "size_w"))"#,
+            r#")"#,
+        ]
+        .join(" "),
+    );
+}


### PR DESCRIPTION
## PR Info

- Closes #756 

## New Features

- [x] Support for creating functional indexes in PostgreSQL and MySQL

## Breaking Changes

- Change public Struct `index::common::IndexColumn` to Enum

## References

- PostgreSQL 17: <https://www.postgresql.org/docs/17/indexes-expressional.html>
- MySQL 8.4: <https://dev.mysql.com/doc/refman/8.4/en/create-index.html>

## Notes

I'm not entirely confident that this implementation is appropriate.
If you have any suggestions for a better implementation, I would greatly appreciate your feedback.