### PR TITLE
Add support for temporary tables

### DIFF
--- a/src/backend/table_builder.rs
+++ b/src/backend/table_builder.rs
@@ -9,7 +9,11 @@ pub trait TableBuilder:
         create: &TableCreateStatement,
         sql: &mut dyn SqlWriter,
     ) {
-        write!(sql, "CREATE TABLE ").unwrap();
+        write!(sql, "CREATE ").unwrap();
+
+        self.prepare_create_temporary_table(create, sql);
+
+        write!(sql, "TABLE ").unwrap();
 
         self.prepare_create_table_if_not_exists(create, sql);
 
@@ -217,6 +221,17 @@ pub trait TableBuilder:
     ) {
         if create.if_not_exists {
             write!(sql, "IF NOT EXISTS ").unwrap();
+        }
+    }
+
+    /// Translate TEMPORARY expression in [`TableCreateStatement`].
+    fn prepare_create_temporary_table(
+        &self,
+        create: &TableCreateStatement,
+        sql: &mut dyn SqlWriter,
+    ) {
+        if create.temporary {
+            write!(sql, "TEMPORARY ").unwrap();
         }
     }
 

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -91,6 +91,7 @@ pub struct TableCreateStatement {
     pub(crate) check: Vec<SimpleExpr>,
     pub(crate) comment: Option<String>,
     pub(crate) extra: Option<String>,
+    pub(crate) temporary: bool,
 }
 
 /// All available table options
@@ -339,6 +340,12 @@ impl TableCreateStatement {
         self.extra.as_ref()
     }
 
+    /// Create temporary table
+    pub fn temporary(&mut self) -> &mut Self {
+        self.temporary = true;
+        self
+    }
+
     pub fn take(&mut self) -> Self {
         Self {
             table: self.table.take(),
@@ -351,6 +358,7 @@ impl TableCreateStatement {
             check: std::mem::take(&mut self.check),
             comment: std::mem::take(&mut self.comment),
             extra: std::mem::take(&mut self.extra),
+            temporary: self.temporary,
         }
     }
 }

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -243,6 +243,31 @@ fn create_10() {
 }
 
 #[test]
+fn create_11() {
+    assert_eq!(
+        Table::create()
+            .table(Font::Table)
+            .temporary()
+            .col(
+                ColumnDef::new(Font::Id)
+                    .integer()
+                    .not_null()
+                    .primary_key()
+                    .auto_increment()
+            )
+            .col(ColumnDef::new(Font::Name).string().not_null())
+            .to_string(MysqlQueryBuilder),
+        [
+            r#"CREATE TEMPORARY TABLE `font` ("#,
+            r#"`id` int NOT NULL PRIMARY KEY AUTO_INCREMENT,"#,
+            r#"`name` varchar(255) NOT NULL"#,
+            r#")"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Table::drop()

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -648,3 +648,28 @@ fn create_17() {
         .join(" ")
     );
 }
+
+#[test]
+fn create_18() {
+    assert_eq!(
+        Table::create()
+            .table(Font::Table)
+            .temporary()
+            .col(
+                ColumnDef::new(Font::Id)
+                    .integer()
+                    .not_null()
+                    .primary_key()
+                    .auto_increment()
+            )
+            .col(ColumnDef::new(Font::Name).string().not_null())
+            .to_string(PostgresQueryBuilder),
+        [
+            r#"CREATE TEMPORARY TABLE "font" ("#,
+            r#""id" serial NOT NULL PRIMARY KEY,"#,
+            r#""name" varchar NOT NULL"#,
+            r#")"#,
+        ]
+        .join(" ")
+    );
+}

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -185,6 +185,31 @@ fn create_7() {
 }
 
 #[test]
+fn create_8() {
+    assert_eq!(
+        Table::create()
+            .table(Font::Table)
+            .temporary()
+            .col(
+                ColumnDef::new(Font::Id)
+                    .integer()
+                    .not_null()
+                    .primary_key()
+                    .auto_increment()
+            )
+            .col(ColumnDef::new(Font::Name).string().not_null())
+            .to_string(SqliteQueryBuilder),
+        [
+            r#"CREATE TEMPORARY TABLE "font" ("#,
+            r#""id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,"#,
+            r#""name" varchar NOT NULL"#,
+            r#")"#,
+        ]
+        .join(" ")
+    );
+}
+
+#[test]
 fn create_with_unique_index() {
     assert_eq!(
         Table::create()


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes None

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - None

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - None

## New Features

- [x] Adds the ability to create temporary tables with `TableCreateStatement::temporary()`, which is available in all supported systems:
  - PostgreSQL: https://www.postgresql.org/docs/17/sql-createtable.html#SQL-CREATETABLE-TEMPORARY
  - MySQL: https://dev.mysql.com/doc/refman/9.2/en/create-temporary-table.html
  - MariaDB: https://mariadb.com/kb/en/create-table/#create-temporary-table
  - SQLite: https://sqlite.org/lang_createtable.html