### PR TITLE
Remove redundant `Expr::expr` from docs and internal code

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ assert_eq!(CharacterIden::Foo.to_string(), "foo");
 
 ### Expression
 
-Use [`Expr`] to construct select, join, where and having expression in query.
+Use [`Expr`] constructors and [`ExprTrait`] methods
+to construct `SELECT`, `JOIN`, `WHERE` and `HAVING` expression in query.
 
 ```rust
 assert_eq!(
@@ -226,9 +227,10 @@ assert_eq!(
         .column(Char::Character)
         .from(Char::Table)
         .and_where(
-            Expr::expr(Expr::col(Char::SizeW).add(1))
+            Expr::col(Char::SizeW)
+                .add(1)
                 .mul(2)
-                .eq(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+                .eq(Expr::col(Char::SizeH).div(2).sub(1))
         )
         .and_where(
             Expr::col(Char::SizeW).in_subquery(

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -37,13 +37,17 @@ pub enum SimpleExpr {
     Constant(Value),
 }
 
-/// "Operator" methods for building complex expressions.
+/// "Operator" methods for building expressions.
 ///
-/// ## Examples
+/// Before `sea_query` 0.32.0 (`sea_orm` 1.1.1),
+/// these methods were awailable only on [`Expr`]/[`SimpleExpr`]
+/// and you needed to manually construct these types first.
+///
+/// Now, you can call them directly on any expression type:
 ///
 /// ```no_run
-/// use sea_query::*;
-///
+/// # use sea_query::*;
+/// #
 /// let expr = 1_i32.cast_as(Alias::new("REAL"));
 ///
 /// let expr = Func::char_length("abc").eq(3_i32);
@@ -1618,7 +1622,14 @@ impl Expr {
         Self::new_with_left(v)
     }
 
-    /// Wrap a [`SimpleExpr`] and perform some operation on it.
+    /// Wrap an expression to perform some operation on it later.
+    ///
+    /// Since `sea_query` 0.32.0 (`sea_orm` 1.1.1), **this is not necessary** in most cases!
+    ///
+    /// Some SQL operations used to be defined only as inherent methods on [`Expr`].
+    /// Thus, to use them, you needed to manually convert from other types to [`Expr`].
+    /// But now these operations are also defined as [`ExprTrait`] methods
+    /// that can be called directly on any expression type,
     ///
     /// # Examples
     ///
@@ -1628,8 +1639,12 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
+    ///     // This is the old style, when `Expr::expr` was necessary:
     ///     .and_where(Expr::expr(Expr::col(Char::SizeW).if_null(0)).gt(2))
     ///     .to_owned();
+    ///
+    /// // But since 0.32.0, this compiles too:
+    /// let _ = Expr::col(Char::SizeW).if_null(0).gt(2);
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
@@ -1651,8 +1666,12 @@ impl Expr {
     /// let query = Query::select()
     ///     .column(Char::Character)
     ///     .from(Char::Table)
+    ///     // This is the old style, when `Expr::expr` was necessary:
     ///     .and_where(Expr::expr(Func::lower(Expr::col(Char::Character))).is_in(["a", "b"]))
     ///     .to_owned();
+    ///
+    /// // But since 0.32.0, this compiles too:
+    /// let _ = Func::lower(Expr::col(Char::Character)).is_in(["a", "b"]);
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
@@ -2733,8 +2752,12 @@ impl Expr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
+    ///     // Before 0.32.0, you had call `not` on an `Expr`, which had to be constructed using `Expr::expr`:
     ///     .and_where(Expr::expr(Expr::col((Char::Table, Char::SizeW)).is_null()).not())
     ///     .to_owned();
+    ///
+    /// // But since 0.32.0, this compiles too:
+    /// let _ = Expr::col((Char::Table, Char::SizeW)).is_null().not();
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),

