### PR TITLE
Don't wrap strings in `Alias::new`

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ assert_eq!(
 
 ```rust
 let query = Query::select()
-    .expr(Func::cast_as("hello", Alias::new("MyType")))
+    .expr(Func::cast_as("hello", "MyType"))
     .to_owned();
 
 assert_eq!(
@@ -575,7 +575,7 @@ assert_eq!(
 let table = Table::alter()
     .table(Font::Table)
     .add_column(
-        ColumnDef::new(Alias::new("new_col"))
+        ColumnDef::new("new_col")
             .integer()
             .not_null()
             .default(100),
@@ -622,7 +622,7 @@ assert_eq!(
 
 ```rust
 let table = Table::rename()
-    .table(Font::Table, Alias::new("font_new"))
+    .table(Font::Table, "font_new")
     .to_owned();
 
 assert_eq!(

--- a/examples/diesel_mysql/src/main.rs
+++ b/examples/diesel_mysql/src/main.rs
@@ -197,7 +197,7 @@ fn main() {
 
     let query = Query::select()
         .from(Character::Table)
-        .expr_as(Func::count(Expr::col(Character::Id)), Alias::new("count"))
+        .expr_as(Func::count(Expr::col(Character::Id)), "count")
         .to_owned();
 
     print!("Count character: ");

--- a/examples/diesel_sqlite/src/main.rs
+++ b/examples/diesel_sqlite/src/main.rs
@@ -196,7 +196,7 @@ fn main() {
 
     let query = Query::select()
         .from(Character::Table)
-        .expr_as(Func::count(Expr::col(Character::Id)), Alias::new("count"))
+        .expr_as(Func::count(Expr::col(Character::Id)), "count")
         .to_owned();
 
     print!("Count character: ");

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -48,12 +48,12 @@ pub enum SimpleExpr {
 /// ```no_run
 /// # use sea_query::*;
 /// #
-/// let expr = 1_i32.cast_as(Alias::new("REAL"));
+/// let expr = 1_i32.cast_as("REAL");
 ///
 /// let expr = Func::char_length("abc").eq(3_i32);
 ///
 /// let expr = Expr::current_date()
-///     .cast_as(Alias::new("TEXT"))
+///     .cast_as("TEXT")
 ///     .like("2024%");
 /// ```
 pub trait ExprTrait: Sized {
@@ -100,7 +100,7 @@ pub trait ExprTrait: Sized {
     /// let query = Query::insert()
     ///     .into_table(Char::Table)
     ///     .columns([Char::FontSize])
-    ///     .values_panic(["large".as_enum(Alias::new("FontSizeEnum"))])
+    ///     .values_panic(["large".as_enum("FontSizeEnum")])
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -205,7 +205,7 @@ pub trait ExprTrait: Sized {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr("1".cast_as(Alias::new("integer")))
+    ///     .expr("1".cast_as("integer"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -3201,8 +3201,8 @@ impl Expr {
     /// use sea_query::{*, tests_cfg::*};
     ///
     /// let query = Query::select()
-    ///     .expr_as(Expr::exists(Query::select().column(Char::Id).from(Char::Table).take()), Alias::new("character_exists"))
-    ///     .expr_as(Expr::exists(Query::select().column(Glyph::Id).from(Glyph::Table).take()), Alias::new("glyph_exists"))
+    ///     .expr_as(Expr::exists(Query::select().column(Char::Id).from(Char::Table).take()), "character_exists")
+    ///     .expr_as(Expr::exists(Query::select().column(Glyph::Id).from(Glyph::Table).take()), "glyph_exists")
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -3305,7 +3305,7 @@ impl Expr {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Expr::col(Char::FontSize).as_enum(Alias::new("text")))
+    ///     .expr(Expr::col(Char::FontSize).as_enum("text"))
     ///     .from(Char::Table)
     ///     .to_owned();
     ///
@@ -3351,7 +3351,7 @@ impl Expr {
     /// let query = Query::insert()
     ///     .into_table(Char::Table)
     ///     .columns([Char::FontSize])
-    ///     .values_panic([Expr::val("large").as_enum(Alias::new("FontSizeEnum"))])
+    ///     .values_panic([Expr::val("large").as_enum("FontSizeEnum")])
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -3388,7 +3388,7 @@ impl Expr {
     ///                 true
     ///              )
     ///             .finally(false),
-    ///          Alias::new("is_even")
+    ///          "is_even"
     ///     )
     ///     .from(Glyph::Table)
     ///     .to_owned();
@@ -3416,7 +3416,7 @@ impl Expr {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Expr::val("1").cast_as(Alias::new("integer")))
+    ///     .expr(Expr::val("1").cast_as("integer"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -3519,7 +3519,7 @@ impl Expr {
     /// use sea_query::*;
     ///
     /// let query = Query::select()
-    ///     .expr(Expr::custom_keyword(Alias::new("test")))
+    ///     .expr(Expr::custom_keyword("test"))
     ///     .to_owned();
     ///
     /// assert_eq!(query.to_string(MysqlQueryBuilder), r#"SELECT test"#);
@@ -3923,7 +3923,7 @@ impl SimpleExpr {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Expr::value("1").cast_as(Alias::new("integer")))
+    ///     .expr(Expr::value("1").cast_as("integer"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -4004,7 +4004,7 @@ impl SimpleExpr {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     .and_where(Expr::col((Char::Table, Char::FontId)).cast_as(Alias::new("TEXT")).like("a%"))
+    ///     .and_where(Expr::col((Char::Table, Char::FontId)).cast_as("TEXT").like("a%"))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -52,9 +52,7 @@ pub enum SimpleExpr {
 ///
 /// let expr = Func::char_length("abc").eq(3_i32);
 ///
-/// let expr = Expr::current_date()
-///     .cast_as("TEXT")
-///     .like("2024%");
+/// let expr = Expr::current_date().cast_as("TEXT").like("2024%");
 /// ```
 pub trait ExprTrait: Sized {
     /// Express an arithmetic addition operation.
@@ -204,9 +202,7 @@ pub trait ExprTrait: Sized {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let query = Query::select()
-    ///     .expr("1".cast_as("integer"))
-    ///     .to_owned();
+    /// let query = Query::select().expr("1".cast_as("integer")).to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -348,7 +348,7 @@ impl TypeAlterStatement {
     /// assert_eq!(
     ///     Type::alter()
     ///         .name(FontFamily::Type)
-    ///         .add_value(Alias::new("cursive"))
+    ///         .add_value("cursive")
     ///         .to_string(PostgresQueryBuilder),
     ///     r#"ALTER TYPE "font_family" ADD VALUE 'cursive'"#
     /// );
@@ -380,7 +380,7 @@ impl TypeAlterStatement {
     /// assert_eq!(
     ///     Type::alter()
     ///         .name(Font::Table)
-    ///         .add_value(Alias::new("weight"))
+    ///         .add_value("weight")
     ///         .before(Font::Variant)
     ///         .to_string(PostgresQueryBuilder),
     ///     r#"ALTER TYPE "font" ADD VALUE 'weight' BEFORE 'variant'"#
@@ -414,7 +414,7 @@ impl TypeAlterStatement {
     /// assert_eq!(
     ///     Type::alter()
     ///         .name(Font::Table)
-    ///         .add_value(Alias::new("weight"))
+    ///         .add_value("weight")
     ///         .if_not_exists()
     ///         .after(Font::Variant)
     ///         .to_string(PostgresQueryBuilder),
@@ -443,7 +443,7 @@ impl TypeAlterStatement {
     /// assert_eq!(
     ///     Type::alter()
     ///         .name(Font::Table)
-    ///         .rename_value(Alias::new("variant"), Alias::new("language"))
+    ///         .rename_value("variant", "language")
     ///         .to_string(PostgresQueryBuilder),
     ///     r#"ALTER TYPE "font" RENAME VALUE 'variant' TO 'language'"#
     /// )

--- a/src/func.rs
+++ b/src/func.rs
@@ -510,7 +510,7 @@ impl Func {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Func::cast_as("hello", Alias::new("MyType")))
+    ///     .expr(Func::cast_as("hello", "MyType"))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -548,7 +548,7 @@ impl Func {
     /// let query = Query::select()
     ///     .expr(Func::cast_as_quoted(
     ///         "hello",
-    ///         Alias::new("MyType"),
+    ///         "MyType",
     ///         '"'.into(),
     ///     ))
     ///     .to_owned();

--- a/src/func.rs
+++ b/src/func.rs
@@ -546,11 +546,7 @@ impl Func {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Func::cast_as_quoted(
-    ///         "hello",
-    ///         "MyType",
-    ///         '"'.into(),
-    ///     ))
+    ///     .expr(Func::cast_as_quoted("hello", "MyType", '"'.into()))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,7 +479,7 @@
 //! ```rust
 //! # use sea_query::{*, tests_cfg::*};
 //! let query = Query::select()
-//!     .expr(Func::cast_as("hello", Alias::new("MyType")))
+//!     .expr(Func::cast_as("hello", "MyType"))
 //!     .to_owned();
 //!
 //! assert_eq!(
@@ -604,7 +604,7 @@
 //! let table = Table::alter()
 //!     .table(Font::Table)
 //!     .add_column(
-//!         ColumnDef::new(Alias::new("new_col"))
+//!         ColumnDef::new("new_col")
 //!             .integer()
 //!             .not_null()
 //!             .default(100),
@@ -653,7 +653,7 @@
 //! ```rust
 //! # use sea_query::{*, tests_cfg::*};
 //! let table = Table::rename()
-//!     .table(Font::Table, Alias::new("font_new"))
+//!     .table(Font::Table, "font_new")
 //!     .to_owned();
 //!
 //! assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,12 +603,7 @@
 //! # use sea_query::{*, tests_cfg::*};
 //! let table = Table::alter()
 //!     .table(Font::Table)
-//!     .add_column(
-//!         ColumnDef::new("new_col")
-//!             .integer()
-//!             .not_null()
-//!             .default(100),
-//!     )
+//!     .add_column(ColumnDef::new("new_col").integer().not_null().default(100))
 //!     .to_owned();
 //!
 //! assert_eq!(
@@ -652,9 +647,7 @@
 //!
 //! ```rust
 //! # use sea_query::{*, tests_cfg::*};
-//! let table = Table::rename()
-//!     .table(Font::Table, "font_new")
-//!     .to_owned();
+//! let table = Table::rename().table(Font::Table, "font_new").to_owned();
 //!
 //! assert_eq!(
 //!     table.to_string(MysqlQueryBuilder),

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -106,7 +106,7 @@ where
                         }
                     }
                 }
-                output.push(mark.to_string())
+                output.push(mark.clone())
             }
             _ => output.push(token.to_string()),
         }

--- a/src/query/case.rs
+++ b/src/query/case.rs
@@ -25,7 +25,7 @@ impl CaseStatement {
     ///         CaseStatement::new()
     ///             .case(Expr::col((Glyph::Table, Glyph::Aspect)).is_in([2, 4]), true)
     ///             .finally(false),
-    ///          Alias::new("is_even")
+    ///          "is_even"
     ///     )
     ///     .from(Glyph::Table)
     ///     .to_owned();
@@ -33,7 +33,7 @@ impl CaseStatement {
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
     ///     r#"SELECT (CASE WHEN ("glyph"."aspect" IN (2, 4)) THEN TRUE ELSE FALSE END) AS "is_even" FROM "glyph""#
-    /// );    
+    /// );
     /// ```
     pub fn new() -> Self {
         Self::default()
@@ -57,7 +57,7 @@ impl CaseStatement {
     ///                 "negative"
     ///              )
     ///             .finally("zero"),
-    ///          Alias::new("polarity")
+    ///          "polarity"
     ///     )
     ///     .from(Glyph::Table)
     ///     .to_owned();
@@ -65,7 +65,7 @@ impl CaseStatement {
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
     ///     r#"SELECT (CASE WHEN ("glyph"."aspect" > 0) THEN 'positive' WHEN ("glyph"."aspect" < 0) THEN 'negative' ELSE 'zero' END) AS "polarity" FROM "glyph""#
-    /// );    
+    /// );
     /// ```
     pub fn case<C, T>(mut self, cond: C, then: T) -> Self
     where
@@ -101,7 +101,7 @@ impl CaseStatement {
     ///             "medium"
     ///         )
     ///         .finally("small"),
-    ///         Alias::new("char_size"))
+    ///         "char_size")
     ///     .from(Character::Table)
     ///     .to_owned();
     ///
@@ -115,7 +115,7 @@ impl CaseStatement {
     ///         r#"FROM "character""#
     ///     ]
     ///     .join(" ")
-    /// );    
+    /// );
     /// ```
     pub fn finally<E>(mut self, r#else: E) -> Self
     where
@@ -140,16 +140,13 @@ mod test {
     #[test]
     #[cfg(feature = "backend-postgres")]
     fn test_where_case_eq() {
-        let case_statement: SimpleExpr = Expr::case(
-            Expr::col(Alias::new("col")).lt(5),
-            Expr::col(Alias::new("othercol")),
-        )
-        .finally(Expr::col(Alias::new("finalcol")))
-        .into();
+        let case_statement: SimpleExpr = Expr::case(Expr::col("col").lt(5), Expr::col("othercol"))
+            .finally(Expr::col("finalcol"))
+            .into();
 
         let result = Query::select()
             .column(Asterisk)
-            .from(Alias::new("tbl"))
+            .from("tbl")
             .and_where(case_statement.eq(10))
             .to_string(PostgresQueryBuilder);
         assert_eq!(

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -202,12 +202,12 @@ impl DeleteStatement {
     ///     let cte = CommonTableExpression::new()
     ///         .query(select)
     ///         .column(Glyph::Id)
-    ///         .table_name(Alias::new("cte"))
+    ///         .table_name("cte")
     ///         .to_owned();
     ///     let with_clause = WithClause::new().cte(cte).to_owned();
     ///     let update = DeleteStatement::new()
     ///         .from_table(Glyph::Table)
-    ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from(Alias::new("cte")).to_owned()))
+    ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from("cte").to_owned()))
     ///         .to_owned();
     ///     let query = update.with(with_clause);
     ///
@@ -243,13 +243,13 @@ impl DeleteStatement {
     ///     let cte = CommonTableExpression::new()
     ///         .query(select)
     ///         .column(Glyph::Id)
-    ///         .table_name(Alias::new("cte"))
+    ///         .table_name("cte")
     ///         .to_owned();
     ///     let with_clause = WithClause::new().cte(cte).to_owned();
     ///     let query = DeleteStatement::new()
     ///         .with_cte(with_clause)
     ///         .from_table(Glyph::Table)
-    ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from(Alias::new("cte")).to_owned()))
+    ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from("cte").to_owned()))
     ///         .to_owned();
     ///
     /// assert_eq!(

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -200,7 +200,7 @@ impl InsertStatement {
     ///     .columns([Glyph::Aspect, Glyph::Image])
     ///     .values([
     ///         2.into(),
-    ///         Func::cast_as("2020-02-02 00:00:00", Alias::new("DATE")).into(),
+    ///         Func::cast_as("2020-02-02 00:00:00", "DATE").into(),
     ///     ])
     ///     .unwrap()
     ///     .to_owned();
@@ -442,12 +442,12 @@ impl InsertStatement {
     ///         .column(Glyph::Id)
     ///         .column(Glyph::Image)
     ///         .column(Glyph::Aspect)
-    ///         .table_name(Alias::new("cte"))
+    ///         .table_name("cte")
     ///         .to_owned();
     ///     let with_clause = WithClause::new().cte(cte).to_owned();
     ///     let select = SelectStatement::new()
     ///         .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
-    ///         .from(Alias::new("cte"))
+    ///         .from("cte")
     ///         .to_owned();
     ///     let mut insert = Query::insert();
     ///     insert
@@ -490,12 +490,12 @@ impl InsertStatement {
     ///         .column(Glyph::Id)
     ///         .column(Glyph::Image)
     ///         .column(Glyph::Aspect)
-    ///         .table_name(Alias::new("cte"))
+    ///         .table_name("cte")
     ///         .to_owned();
     ///     let with_clause = WithClause::new().cte(cte).to_owned();
     ///     let select = SelectStatement::new()
     ///         .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
-    ///         .from(Alias::new("cte"))
+    ///         .from("cte")
     ///         .to_owned();
     ///     let mut query = Query::insert();
     ///     query

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -724,10 +724,7 @@ impl SelectStatement {
     /// let query = Query::select()
     ///     .from(Char::Table)
     ///     .expr_window_name(Expr::col(Char::Character), "w")
-    ///     .window(
-    ///         "w",
-    ///         WindowStatement::partition_by(Char::FontSize),
-    ///     )
+    ///     .window("w", WindowStatement::partition_by(Char::FontSize))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -508,7 +508,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .column((Alias::new("schema"), Char::Table, Char::Character))
+    ///     .column(("schema", Char::Table, Char::Character))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -603,7 +603,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .expr_as(Expr::col(Char::Character), Alias::new("C"))
+    ///     .expr_as(Expr::col(Char::Character), "C")
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -684,7 +684,7 @@ impl SelectStatement {
     ///     .expr_window_as(
     ///         Expr::col(Char::Character),
     ///         WindowStatement::partition_by(Char::FontSize),
-    ///         Alias::new("C"),
+    ///         "C",
     ///     )
     ///     .to_owned();
     ///
@@ -723,9 +723,9 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .expr_window_name(Expr::col(Char::Character), Alias::new("w"))
+    ///     .expr_window_name(Expr::col(Char::Character), "w")
     ///     .window(
-    ///         Alias::new("w"),
+    ///         "w",
     ///         WindowStatement::partition_by(Char::FontSize),
     ///     )
     ///     .to_owned();
@@ -765,8 +765,8 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .expr_window_name_as(Expr::col(Char::Character), Alias::new("w"), Alias::new("C"))
-    ///     .window(Alias::new("w"), WindowStatement::partition_by(Char::FontSize))
+    ///     .expr_window_name_as(Expr::col(Char::Character), "w", "C")
+    ///     .window("w", WindowStatement::partition_by(Char::FontSize))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -849,7 +849,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .column(Char::FontSize)
-    ///     .from((Alias::new("database"), Char::Table, Glyph::Table))
+    ///     .from(("database", Char::Table, Glyph::Table))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -907,7 +907,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .expr(Expr::asterisk())
-    ///     .from_values([(1, "hello"), (2, "world")], Alias::new("x"))
+    ///     .from_values([(1, "hello"), (2, "world")], "x")
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -944,7 +944,7 @@ impl SelectStatement {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let table_as: DynIden = SeaRc::new(Alias::new("char"));
+    /// let table_as: DynIden = SeaRc::new("char");
     ///
     /// let query = Query::select()
     ///     .from_as(Char::Table, table_as.clone())
@@ -968,7 +968,7 @@ impl SelectStatement {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let table_as = Alias::new("alias");
+    /// let table_as = "alias";
     ///
     /// let query = Query::select()
     ///     .from_as((Font::Table, Char::Table), table_as.clone())
@@ -1010,7 +1010,7 @@ impl SelectStatement {
     ///             .columns([Glyph::Image, Glyph::Aspect])
     ///             .from(Glyph::Table)
     ///             .take(),
-    ///         Alias::new("subglyph"),
+    ///         "subglyph",
     ///     )
     ///     .to_owned();
     ///
@@ -1043,7 +1043,7 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .column(ColumnRef::Asterisk)
-    ///     .from_function(Func::random(), Alias::new("func"))
+    ///     .from_function(Func::random(), "func")
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -1490,7 +1490,7 @@ impl SelectStatement {
     ///     .join_as(
     ///         JoinType::RightJoin,
     ///         Font::Table,
-    ///         Alias::new("f"),
+    ///         "f",
     ///         Expr::col((Char::Table, Char::FontId)).equals((Font::Table, Font::Id))
     ///     )
     ///     .to_owned();
@@ -1517,7 +1517,7 @@ impl SelectStatement {
     ///         .join_as(
     ///             JoinType::RightJoin,
     ///             Font::Table,
-    ///             Alias::new("f"),
+    ///             "f",
     ///             Condition::all()
     ///                 .add(Expr::col((Char::Table, Char::FontId)).equals((Font::Table, Font::Id)))
     ///                 .add(Expr::col((Char::Table, Char::FontId)).equals((Font::Table, Font::Id)))
@@ -1555,7 +1555,7 @@ impl SelectStatement {
     /// ```
     /// use sea_query::{*, tests_cfg::*};
     ///
-    /// let sub_glyph: DynIden = SeaRc::new(Alias::new("sub_glyph"));
+    /// let sub_glyph: DynIden = SeaRc::new("sub_glyph");
     /// let query = Query::select()
     ///     .column(Font::Name)
     ///     .from(Font::Table)
@@ -1625,7 +1625,7 @@ impl SelectStatement {
     /// ```
     /// use sea_query::{*, tests_cfg::*};
     ///
-    /// let sub_glyph: DynIden = SeaRc::new(Alias::new("sub_glyph"));
+    /// let sub_glyph: DynIden = SeaRc::new("sub_glyph");
     /// let query = Query::select()
     ///     .column(Font::Name)
     ///     .from(Font::Table)
@@ -2294,23 +2294,23 @@ impl SelectStatement {
     /// use sea_query::{*, IntoCondition, IntoIden, tests_cfg::*};
     ///
     /// let base_query = SelectStatement::new()
-    ///                     .column(Alias::new("id"))
+    ///                     .column("id")
     ///                     .expr(1i32)
-    ///                     .column(Alias::new("next"))
-    ///                     .column(Alias::new("value"))
-    ///                     .from(Alias::new("table"))
+    ///                     .column("next")
+    ///                     .column("value")
+    ///                     .from("table")
     ///                     .to_owned();
     ///
     /// let cte_referencing = SelectStatement::new()
-    ///                             .column(Alias::new("id"))
-    ///                             .expr(Expr::col(Alias::new("depth")).add(1i32))
-    ///                             .column(Alias::new("next"))
-    ///                             .column(Alias::new("value"))
-    ///                             .from(Alias::new("table"))
+    ///                             .column("id")
+    ///                             .expr(Expr::col("depth").add(1i32))
+    ///                             .column("next")
+    ///                             .column("value")
+    ///                             .from("table")
     ///                             .join(
     ///                                 JoinType::InnerJoin,
-    ///                                 Alias::new("cte_traversal"),
-    ///                                 Expr::col((Alias::new("cte_traversal"), Alias::new("next"))).equals((Alias::new("table"), Alias::new("id")))
+    ///                                 "cte_traversal",
+    ///                                 Expr::col(("cte_traversal", "next")).equals(("table", "id"))
     ///                             )
     ///                             .to_owned();
     ///
@@ -2318,19 +2318,19 @@ impl SelectStatement {
     ///             .query(
     ///                 base_query.clone().union(UnionType::All, cte_referencing).to_owned()
     ///             )
-    ///             .columns([Alias::new("id"), Alias::new("depth"), Alias::new("next"), Alias::new("value")])
-    ///             .table_name(Alias::new("cte_traversal"))
+    ///             .columns(["id", "depth", "next", "value"])
+    ///             .table_name("cte_traversal")
     ///             .to_owned();
     ///
     /// let select = SelectStatement::new()
     ///         .column(ColumnRef::Asterisk)
-    ///         .from(Alias::new("cte_traversal"))
+    ///         .from("cte_traversal")
     ///         .to_owned();
     ///
     /// let with_clause = WithClause::new()
     ///         .recursive(true)
     ///         .cte(common_table_expression)
-    ///         .cycle(Cycle::new_from_expr_set_using(SimpleExpr::Column(ColumnRef::Column(Alias::new("id").into_iden())), Alias::new("looped"), Alias::new("traversal_path")))
+    ///         .cycle(Cycle::new_from_expr_set_using(SimpleExpr::Column(ColumnRef::Column("id".into_iden())), "looped", "traversal_path"))
     ///         .to_owned();
     ///
     /// let query = select.with(with_clause).to_owned();
@@ -2360,23 +2360,23 @@ impl SelectStatement {
     /// use sea_query::{*, IntoCondition, IntoIden, tests_cfg::*};
     ///
     /// let base_query = SelectStatement::new()
-    ///                     .column(Alias::new("id"))
+    ///                     .column("id")
     ///                     .expr(1i32)
-    ///                     .column(Alias::new("next"))
-    ///                     .column(Alias::new("value"))
-    ///                     .from(Alias::new("table"))
+    ///                     .column("next")
+    ///                     .column("value")
+    ///                     .from("table")
     ///                     .to_owned();
     ///
     /// let cte_referencing = SelectStatement::new()
-    ///                             .column(Alias::new("id"))
-    ///                             .expr(Expr::col(Alias::new("depth")).add(1i32))
-    ///                             .column(Alias::new("next"))
-    ///                             .column(Alias::new("value"))
-    ///                             .from(Alias::new("table"))
+    ///                             .column("id")
+    ///                             .expr(Expr::col("depth").add(1i32))
+    ///                             .column("next")
+    ///                             .column("value")
+    ///                             .from("table")
     ///                             .join(
     ///                                 JoinType::InnerJoin,
-    ///                                 Alias::new("cte_traversal"),
-    ///                                 Expr::col((Alias::new("cte_traversal"), Alias::new("next"))).equals((Alias::new("table"), Alias::new("id")))
+    ///                                 "cte_traversal",
+    ///                                 Expr::col(("cte_traversal", "next")).equals(("table", "id"))
     ///                             )
     ///                             .to_owned();
     ///
@@ -2384,19 +2384,19 @@ impl SelectStatement {
     ///             .query(
     ///                 base_query.clone().union(UnionType::All, cte_referencing).to_owned()
     ///             )
-    ///             .columns([Alias::new("id"), Alias::new("depth"), Alias::new("next"), Alias::new("value")])
-    ///             .table_name(Alias::new("cte_traversal"))
+    ///             .columns(["id", "depth", "next", "value"])
+    ///             .table_name("cte_traversal")
     ///             .to_owned();
     ///
     /// let with_clause = WithClause::new()
     ///         .recursive(true)
     ///         .cte(common_table_expression)
-    ///         .cycle(Cycle::new_from_expr_set_using(SimpleExpr::Column(ColumnRef::Column(Alias::new("id").into_iden())), Alias::new("looped"), Alias::new("traversal_path")))
+    ///         .cycle(Cycle::new_from_expr_set_using(SimpleExpr::Column(ColumnRef::Column("id".into_iden())), "looped", "traversal_path"))
     ///         .to_owned();
     ///
     /// let query = SelectStatement::new()
     ///         .column(ColumnRef::Asterisk)
-    ///         .from(Alias::new("cte_traversal"))
+    ///         .from("cte_traversal")
     ///         .with_cte(with_clause)
     ///         .to_owned();
     ///
@@ -2427,8 +2427,8 @@ impl SelectStatement {
     ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .expr_window_name_as(Expr::col(Char::Character), Alias::new("w"), Alias::new("C"))
-    ///     .window(Alias::new("w"), WindowStatement::partition_by(Char::FontSize))
+    ///     .expr_window_name_as(Expr::col(Char::Character), "w", "C")
+    ///     .window("w", WindowStatement::partition_by(Char::FontSize))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -331,12 +331,12 @@ impl UpdateStatement {
     ///     let cte = CommonTableExpression::new()
     ///         .query(select)
     ///         .column(Glyph::Id)
-    ///         .table_name(Alias::new("cte"))
+    ///         .table_name("cte")
     ///         .to_owned();
     ///     let with_clause = WithClause::new().cte(cte).to_owned();
     ///     let update = UpdateStatement::new()
     ///         .table(Glyph::Table)
-    ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from(Alias::new("cte")).to_owned()))
+    ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from("cte").to_owned()))
     ///         .value(Glyph::Aspect, Expr::cust("60 * 24 * 24"))
     ///         .to_owned();
     ///     let query = update.with(with_clause);
@@ -373,12 +373,12 @@ impl UpdateStatement {
     ///     let cte = CommonTableExpression::new()
     ///         .query(select)
     ///         .column(Glyph::Id)
-    ///         .table_name(Alias::new("cte"))
+    ///         .table_name("cte")
     ///         .to_owned();
     ///     let with_clause = WithClause::new().cte(cte).to_owned();
     ///     let query = UpdateStatement::new()
     ///         .table(Glyph::Table)
-    ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from(Alias::new("cte")).to_owned()))
+    ///         .and_where(Expr::col(Glyph::Id).in_subquery(SelectStatement::new().column(Glyph::Id).from("cte").to_owned()))
     ///         .value(Glyph::Aspect, Expr::cust("60 * 24 * 24"))
     ///         .with_cte(with_clause)
     ///         .to_owned();

--- a/src/query/window.rs
+++ b/src/query/window.rs
@@ -125,7 +125,7 @@ impl WindowStatement {
     ///         WindowStatement::partition_by(Char::FontSize)
     ///             .frame_start(FrameType::Rows, Frame::UnboundedPreceding)
     ///             .take(),
-    ///         Alias::new("C"))
+    ///         "C")
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -159,7 +159,7 @@ impl WindowStatement {
     ///         WindowStatement::partition_by(Char::FontSize)
     ///             .frame_between(FrameType::Rows, Frame::UnboundedPreceding, Frame::UnboundedFollowing)
     ///             .take(),
-    ///         Alias::new("C"))
+    ///         "C")
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -132,7 +132,7 @@ impl CommonTableExpression {
     }
 
     fn set_table_name_from_select(&mut self, iden: &DynIden) {
-        self.table_name = Some(Alias::new(format!("cte_{}", iden.to_string())).into_iden())
+        self.table_name = Some(format!("cte_{}", iden.to_string()).into_iden())
     }
 
     /// Set up the columns of the CTE to match the given [SelectStatement] selected columns.
@@ -155,8 +155,7 @@ impl CommonTableExpression {
                         SimpleExpr::Column(column) => match column {
                             ColumnRef::Column(iden) => Some(iden.clone()),
                             ColumnRef::TableColumn(table, column) => Some(
-                                Alias::new(format!("{}_{}", table.to_string(), column.to_string()))
-                                    .into_iden(),
+                                format!("{}_{}", table.to_string(), column.to_string()).into_iden(),
                             ),
                             ColumnRef::SchemaTableColumn(schema, table, column) => Some(
                                 Alias::new(format!(
@@ -369,23 +368,23 @@ impl Cycle {
 /// use sea_query::{*, IntoCondition, IntoIden, tests_cfg::*};
 ///
 /// let base_query = SelectStatement::new()
-///                     .column(Alias::new("id"))
+///                     .column("id")
 ///                     .expr(1i32)
-///                     .column(Alias::new("next"))
-///                     .column(Alias::new("value"))
-///                     .from(Alias::new("table"))
+///                     .column("next")
+///                     .column("value")
+///                     .from("table")
 ///                     .to_owned();
 ///
 /// let cte_referencing = SelectStatement::new()
-///                             .column(Alias::new("id"))
-///                             .expr(Expr::col(Alias::new("depth")).add(1i32))
-///                             .column(Alias::new("next"))
-///                             .column(Alias::new("value"))
-///                             .from(Alias::new("table"))
+///                             .column("id")
+///                             .expr(Expr::col("depth").add(1i32))
+///                             .column("next")
+///                             .column("value")
+///                             .from("table")
 ///                             .join(
 ///                                 JoinType::InnerJoin,
-///                                 Alias::new("cte_traversal"),
-///                                 Expr::col((Alias::new("cte_traversal"), Alias::new("next"))).equals((Alias::new("table"), Alias::new("id")))
+///                                 "cte_traversal",
+///                                 Expr::col(("cte_traversal", "next")).equals(("table", "id"))
 ///                             )
 ///                             .to_owned();
 ///
@@ -393,22 +392,22 @@ impl Cycle {
 ///             .query(
 ///                 base_query.clone().union(UnionType::All, cte_referencing).to_owned()
 ///             )
-///             .column(Alias::new("id"))
-///             .column(Alias::new("depth"))
-///             .column(Alias::new("next"))
-///             .column(Alias::new("value"))
-///             .table_name(Alias::new("cte_traversal"))
+///             .column("id")
+///             .column("depth")
+///             .column("next")
+///             .column("value")
+///             .table_name("cte_traversal")
 ///             .to_owned();
 ///
 /// let select = SelectStatement::new()
 ///         .column(ColumnRef::Asterisk)
-///         .from(Alias::new("cte_traversal"))
+///         .from("cte_traversal")
 ///         .to_owned();
 ///
 /// let with_clause = WithClause::new()
 ///         .recursive(true)
 ///         .cte(common_table_expression)
-///         .cycle(Cycle::new_from_expr_set_using(SimpleExpr::Column(ColumnRef::Column(Alias::new("id").into_iden())), Alias::new("looped"), Alias::new("traversal_path")))
+///         .cycle(Cycle::new_from_expr_set_using(SimpleExpr::Column(ColumnRef::Column("id".into_iden())), "looped", "traversal_path"))
 ///         .to_owned();
 ///
 /// let query = select.with(with_clause).to_owned();

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -132,7 +132,7 @@ impl CommonTableExpression {
     }
 
     fn set_table_name_from_select(&mut self, iden: &DynIden) {
-        self.table_name = Some(format!("cte_{}", iden.to_string()).into_iden())
+        self.table_name = Some(Alias::new(format!("cte_{}", iden.to_string())).into_iden())
     }
 
     /// Set up the columns of the CTE to match the given [SelectStatement] selected columns.
@@ -155,7 +155,8 @@ impl CommonTableExpression {
                         SimpleExpr::Column(column) => match column {
                             ColumnRef::Column(iden) => Some(iden.clone()),
                             ColumnRef::TableColumn(table, column) => Some(
-                                format!("{}_{}", table.to_string(), column.to_string()).into_iden(),
+                                Alias::new(format!("{}_{}", table.to_string(), column.to_string()))
+                                    .into_iden(),
                             ),
                             ColumnRef::SchemaTableColumn(schema, table, column) => Some(
                                 Alias::new(format!(

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -13,12 +13,7 @@ use inherent::inherent;
 ///
 /// let table = Table::alter()
 ///     .table(Font::Table)
-///     .add_column(
-///         ColumnDef::new("new_col")
-///             .integer()
-///             .not_null()
-///             .default(100),
-///     )
+///     .add_column(ColumnDef::new("new_col").integer().not_null().default(100))
 ///     .to_owned();
 ///
 /// assert_eq!(
@@ -82,12 +77,7 @@ impl TableAlterStatement {
     ///
     /// let table = Table::alter()
     ///     .table(Font::Table)
-    ///     .add_column(
-    ///         ColumnDef::new("new_col")
-    ///             .integer()
-    ///             .not_null()
-    ///             .default(100),
-    ///     )
+    ///     .add_column(ColumnDef::new("new_col").integer().not_null().default(100))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -121,12 +111,7 @@ impl TableAlterStatement {
     ///
     /// let table = Table::alter()
     ///     .table(Font::Table)
-    ///     .add_column_if_not_exists(
-    ///         ColumnDef::new("new_col")
-    ///             .integer()
-    ///             .not_null()
-    ///             .default(100),
-    ///     )
+    ///     .add_column_if_not_exists(ColumnDef::new("new_col").integer().not_null().default(100))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -160,11 +145,7 @@ impl TableAlterStatement {
     ///
     /// let table = Table::alter()
     ///     .table(Font::Table)
-    ///     .modify_column(
-    ///         ColumnDef::new("new_col")
-    ///             .big_integer()
-    ///             .default(999),
-    ///     )
+    ///     .modify_column(ColumnDef::new("new_col").big_integer().default(999))
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -14,7 +14,7 @@ use inherent::inherent;
 /// let table = Table::alter()
 ///     .table(Font::Table)
 ///     .add_column(
-///         ColumnDef::new(Alias::new("new_col"))
+///         ColumnDef::new("new_col")
 ///             .integer()
 ///             .not_null()
 ///             .default(100),
@@ -83,7 +83,7 @@ impl TableAlterStatement {
     /// let table = Table::alter()
     ///     .table(Font::Table)
     ///     .add_column(
-    ///         ColumnDef::new(Alias::new("new_col"))
+    ///         ColumnDef::new("new_col")
     ///             .integer()
     ///             .not_null()
     ///             .default(100),
@@ -122,7 +122,7 @@ impl TableAlterStatement {
     /// let table = Table::alter()
     ///     .table(Font::Table)
     ///     .add_column_if_not_exists(
-    ///         ColumnDef::new(Alias::new("new_col"))
+    ///         ColumnDef::new("new_col")
     ///             .integer()
     ///             .not_null()
     ///             .default(100),
@@ -161,7 +161,7 @@ impl TableAlterStatement {
     /// let table = Table::alter()
     ///     .table(Font::Table)
     ///     .modify_column(
-    ///         ColumnDef::new(Alias::new("new_col"))
+    ///         ColumnDef::new("new_col")
     ///             .big_integer()
     ///             .default(999),
     ///     )
@@ -195,7 +195,7 @@ impl TableAlterStatement {
     ///
     /// let table = Table::alter()
     ///     .table(Font::Table)
-    ///     .rename_column(Alias::new("new_col"), Alias::new("new_column"))
+    ///     .rename_column("new_col", "new_column")
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -231,7 +231,7 @@ impl TableAlterStatement {
     ///
     /// let table = Table::alter()
     ///     .table(Font::Table)
-    ///     .drop_column(Alias::new("new_column"))
+    ///     .drop_column("new_column")
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -332,8 +332,8 @@ impl TableAlterStatement {
     ///
     /// let table = Table::alter()
     ///     .table(Character::Table)
-    ///     .drop_foreign_key(Alias::new("FK_character_glyph"))
-    ///     .drop_foreign_key(Alias::new("FK_character_font"))
+    ///     .drop_foreign_key("FK_character_glyph")
+    ///     .drop_foreign_key("FK_character_font")
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -461,22 +461,22 @@ impl ColumnDef {
     ///     Table::create()
     ///         .table(Glyph::Table)
     ///         .col(
-    ///             ColumnDef::new(Alias::new("I1"))
+    ///             ColumnDef::new("I1")
     ///                 .interval(None, None)
     ///                 .not_null()
     ///         )
     ///         .col(
-    ///             ColumnDef::new(Alias::new("I2"))
+    ///             ColumnDef::new("I2")
     ///                 .interval(Some(PgInterval::YearToMonth), None)
     ///                 .not_null()
     ///         )
     ///         .col(
-    ///             ColumnDef::new(Alias::new("I3"))
+    ///             ColumnDef::new("I3")
     ///                 .interval(None, Some(42))
     ///                 .not_null()
     ///         )
     ///         .col(
-    ///             ColumnDef::new(Alias::new("I4"))
+    ///             ColumnDef::new("I4")
     ///                 .interval(Some(PgInterval::Hour), Some(43))
     ///                 .not_null()
     ///         )
@@ -771,7 +771,7 @@ impl ColumnDef {
     ///     .modify_column(
     ///         ColumnDef::new(Char::Id)
     ///             .integer()
-    ///             .using(Expr::col(Char::Id).cast_as(Alias::new("integer"))),
+    ///             .using(Expr::col(Char::Id).cast_as("integer")),
     ///     )
     ///     .to_owned();
     /// assert_eq!(

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -460,21 +460,13 @@ impl ColumnDef {
     /// assert_eq!(
     ///     Table::create()
     ///         .table(Glyph::Table)
-    ///         .col(
-    ///             ColumnDef::new("I1")
-    ///                 .interval(None, None)
-    ///                 .not_null()
-    ///         )
+    ///         .col(ColumnDef::new("I1").interval(None, None).not_null())
     ///         .col(
     ///             ColumnDef::new("I2")
     ///                 .interval(Some(PgInterval::YearToMonth), None)
     ///                 .not_null()
     ///         )
-    ///         .col(
-    ///             ColumnDef::new("I3")
-    ///                 .interval(None, Some(42))
-    ///                 .not_null()
-    ///         )
+    ///         .col(ColumnDef::new("I3").interval(None, Some(42)).not_null())
     ///         .col(
     ///             ColumnDef::new("I4")
     ///                 .interval(Some(PgInterval::Hour), Some(43))

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -9,9 +9,7 @@ use crate::{backend::SchemaBuilder, types::*, SchemaStatementBuilder};
 /// ```
 /// use sea_query::{tests_cfg::*, *};
 ///
-/// let table = Table::rename()
-///     .table(Font::Table, "font_new")
-///     .to_owned();
+/// let table = Table::rename().table(Font::Table, "font_new").to_owned();
 ///
 /// assert_eq!(
 ///     table.to_string(MysqlQueryBuilder),

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -10,7 +10,7 @@ use crate::{backend::SchemaBuilder, types::*, SchemaStatementBuilder};
 /// use sea_query::{tests_cfg::*, *};
 ///
 /// let table = Table::rename()
-///     .table(Font::Table, Alias::new("font_new"))
+///     .table(Font::Table, "font_new")
 ///     .to_owned();
 ///
 /// assert_eq!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,12 +38,23 @@ macro_rules! iden_trait {
                 self.to_string().replace(qq, qq.repeat(2).as_str())
             }
 
+            /// A shortcut for writing an [`unquoted`][Iden::unquoted]
+            /// identifier into a [`String`].
+            ///
+            /// We can't reuse [`ToString`] for this, because [`ToString`] uses
+            /// the [`Display`][std::fmt::Display] representation. Bnd [`Iden`]
+            /// representation is distinct from [`Display`][std::fmt::Display]
+            /// and can be different.
             fn to_string(&self) -> String {
                 let mut s = String::new();
                 self.unquoted(&mut s);
                 s
             }
 
+            /// Write a raw identifier string without quotes.
+            ///
+            /// We indentionally don't reuse [`Display`][std::fmt::Display] for
+            /// this, because we want to allow it to have a different logic.
             fn unquoted(&self, s: &mut dyn fmt::Write);
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -253,9 +253,9 @@ pub enum Order {
     Field(Values),
 }
 
-/// An explicit wrapper for [`Iden`]s which are user-provided strings.
+/// An explicit wrapper for [`Iden`]s which are dynamic user-provided strings.
 ///
-/// Nowadays, strings implement [`Iden`] and can be used directly.
+/// Nowadays, `&str` implements [`Iden`] and can be used directly.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Alias(String);
 
@@ -566,10 +566,10 @@ impl Alias {
     }
 }
 
-// TODO: in the next major version, just `impl Iden for T where T: AsRef<str>`.
-// Perhaps, also delete the `Alias` type, which is just a string.
+// Regaring potential `impl for String` and the need for `Alias`,
+// see discussions on https://github.com/SeaQL/sea-query/pull/882
 
-/// Reuses the `impl` for the underlying [String].
+/// Reuses the `impl` for the underlying [str].
 impl Iden for Alias {
     fn unquoted(&self, s: &mut dyn fmt::Write) {
         self.0.as_str().unquoted(s);
@@ -582,22 +582,6 @@ impl Iden for Alias {
 impl Iden for &str {
     fn unquoted(&self, s: &mut dyn fmt::Write) {
         s.write_str(self).unwrap();
-    }
-}
-
-/// Provided for backwards-compatible ergonomics,
-/// the implementation is the same as for `&str`.
-impl Iden for &String {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
-        self.as_str().unquoted(s);
-    }
-}
-
-/// Provided for backwards-compatible ergonomics,
-/// the implementation is the same as for `&str`.
-impl Iden for String {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
-        self.as_str().unquoted(s);
     }
 }
 

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -51,7 +51,7 @@ fn select_4() {
                     .columns([Glyph::Image, Glyph::Aspect])
                     .from(Glyph::Table)
                     .take(),
-                Alias::new("subglyph")
+                "subglyph"
             )
             .to_string(MysqlQueryBuilder),
         "SELECT `image` FROM (SELECT `image`, `aspect` FROM `glyph`) AS `subglyph`"
@@ -459,7 +459,7 @@ fn select_31() {
 fn select_32() {
     assert_eq!(
         Query::select()
-            .expr_as(Expr::col(Char::Character), Alias::new("C"))
+            .expr_as(Expr::col(Char::Character), "C")
             .from(Char::Table)
             .to_string(MysqlQueryBuilder),
         "SELECT `character` AS `C` FROM `character`"
@@ -976,7 +976,7 @@ fn select_57() {
                 .case(Expr::col((Glyph::Table, Glyph::Aspect)).gt(0), "positive")
                 .case(Expr::col((Glyph::Table, Glyph::Aspect)).lt(0), "negative")
                 .finally("zero"),
-            Alias::new("polarity"),
+            "polarity",
         )
         .from(Glyph::Table)
         .to_owned();

--- a/tests/mysql/table.rs
+++ b/tests/mysql/table.rs
@@ -233,10 +233,7 @@ fn create_10() {
     assert_eq!(
         Table::create()
             .table(Glyph::Table)
-            .col(ColumnDef::new(Glyph::Id).enumeration(
-                Alias::new("tea"),
-                [Alias::new("EverydayTea"), Alias::new("BreakfastTea")]
-            ),)
+            .col(ColumnDef::new(Glyph::Id).enumeration("tea", ["EverydayTea", "BreakfastTea"]),)
             .to_string(MysqlQueryBuilder),
         "CREATE TABLE `glyph` ( `id` ENUM('EverydayTea', 'BreakfastTea') )"
     );
@@ -294,12 +291,7 @@ fn alter_1() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .add_column(
-                ColumnDef::new(Alias::new("new_col"))
-                    .integer()
-                    .not_null()
-                    .default(100)
-            )
+            .add_column(ColumnDef::new("new_col").integer().not_null().default(100))
             .to_string(MysqlQueryBuilder),
         "ALTER TABLE `font` ADD COLUMN `new_col` int NOT NULL DEFAULT 100"
     );
@@ -310,11 +302,7 @@ fn alter_2() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .modify_column(
-                ColumnDef::new(Alias::new("new_col"))
-                    .big_integer()
-                    .default(999)
-            )
+            .modify_column(ColumnDef::new("new_col").big_integer().default(999))
             .to_string(MysqlQueryBuilder),
         "ALTER TABLE `font` MODIFY COLUMN `new_col` bigint DEFAULT 999"
     );
@@ -325,7 +313,7 @@ fn alter_3() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .rename_column(Alias::new("new_col"), Alias::new("new_column"))
+            .rename_column("new_col", "new_column")
             .to_string(MysqlQueryBuilder),
         "ALTER TABLE `font` RENAME COLUMN `new_col` TO `new_column`"
     );
@@ -336,7 +324,7 @@ fn alter_4() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .drop_column(Alias::new("new_column"))
+            .drop_column("new_column")
             .to_string(MysqlQueryBuilder),
         "ALTER TABLE `font` DROP COLUMN `new_column`"
     );
@@ -346,7 +334,7 @@ fn alter_4() {
 fn alter_5() {
     assert_eq!(
         Table::rename()
-            .table(Font::Table, Alias::new("font_new"))
+            .table(Font::Table, "font_new")
             .to_string(MysqlQueryBuilder),
         "RENAME TABLE `font` TO `font_new`"
     );
@@ -363,8 +351,8 @@ fn alter_7() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .drop_column(Alias::new("new_column"))
-            .rename_column(Font::Name, Alias::new("name_new"))
+            .drop_column("new_column")
+            .rename_column(Font::Name, "name_new")
             .to_string(MysqlQueryBuilder),
         "ALTER TABLE `font` DROP COLUMN `new_column`, RENAME COLUMN `name` TO `name_new`"
     );

--- a/tests/postgres/foreign_key.rs
+++ b/tests/postgres/foreign_key.rs
@@ -25,7 +25,7 @@ fn create_2() {
     assert_eq!(
         ForeignKey::create()
             .name("FK_2e303c3a712662f1fc2a4d0aad6")
-            .from((Alias::new("schema"), Char::Table), Char::FontId)
+            .from(("schema", Char::Table), Char::FontId)
             .to(Font::Table, Font::Id)
             .on_delete(ForeignKeyAction::Cascade)
             .on_update(ForeignKeyAction::Cascade)
@@ -55,7 +55,7 @@ fn drop_2() {
     assert_eq!(
         ForeignKey::drop()
             .name("FK_2e303c3a712662f1fc2a4d0aad6")
-            .table((Alias::new("schema"), Char::Table))
+            .table(("schema", Char::Table))
             .to_string(PostgresQueryBuilder),
         r#"ALTER TABLE "schema"."character" DROP CONSTRAINT "FK_2e303c3a712662f1fc2a4d0aad6""#
     );

--- a/tests/postgres/index.rs
+++ b/tests/postgres/index.rs
@@ -60,7 +60,7 @@ fn create_5() {
         Index::create()
             .unique()
             .name("idx-glyph-aspect-image")
-            .table((Alias::new("schema"), Glyph::Table))
+            .table(("schema", Glyph::Table))
             .col(Glyph::Aspect)
             .col(Glyph::Image)
             .to_string(PostgresQueryBuilder),
@@ -129,7 +129,7 @@ fn drop_2() {
     assert_eq!(
         Index::drop()
             .name("idx-glyph-aspect")
-            .table((Alias::new("schema"), Glyph::Table))
+            .table(("schema", Glyph::Table))
             .to_string(PostgresQueryBuilder),
         r#"DROP INDEX "schema"."idx-glyph-aspect""#
     );
@@ -151,6 +151,6 @@ fn drop_3() {
 fn drop_4() {
     Index::drop()
         .name("idx-glyph-aspect")
-        .table((Alias::new("database"), Alias::new("schema"), Glyph::Table))
+        .table(("database", "schema", Glyph::Table))
         .to_string(PostgresQueryBuilder);
 }

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -50,7 +50,7 @@ fn select_4() {
                     .columns([Glyph::Image, Glyph::Aspect])
                     .from(Glyph::Table)
                     .take(),
-                Alias::new("subglyph")
+                "subglyph"
             )
             .to_string(PostgresQueryBuilder),
         r#"SELECT "aspect" FROM (SELECT "image", "aspect" FROM "glyph") AS "subglyph""#
@@ -443,7 +443,7 @@ fn select_31() {
 fn select_32() {
     assert_eq!(
         Query::select()
-            .expr_as(Expr::col(Char::Character), Alias::new("C"))
+            .expr_as(Expr::col(Char::Character), "C")
             .from(Char::Table)
             .to_string(PostgresQueryBuilder),
         r#"SELECT "character" AS "C" FROM "character""#
@@ -992,12 +992,12 @@ fn select_58() {
         .to_owned();
     let cte = CommonTableExpression::new()
         .query(select)
-        .table_name(Alias::new("cte"))
+        .table_name("cte")
         .to_owned();
     let with_clause = WithClause::new().cte(cte).to_owned();
     let select = SelectStatement::new()
         .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
-        .from(Alias::new("cte"))
+        .from("cte")
         .to_owned();
     assert_eq!(
         select.with(with_clause).to_string(PostgresQueryBuilder),
@@ -1019,7 +1019,7 @@ fn select_59() {
                 .case(Expr::col((Glyph::Table, Glyph::Aspect)).gt(0), "positive")
                 .case(Expr::col((Glyph::Table, Glyph::Aspect)).lt(0), "negative")
                 .finally("zero"),
-            Alias::new("polarity"),
+            "polarity",
         )
         .from(Glyph::Table)
         .to_owned();
@@ -1070,16 +1070,16 @@ fn select_61() {
 fn select_62() {
     let select = SelectStatement::new()
         .column(Asterisk)
-        .from_values([(1i32, "hello"), (2, "world")], Alias::new("x"))
+        .from_values([(1i32, "hello"), (2, "world")], "x")
         .to_owned();
     let cte = CommonTableExpression::new()
         .query(select)
-        .table_name(Alias::new("cte"))
+        .table_name("cte")
         .to_owned();
     let with_clause = WithClause::new().cte(cte).to_owned();
     let select = SelectStatement::new()
-        .columns([Alias::new("column1"), Alias::new("column2")])
-        .from(Alias::new("cte"))
+        .columns(["column1", "column2"])
+        .from("cte")
         .to_owned();
     assert_eq!(
         select.with(with_clause).to_string(PostgresQueryBuilder),
@@ -1101,11 +1101,11 @@ fn select_63() {
         .to_owned();
     let cte = CommonTableExpression::new()
         .query(select)
-        .table_name(Alias::new("cte"))
+        .table_name("cte")
         .to_owned();
     let select = SelectStatement::new()
         .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
-        .from(Alias::new("cte"))
+        .from("cte")
         .with_cte(cte)
         .to_owned();
     assert_eq!(
@@ -1236,12 +1236,12 @@ fn insert_6() -> error::Result<()> {
         .column(Glyph::Id)
         .column(Glyph::Image)
         .column(Glyph::Aspect)
-        .table_name(Alias::new("cte"))
+        .table_name("cte")
         .to_owned();
     let with_clause = WithClause::new().cte(cte).to_owned();
     let select = SelectStatement::new()
         .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
-        .from(Alias::new("cte"))
+        .from("cte")
         .to_owned();
     let mut insert = Query::insert();
     insert
@@ -1328,11 +1328,11 @@ fn insert_11() -> error::Result<()> {
         .column(Glyph::Id)
         .column(Glyph::Image)
         .column(Glyph::Aspect)
-        .table_name(Alias::new("cte"))
+        .table_name("cte")
         .to_owned();
     let select = SelectStatement::new()
         .columns([Glyph::Id, Glyph::Image, Glyph::Aspect])
-        .from(Alias::new("cte"))
+        .from("cte")
         .to_owned();
     let mut insert = Query::insert();
     insert

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -295,7 +295,7 @@ fn create_13() {
 fn create_14() {
     assert_eq!(
         Table::create()
-            .table((Alias::new("schema"), Glyph::Table))
+            .table(("schema", Glyph::Table))
             .col(ColumnDef::new(Glyph::Image).custom(Glyph::Aspect))
             .to_string(PostgresQueryBuilder),
         [
@@ -351,8 +351,8 @@ fn drop_1() {
 fn drop_2() {
     assert_eq!(
         Table::drop()
-            .table((Alias::new("schema1"), Glyph::Table))
-            .table((Alias::new("schema2"), Char::Table))
+            .table(("schema1", Glyph::Table))
+            .table(("schema2", Char::Table))
             .cascade()
             .to_string(PostgresQueryBuilder),
         r#"DROP TABLE "schema1"."glyph", "schema2"."character" CASCADE"#
@@ -373,7 +373,7 @@ fn truncate_1() {
 fn truncate_2() {
     assert_eq!(
         Table::truncate()
-            .table((Alias::new("schema"), Font::Table))
+            .table(("schema", Font::Table))
             .to_string(PostgresQueryBuilder),
         r#"TRUNCATE TABLE "schema"."font""#
     );
@@ -384,12 +384,7 @@ fn alter_1() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .add_column(
-                ColumnDef::new(Alias::new("new_col"))
-                    .integer()
-                    .not_null()
-                    .default(100)
-            )
+            .add_column(ColumnDef::new("new_col").integer().not_null().default(100))
             .to_string(PostgresQueryBuilder),
         r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 100"#
     );
@@ -400,11 +395,7 @@ fn alter_2() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .modify_column(
-                ColumnDef::new(Alias::new("new_col"))
-                    .big_integer()
-                    .default(999)
-            )
+            .modify_column(ColumnDef::new("new_col").big_integer().default(999))
             .to_string(PostgresQueryBuilder),
         [
             r#"ALTER TABLE "font""#,
@@ -420,7 +411,7 @@ fn alter_3() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .rename_column(Alias::new("new_col"), Alias::new("new_column"))
+            .rename_column("new_col", "new_column")
             .to_string(PostgresQueryBuilder),
         r#"ALTER TABLE "font" RENAME COLUMN "new_col" TO "new_column""#
     );
@@ -431,7 +422,7 @@ fn alter_4() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .drop_column(Alias::new("new_column"))
+            .drop_column("new_column")
             .to_string(PostgresQueryBuilder),
         r#"ALTER TABLE "font" DROP COLUMN "new_column""#
     );
@@ -441,8 +432,8 @@ fn alter_4() {
 fn alter_5() {
     assert_eq!(
         Table::alter()
-            .table((Alias::new("schema"), Font::Table))
-            .rename_column(Alias::new("new_col"), Alias::new("new_column"))
+            .table(("schema", Font::Table))
+            .rename_column("new_col", "new_column")
             .to_string(PostgresQueryBuilder),
         r#"ALTER TABLE "schema"."font" RENAME COLUMN "new_col" TO "new_column""#
     );
@@ -459,8 +450,8 @@ fn alter_7() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .add_column(ColumnDef::new(Alias::new("new_col")).integer())
-            .rename_column(Font::Name, Alias::new("name_new"))
+            .add_column(ColumnDef::new("new_col").integer())
+            .rename_column(Font::Name, "name_new")
             .to_string(PostgresQueryBuilder),
         r#"ALTER TABLE "font" ADD COLUMN "new_col" integer, RENAME COLUMN "name" TO "name_new""#
     );
@@ -534,7 +525,7 @@ fn alter_10() {
 fn rename_1() {
     assert_eq!(
         Table::rename()
-            .table(Font::Table, Alias::new("font_new"))
+            .table(Font::Table, "font_new")
             .to_string(PostgresQueryBuilder),
         r#"ALTER TABLE "font" RENAME TO "font_new""#
     );
@@ -544,10 +535,7 @@ fn rename_1() {
 fn rename_2() {
     assert_eq!(
         Table::rename()
-            .table(
-                (Alias::new("schema"), Font::Table),
-                (Alias::new("schema"), Alias::new("font_new")),
-            )
+            .table(("schema", Font::Table), ("schema", "font_new"),)
             .to_string(PostgresQueryBuilder),
         r#"ALTER TABLE "schema"."font" RENAME TO "schema"."font_new""#
     );

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -1,6 +1,6 @@
 use super::*;
 use pretty_assertions::assert_eq;
-use sea_query::{extension::postgres::Type, Alias, PostgresQueryBuilder};
+use sea_query::{extension::postgres::Type, PostgresQueryBuilder};
 
 #[test]
 fn create_1() {
@@ -17,7 +17,7 @@ fn create_1() {
 fn create_2() {
     assert_eq!(
         Type::create()
-            .as_enum((Alias::new("schema"), Font::Table))
+            .as_enum(("schema", Font::Table))
             .values([Font::Name, Font::Variant, Font::Language])
             .to_string(PostgresQueryBuilder),
         r#"CREATE TYPE "schema"."font" AS ENUM ('name', 'variant', 'language')"#
@@ -94,7 +94,7 @@ fn drop_3() {
 fn drop_4() {
     assert_eq!(
         Type::drop()
-            .name((Alias::new("schema"), Font::Table))
+            .name(("schema", Font::Table))
             .to_string(PostgresQueryBuilder),
         r#"DROP TYPE "schema"."font""#
     );
@@ -105,7 +105,7 @@ fn alter_1() {
     assert_eq!(
         Type::alter()
             .name(Font::Table)
-            .add_value(Alias::new("weight"))
+            .add_value("weight")
             .to_string(PostgresQueryBuilder),
         r#"ALTER TYPE "font" ADD VALUE 'weight'"#
     )
@@ -115,7 +115,7 @@ fn alter_2() {
     assert_eq!(
         Type::alter()
             .name(Font::Table)
-            .add_value(Alias::new("weight"))
+            .add_value("weight")
             .before(Font::Variant)
             .to_string(PostgresQueryBuilder),
         r#"ALTER TYPE "font" ADD VALUE 'weight' BEFORE 'variant'"#
@@ -127,7 +127,7 @@ fn alter_3() {
     assert_eq!(
         Type::alter()
             .name(Font::Table)
-            .add_value(Alias::new("weight"))
+            .add_value("weight")
             .after(Font::Variant)
             .to_string(PostgresQueryBuilder),
         r#"ALTER TYPE "font" ADD VALUE 'weight' AFTER 'variant'"#
@@ -139,7 +139,7 @@ fn alter_4() {
     assert_eq!(
         Type::alter()
             .name(Font::Table)
-            .rename_to(Alias::new("typeface"))
+            .rename_to("typeface")
             .to_string(PostgresQueryBuilder),
         r#"ALTER TYPE "font" RENAME TO 'typeface'"#
     )
@@ -160,8 +160,8 @@ fn alter_5() {
 fn alter_6() {
     assert_eq!(
         Type::alter()
-            .name((Alias::new("schema"), Font::Table))
-            .rename_to(Alias::new("typeface"))
+            .name(("schema", Font::Table))
+            .rename_to("typeface")
             .to_string(PostgresQueryBuilder),
         r#"ALTER TYPE "schema"."font" RENAME TO 'typeface'"#
     )

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -50,7 +50,7 @@ fn select_4() {
                     .columns([Glyph::Image, Glyph::Aspect])
                     .from(Glyph::Table)
                     .take(),
-                Alias::new("subglyph")
+                "subglyph"
             )
             .to_string(SqliteQueryBuilder),
         r#"SELECT "image" FROM (SELECT "image", "aspect" FROM "glyph") AS "subglyph""#
@@ -443,7 +443,7 @@ fn select_31() {
 fn select_32() {
     assert_eq!(
         Query::select()
-            .expr_as(Expr::col(Char::Character), Alias::new("C"))
+            .expr_as(Expr::col(Char::Character), "C")
             .from(Char::Table)
             .to_string(SqliteQueryBuilder),
         r#"SELECT "character" AS "C" FROM "character""#
@@ -964,7 +964,7 @@ fn select_57() {
                 .case(Expr::col((Glyph::Table, Glyph::Aspect)).gt(0), "positive")
                 .case(Expr::col((Glyph::Table, Glyph::Aspect)).lt(0), "negative")
                 .finally("zero"),
-            Alias::new("polarity"),
+            "polarity",
         )
         .from(Glyph::Table)
         .to_owned();
@@ -1800,19 +1800,19 @@ fn recursive_with_multiple_ctes() {
         .column(Asterisk)
         .from(Char::Table)
         .to_owned();
-    let sub_select1_name = SeaRc::new(Alias::new("sub1"));
+    let sub_select1_name = SeaRc::new("sub1");
     let mut sub_select1_cte = CommonTableExpression::new();
     sub_select1_cte.table_name(sub_select1_name.clone());
-    sub_select1_cte.column(SeaRc::new(Alias::new("a")));
+    sub_select1_cte.column(SeaRc::new("a"));
     sub_select1_cte.query(sub_select1);
     let sub_select2 = Query::select()
         .column(Asterisk)
         .from(Char::Table)
         .to_owned();
-    let sub_select2_name = SeaRc::new(Alias::new("sub2"));
+    let sub_select2_name = SeaRc::new("sub2");
     let mut sub_select2_cte = CommonTableExpression::new();
     sub_select2_cte.table_name(sub_select2_name.clone());
-    sub_select2_cte.column(SeaRc::new(Alias::new("b")));
+    sub_select2_cte.column(SeaRc::new("b"));
     sub_select2_cte.query(sub_select2);
 
     let mut with = WithClause::new();

--- a/tests/sqlite/table.rs
+++ b/tests/sqlite/table.rs
@@ -382,12 +382,7 @@ fn alter_1() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .add_column(
-                ColumnDef::new(Alias::new("new_col"))
-                    .integer()
-                    .not_null()
-                    .default(99)
-            )
+            .add_column(ColumnDef::new("new_col").integer().not_null().default(99))
             .to_string(SqliteQueryBuilder),
         r#"ALTER TABLE "font" ADD COLUMN "new_col" integer NOT NULL DEFAULT 99"#
     );
@@ -398,7 +393,7 @@ fn alter_1() {
 fn alter_2() {
     Table::alter()
         .table(Font::Table)
-        .modify_column(ColumnDef::new(Alias::new("new_col")).double())
+        .modify_column(ColumnDef::new("new_col").double())
         .to_string(SqliteQueryBuilder);
 }
 
@@ -407,7 +402,7 @@ fn alter_3() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .rename_column(Alias::new("new_col"), Alias::new("new_column"))
+            .rename_column("new_col", "new_column")
             .to_string(SqliteQueryBuilder),
         r#"ALTER TABLE "font" RENAME COLUMN "new_col" TO "new_column""#
     );
@@ -418,7 +413,7 @@ fn alter_4() {
     assert_eq!(
         Table::alter()
             .table(Font::Table)
-            .drop_column(Alias::new("new_column"))
+            .drop_column("new_column")
             .to_string(SqliteQueryBuilder),
         r#"ALTER TABLE "font" DROP COLUMN "new_column""#
     );
@@ -428,7 +423,7 @@ fn alter_4() {
 fn alter_5() {
     assert_eq!(
         Table::rename()
-            .table(Font::Table, Alias::new("font_new"))
+            .table(Font::Table, "font_new")
             .to_string(SqliteQueryBuilder),
         r#"ALTER TABLE "font" RENAME TO "font_new""#
     );
@@ -445,9 +440,9 @@ fn alter_6() {
 fn alter_7() {
     let _ = Table::alter()
         .table(Font::Table)
-        .add_column(ColumnDef::new(Alias::new("new_col")).integer())
-        .rename_column(Font::Name, Alias::new("name_new"))
-        .drop_column(Alias::new("name_new"))
+        .add_column(ColumnDef::new("new_col").integer())
+        .rename_column(Font::Name, "name_new")
+        .drop_column("name_new")
         .to_string(SqliteQueryBuilder);
 }
 


### PR DESCRIPTION
## PR Info

- Closes: none
- Dependencies: none
- Dependents: none

## New Features

## Bug Fixes

## Breaking Changes

## Changes

(EDIT: outdated, see the up-to-date changelog in the comments below)

- Implemented `Iden` for `&str`, `&String` and `String`. Now you don't need to wrap strings into `Alias::new` where `T: IntoIden` is needed.

This was so noisy! Really drove me insane to hand-write every time. Just look at the diff that I was able to achieve.

Most of the diff is an automaned find-and-replace in VSCode (`Alias::new\(([^)]+)\)` -> `$1`, ignoring the changelog). Other than that, there are only two files with interesting changes:

- In `src/types.rs`, I implemented `Iden` for `&str`, `&String` and `String`. That's the actual change that causes strings to implicitly implement `IntoIden` and be accepted in methods that need `T: IntoIden`.

- This caused a type inference regression, because now these types have multiple `to_string` methods from multiple traits. I replaced the now-ambiguous `to_string` call in `src/prepare.rs`.

### Compatibility

The type inference issue is technically a breaking change, but it's commonly excluded from semver guarantees and doesn't require a major version bump. To quote [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks/issues/5):

>  implementing an existing pub trait for an existing type
> - breaking because the trait's methods or associated types on that type may be ambiguous relative to those from traits implemented for that type in another crate (Rust for Rustaceans, chapter 3, pg. 52, "Trait Implementations")
> - inference breakage like this doesn't require a semver major bump, so this should be a warning, not an error

My mid-sized project (and the latest SeaORM 1.1.10 that it uses) compile fine with these changes.

There shouldn't be any other breaking changes.

`cargo semver-checks --release-type patch --baseline-rev master --all-features` doesn't report anything.

## Discussion: future breaking changes

Actually, I'd prefer a general blanket `impl Iden for T where T: AsRef<str>`. I think, it makes a lot of sense. Most `Iden` impls that I see in `sea_query` just `match Self -> &'static str` and then `write!` it. `impl AsRef<str>` could handle getting the right `&str`, and then the blanket `impl Iden for T where T: AsRef<str>` takes care of the common `s.write_str(self.as_ref()).unwrap()`. But this requires a new major version, so I just left a `TODO` in the code until then.

I'm kinda suspicious of `Iden::unquoted` that looks like `Display::fmt`, and `Iden::to_string` that obviously duplicates `ToString::to_string` (which is exactly what we would get by requiring `Iden: Display`!). But I'm not sure whether the `unquoted` string is semantically the same as `Display` and whether it could be replaced by it. Consider documenting this!

Also, I don't see the point of having an `Alias` newtype, instead of using strings directly. This area has very few docs and doesn't explain why `Alias` is necessary. So far, I'd like to just delete `Alias` in the next major version.

And it would be nice to hear something about https://github.com/SeaQL/sea-orm/discussions/2327. These `Into*` traits are very annoying and don't document why they're necessary.