### PR TITLE
Conversions from `Condition` and `ConditionExpression` into `SimpleExpr`

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1389,7 +1389,7 @@ pub trait QueryBuilder:
     #[doc(hidden)]
     /// Translate part of a condition to part of a "WHERE" clause.
     fn prepare_condition_where(&self, condition: &Condition, sql: &mut dyn SqlWriter) {
-        let simple_expr = condition.to_simple_expr();
+        let simple_expr = condition.clone().into();
         self.prepare_simple_expr(&simple_expr, sql);
     }
 


### PR DESCRIPTION
Yet another type conversion problem that drove me insane.

Motivating examples:

- I needed `Func::coalesce([my_condition.into(), false.into()])`. But `coalesce` accepts `SimpleExpr`s and there's no public way to convert `my_condition` into `SimpleExpr`! Not a single public workaround. Which is crazy, because it's obviously already implemented (privately).

- I needed `.expr_as(any![..], "my_alias")`. But `expr_as` accepts `Into<SimpleExpr>` and `any!` is a `Condition` that didn't implement that. This one's less urgent, because there's an `.or()` chain workaround.

The first one is useful/urgent enough that I'm going to use [`[patch.crates-io]`](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section) and immediately depend on this fork in my project.

If you look at the diff, the new conversion method may seem less efficient than the old one, because the conversion now consumes the `Condition` and there's a new `.clone()` call because of that. However, nothing has actually changed. The old non-consuming function was doing the same `clone()`ing inside of its body, and I removed that call.

## PR Info

- Closes: none
- Dependencies: none
- Dependents: none

## New Features

- `impl From<Condition> for SimpleExpr`
- `impl From<ConditionExpression> for SimpleExpr`

## Bug Fixes

## Breaking Changes

## Changes