--- a/src/func.rs
+++ b/src/func.rs
@@ -644,7 +644,7 @@ impl Func {
     /// let query = Query::select()
     ///     .column(Font::Id)
     ///     .from(Font::Table)
-    ///     .and_where(Expr::expr(Func::lower(Expr::col(Font::Name))).eq("abc".trim().to_lowercase()))
+    ///     .and_where(Func::lower(Expr::col(Font::Name)).eq("abc".trim().to_lowercase()))
     ///     .take();
     ///
     /// assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,8 @@
 //!
 //! ### Expression
 //!
-//! Use [`Expr`] to construct select, join, where and having expression in query.
+//! Use [`Expr`] constructors and [`ExprTrait`] methods
+//! to construct `SELECT`, `JOIN`, `WHERE` and `HAVING` expression in query.
 //!
 //! ```rust
 //! # use sea_query::{*, tests_cfg::*};
@@ -238,9 +239,10 @@
 //!         .column(Char::Character)
 //!         .from(Char::Table)
 //!         .and_where(
-//!             Expr::expr(Expr::col(Char::SizeW).add(1))
+//!             Expr::col(Char::SizeW)
+//!                 .add(1)
 //!                 .mul(2)
-//!                 .eq(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+//!                 .eq(Expr::col(Char::SizeH).div(2).sub(1))
 //!         )
 //!         .and_where(
 //!             Expr::col(Char::SizeW).in_subquery(

--- a/src/query/ordered.rs
+++ b/src/query/ordered.rs
@@ -19,7 +19,7 @@ pub trait OrderedStatement {
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
     ///     .to_owned();

--- a/src/query/traits.rs
+++ b/src/query/traits.rs
@@ -38,7 +38,7 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
     ///     .to_string(MysqlQueryBuilder);
@@ -64,7 +64,7 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     /// let (query, params) = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
     ///     .build(MysqlQueryBuilder);
@@ -95,7 +95,7 @@ pub trait QueryStatementWriter: QueryStatementBuilder {
     /// let query = Query::select()
     ///     .column(Glyph::Aspect)
     ///     .from(Glyph::Table)
-    ///     .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+    ///     .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
     ///     .order_by(Glyph::Image, Order::Desc)
     ///     .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
     ///     .to_owned();

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -90,7 +90,7 @@ fn select_7() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .to_string(MysqlQueryBuilder),
         "SELECT `aspect` FROM `glyph` WHERE IFNULL(`aspect`, 0) > 2"
     );
@@ -150,7 +150,7 @@ fn select_11() {
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by(Glyph::Image, Order::Desc)
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
             .to_string(MysqlQueryBuilder),
@@ -166,7 +166,7 @@ fn select_12() {
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns([
                 (Glyph::Id, Order::Asc),
                 (Glyph::Aspect, Order::Desc),
@@ -184,7 +184,7 @@ fn select_13() {
                 Glyph::Aspect,
             ])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns([
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
@@ -383,9 +383,10 @@ fn select_26() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where(
-                Expr::expr(Expr::col(Char::SizeW).add(1))
+                Expr::col(Char::SizeW)
+                    .add(1)
                     .mul(2)
-                    .eq(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+                    .eq(Expr::col(Char::SizeH).div(2).sub(1))
             )
             .to_string(MysqlQueryBuilder),
         "SELECT `character` FROM `character` WHERE (`size_w` + 1) * 2 = (`size_h` / 2) - 1"
@@ -820,7 +821,7 @@ fn select_51() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_with_nulls(Glyph::Image, Order::Desc, NullOrdering::First)
             .order_by_with_nulls(
                 (Glyph::Table, Glyph::Aspect),
@@ -847,7 +848,7 @@ fn select_52() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns_with_nulls([
                 (Glyph::Id, Order::Asc, NullOrdering::First),
                 (Glyph::Aspect, Order::Desc, NullOrdering::Last),
@@ -872,7 +873,7 @@ fn select_53() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns_with_nulls([
                 ((Glyph::Table, Glyph::Id), Order::Asc, NullOrdering::First),
                 (
@@ -916,7 +917,7 @@ fn select_55() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by(
                 Glyph::Id,
                 Order::Field(Values(vec![4.into(), 5.into(), 1.into(), 3.into()]))
@@ -945,7 +946,7 @@ fn select_56() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
             .order_by(
                 Glyph::Id,

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -89,7 +89,7 @@ fn select_7() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .to_string(PostgresQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2"#
     );
@@ -152,7 +152,7 @@ fn select_11() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by(Glyph::Image, Order::Desc)
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
             .to_string(PostgresQueryBuilder),
@@ -166,7 +166,7 @@ fn select_12() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns([(Glyph::Id, Order::Asc), (Glyph::Aspect, Order::Desc)])
             .to_string(PostgresQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE COALESCE("aspect", 0) > 2 ORDER BY "id" ASC, "aspect" DESC"#
@@ -179,7 +179,7 @@ fn select_13() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns([
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
@@ -372,9 +372,10 @@ fn select_26() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where(
-                Expr::expr(Expr::col(Char::SizeW).add(1))
+                Expr::col(Char::SizeW)
+                    .add(1)
                     .mul(2)
-                    .eq(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+                    .eq(Expr::col(Char::SizeH).div(2).sub(1))
             )
             .to_string(PostgresQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#
@@ -804,7 +805,7 @@ fn select_51() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_with_nulls(Glyph::Image, Order::Desc, NullOrdering::First)
             .order_by_with_nulls(
                 (Glyph::Table, Glyph::Aspect),
@@ -829,7 +830,7 @@ fn select_52() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns_with_nulls([
                 (Glyph::Id, Order::Asc, NullOrdering::First),
                 (Glyph::Aspect, Order::Desc, NullOrdering::Last),
@@ -852,7 +853,7 @@ fn select_53() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns_with_nulls([
                 ((Glyph::Table, Glyph::Id), Order::Asc, NullOrdering::First),
                 (
@@ -880,7 +881,7 @@ fn select_54() {
             .distinct_on([Glyph::Aspect])
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns_with_nulls([
                 ((Glyph::Table, Glyph::Id), Order::Asc, NullOrdering::First),
                 (
@@ -922,7 +923,7 @@ fn select_56() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by(
                 Glyph::Id,
                 Order::Field(Values(vec![
@@ -956,7 +957,7 @@ fn select_57() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
             .order_by(
                 Glyph::Id,

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -89,7 +89,7 @@ fn select_7() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .to_string(SqliteQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE IFNULL("aspect", 0) > 2"#
     );
@@ -152,7 +152,7 @@ fn select_11() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by(Glyph::Image, Order::Desc)
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
             .to_string(SqliteQueryBuilder),
@@ -166,7 +166,7 @@ fn select_12() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns([(Glyph::Id, Order::Asc), (Glyph::Aspect, Order::Desc)])
             .to_string(SqliteQueryBuilder),
         r#"SELECT "aspect" FROM "glyph" WHERE IFNULL("aspect", 0) > 2 ORDER BY "id" ASC, "aspect" DESC"#
@@ -179,7 +179,7 @@ fn select_13() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns([
                 ((Glyph::Table, Glyph::Id), Order::Asc),
                 ((Glyph::Table, Glyph::Aspect), Order::Desc),
@@ -372,9 +372,10 @@ fn select_26() {
             .column(Char::Character)
             .from(Char::Table)
             .and_where(
-                Expr::expr(Expr::col(Char::SizeW).add(1))
+                Expr::col(Char::SizeW)
+                    .add(1)
                     .mul(2)
-                    .eq(Expr::expr(Expr::col(Char::SizeH).div(2)).sub(1))
+                    .eq(Expr::col(Char::SizeH).div(2).sub(1))
             )
             .to_string(SqliteQueryBuilder),
         r#"SELECT "character" FROM "character" WHERE ("size_w" + 1) * 2 = ("size_h" / 2) - 1"#
@@ -804,7 +805,7 @@ fn select_51() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_with_nulls(Glyph::Image, Order::Desc, NullOrdering::First)
             .order_by_with_nulls(
                 (Glyph::Table, Glyph::Aspect),
@@ -829,7 +830,7 @@ fn select_52() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns_with_nulls([
                 (Glyph::Id, Order::Asc, NullOrdering::First),
                 (Glyph::Aspect, Order::Desc, NullOrdering::Last),
@@ -852,7 +853,7 @@ fn select_53() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by_columns_with_nulls([
                 ((Glyph::Table, Glyph::Id), Order::Asc, NullOrdering::First),
                 (
@@ -894,7 +895,7 @@ fn select_55() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by(
                 Glyph::Id,
                 Order::Field(Values(vec![
@@ -928,7 +929,7 @@ fn select_56() {
         Query::select()
             .columns([Glyph::Aspect])
             .from(Glyph::Table)
-            .and_where(Expr::expr(Expr::col(Glyph::Aspect).if_null(0)).gt(2))
+            .and_where(Expr::col(Glyph::Aspect).if_null(0).gt(2))
             .order_by((Glyph::Table, Glyph::Aspect), Order::Asc)
             .order_by(
                 Glyph::Id,


### PR DESCRIPTION
## PR Info

- Closes: none
- Dependencies: none
- Dependents: none

## New Features

## Bug Fixes

## Breaking Changes

## Changes

(probably not changelog-worthy)

- Removed redundant `Expr::expr` calls from docs and internal code.
- Updated the wording in the relevant docs.

Explained in more defail there:

```md
Since `sea_query` 0.32.0 (`sea_orm` 1.1.1), **this is not necessary** in most cases!

Some SQL operations used to be defined only as inherent methods on [`Expr`].
Thus, to use them, you needed to manually convert from other types to [`Expr`].
But now these operations are also defined as [`ExprTrait`] methods
that can be called directly on any expression type,
```

The diff speaks for itself. Let's move the ecosystem towards the cleaner style!