### PR TITLE
Make `RcOrArc` a documented type alias instead of a direct reexport

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -7,10 +7,19 @@ use std::{fmt, mem, ops};
 use crate::extension::postgres::PgBinOper;
 #[cfg(feature = "backend-sqlite")]
 use crate::extension::sqlite::SqliteBinOper;
+
+/// A reference counted pointer: either [`Rc`][std::rc::Rc] or [`Arc`][std::sync::Arc],
+/// depending on the feature flags.
+///
+/// [`Arc`][std::sync::Arc] is used when `thread-safe` feature is activated.
 #[cfg(not(feature = "thread-safe"))]
-pub use std::rc::Rc as RcOrArc;
+pub type RcOrArc<T> = std::rc::Rc<T>;
+/// A reference counted pointer: either [`Rc`][std::rc::Rc] or [`Arc`][std::sync::Arc],
+/// depending on the feature flags.
+///
+/// [`Arc`][std::sync::Arc] is used when `thread-safe` feature is activated.
 #[cfg(feature = "thread-safe")]
-pub use std::sync::Arc as RcOrArc;
+pub type RcOrArc<T> = std::sync::Arc<T>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Quote(pub(crate) u8, pub(crate) u8);


### PR DESCRIPTION
## PR Info

- Closes: none
- Dependencies: none
- Dependents: none

## New Features

## Bug Fixes

## Breaking Changes

## Changes

(probably not changelog-worthy)

- Made `RcOrArc` a documented type alias instead of a direct reexport.

It [used to show](https://docs.rs/sea-query/0.32.3/sea_query/types/struct.RcOrArc.html) full documentation for `Rc`/`Arc`. I find it weird.

Now, it documents what `RcOrArc` actually is and how to control the representation.