### PR TITLE
Unify `Expr` and `SimpleExpr` as one type

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1401,17 +1401,8 @@ where
 }
 
 impl SimpleExpr {
-    fn new(e: impl Into<Self>) -> Self {
-        e.into()
-    }
-
-    // TODO: since
-    #[deprecated(note = "Please use the [`SimpleExpr::new`] method")]
-    fn new_with_left<T>(left: T) -> Self
-    where
-        T: Into<Self>,
-    {
-        left.into()
+    pub fn new(expr: impl Into<Self>) -> Self {
+        expr.into()
     }
 
     #[deprecated(since = "0.29.0", note = "Please use the [`Asterisk`]")]
@@ -1606,7 +1597,7 @@ impl SimpleExpr {
     where
         V: Into<Value>,
     {
-        Self::new(v)
+        Self::from(v)
     }
 
     /// Wrap an expression to perform some operation on it later.
@@ -1679,7 +1670,7 @@ impl SimpleExpr {
     where
         T: Into<Self>,
     {
-        Self::new(expr)
+        expr.into()
     }
 
     /// Express a [`Value`], returning a [`SimpleExpr`].

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1747,7 +1747,7 @@ impl SimpleExpr {
     where
         T: Into<String>,
     {
-        SimpleExpr::Custom(s.into())
+        Self::Custom(s.into())
     }
 
     /// Express any custom expression with [`Value`]. Use this if your expression needs variables.
@@ -1826,7 +1826,7 @@ impl SimpleExpr {
         V: Into<Value>,
         I: IntoIterator<Item = V>,
     {
-        SimpleExpr::CustomWithExpr(
+        Self::CustomWithExpr(
             s.into(),
             v.into_iter()
                 .map(|v| Into::<Value>::into(v).into())
@@ -1873,7 +1873,7 @@ impl SimpleExpr {
         T: Into<String>,
         E: Into<Self>,
     {
-        SimpleExpr::CustomWithExpr(s.into(), vec![expr.into()])
+        Self::CustomWithExpr(s.into(), vec![expr.into()])
     }
 
     /// Express any custom expression with [`SimpleExpr`]. Use this if your expression needs other expressions.
@@ -1882,7 +1882,7 @@ impl SimpleExpr {
         T: Into<String>,
         I: IntoIterator<Item = SimpleExpr>,
     {
-        SimpleExpr::CustomWithExpr(s.into(), v.into_iter().collect())
+        Self::CustomWithExpr(s.into(), v.into_iter().collect())
     }
 
     /// Express a equal expression between two table columns,
@@ -2853,7 +2853,7 @@ impl SimpleExpr {
     /// );
     /// ```
     pub fn exists(sel: SelectStatement) -> Self {
-        SimpleExpr::SubQuery(
+        Self::SubQuery(
             Some(SubQueryOper::Exists),
             Box::new(sel.into_sub_query_statement()),
         )
@@ -2884,7 +2884,7 @@ impl SimpleExpr {
     /// );
     /// ```
     pub fn any(sel: SelectStatement) -> Self {
-        SimpleExpr::SubQuery(
+        Self::SubQuery(
             Some(SubQueryOper::Any),
             Box::new(sel.into_sub_query_statement()),
         )
@@ -2915,7 +2915,7 @@ impl SimpleExpr {
     /// );
     /// ```
     pub fn some(sel: SelectStatement) -> Self {
-        SimpleExpr::SubQuery(
+        Self::SubQuery(
             Some(SubQueryOper::Some),
             Box::new(sel.into_sub_query_statement()),
         )
@@ -2923,7 +2923,7 @@ impl SimpleExpr {
 
     /// Express a `ALL` sub-query expression.
     pub fn all(sel: SelectStatement) -> Self {
-        SimpleExpr::SubQuery(
+        Self::SubQuery(
             Some(SubQueryOper::All),
             Box::new(sel.into_sub_query_statement()),
         )
@@ -3139,32 +3139,32 @@ where
     T: Into<Value>,
 {
     fn from(v: T) -> Self {
-        SimpleExpr::Value(v.into())
+        Self::Value(v.into())
     }
 }
 
 impl From<FunctionCall> for SimpleExpr {
     fn from(func: FunctionCall) -> Self {
-        SimpleExpr::FunctionCall(func)
+        Self::FunctionCall(func)
     }
 }
 
 impl From<ColumnRef> for SimpleExpr {
     fn from(col: ColumnRef) -> Self {
-        SimpleExpr::Column(col)
+        Self::Column(col)
     }
 }
 
 impl From<Keyword> for SimpleExpr {
     fn from(k: Keyword) -> Self {
-        SimpleExpr::Keyword(k)
+        Self::Keyword(k)
     }
 }
 
 impl From<LikeExpr> for SimpleExpr {
     fn from(like: LikeExpr) -> Self {
         match like.escape {
-            Some(escape) => SimpleExpr::Binary(
+            Some(escape) => Self::Binary(
                 Box::new(like.pattern.into()),
                 BinOper::Escape,
                 Box::new(SimpleExpr::Constant(escape.into())),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3058,8 +3058,8 @@ impl SimpleExpr {
     ///     r#"SELECT CURRENT_DATE"#
     /// );
     /// ```
-    pub fn current_date() -> Expr {
-        Expr::Keyword(Keyword::CurrentDate)
+    pub fn current_date() -> Self {
+        Self::Keyword(Keyword::CurrentDate)
     }
 
     /// Keyword `CURRENT_TIMESTAMP`.
@@ -3081,8 +3081,8 @@ impl SimpleExpr {
     ///     r#"SELECT CURRENT_TIME"#
     /// );
     /// ```
-    pub fn current_time() -> Expr {
-        Expr::Keyword(Keyword::CurrentTime)
+    pub fn current_time() -> Self {
+        Self::Keyword(Keyword::CurrentTime)
     }
 
     /// Keyword `CURRENT_TIMESTAMP`.
@@ -3107,8 +3107,8 @@ impl SimpleExpr {
     ///     r#"SELECT CURRENT_TIMESTAMP"#
     /// );
     /// ```
-    pub fn current_timestamp() -> Expr {
-        Expr::Keyword(Keyword::CurrentTimestamp)
+    pub fn current_timestamp() -> Self {
+        Self::Keyword(Keyword::CurrentTimestamp)
     }
 
     /// Custom keyword.
@@ -3126,11 +3126,11 @@ impl SimpleExpr {
     /// assert_eq!(query.to_string(PostgresQueryBuilder), r#"SELECT test"#);
     /// assert_eq!(query.to_string(SqliteQueryBuilder), r#"SELECT test"#);
     /// ```
-    pub fn custom_keyword<T>(i: T) -> Expr
+    pub fn custom_keyword<T>(i: T) -> Self
     where
         T: IntoIden,
     {
-        Expr::Keyword(Keyword::Custom(i.into_iden()))
+        Self::Keyword(Keyword::Custom(i.into_iden()))
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1666,7 +1666,7 @@ impl SimpleExpr {
     /// ```
     #[allow(clippy::self_named_constructors)]
     #[deprecated(
-        since = "1.0.0-rc1",
+        since = "1.0.0-rc.1",
         note = "Please use the [`SimpleExpr::new`] method"
     )]
     pub fn expr<T>(expr: T) -> Self

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1665,7 +1665,10 @@ impl SimpleExpr {
     /// );
     /// ```
     #[allow(clippy::self_named_constructors)]
-    #[deprecated(since = "1.0.0", note = "Please use the [`SimpleExpr::new`] method")]
+    #[deprecated(
+        since = "1.0.0-rc1",
+        note = "Please use the [`SimpleExpr::new`] method"
+    )]
     pub fn expr<T>(expr: T) -> Self
     where
         T: Into<Self>,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -6,14 +6,7 @@
 
 use crate::{func::*, query::*, types::*, value::*};
 
-/// Helper to build a [`SimpleExpr`].
-#[derive(Debug, Clone)]
-pub struct Expr {
-    pub(crate) left: SimpleExpr,
-    pub(crate) right: Option<SimpleExpr>,
-    pub(crate) uopr: Option<UnOper>,
-    pub(crate) bopr: Option<BinOper>,
-}
+pub type Expr = SimpleExpr;
 
 /// Represents a Simple Expression in SQL.
 ///
@@ -1407,18 +1400,18 @@ where
     }
 }
 
-impl Expr {
+impl SimpleExpr {
+    fn new(e: impl Into<Self>) -> Self {
+        e.into()
+    }
+
+    // TODO: since
+    #[deprecated(note = "Please use the [`SimpleExpr::new`] method")]
     fn new_with_left<T>(left: T) -> Self
     where
-        T: Into<SimpleExpr>,
+        T: Into<Self>,
     {
-        let left = left.into();
-        Self {
-            left,
-            right: None,
-            uopr: None,
-            bopr: None,
-        }
+        left.into()
     }
 
     #[deprecated(since = "0.29.0", note = "Please use the [`Asterisk`]")]
@@ -1479,7 +1472,7 @@ impl Expr {
     where
         T: IntoColumnRef,
     {
-        Self::new_with_left(n.into_column_ref())
+        Self::Column(n.into_column_ref())
     }
 
     /// Express the target column without table prefix, returning a [`SimpleExpr`].
@@ -1531,11 +1524,11 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" = 1"#
     /// );
     /// ```
-    pub fn column<T>(n: T) -> SimpleExpr
+    pub fn column<T>(n: T) -> Self
     where
         T: IntoColumnRef,
     {
-        SimpleExpr::Column(n.into_column_ref())
+        Self::Column(n.into_column_ref())
     }
 
     /// Wraps tuple of `SimpleExpr`, can be used for tuple comparison
@@ -1568,11 +1561,9 @@ impl Expr {
     /// ```
     pub fn tuple<I>(n: I) -> Self
     where
-        I: IntoIterator<Item = SimpleExpr>,
+        I: IntoIterator<Item = Self>,
     {
-        Expr::expr(SimpleExpr::Tuple(
-            n.into_iter().collect::<Vec<SimpleExpr>>(),
-        ))
+        Self::Tuple(n.into_iter().collect::<Vec<Self>>())
     }
 
     #[deprecated(since = "0.29.0", note = "Please use the [`Asterisk`]")]
@@ -1615,7 +1606,7 @@ impl Expr {
     where
         V: Into<Value>,
     {
-        Self::new_with_left(v)
+        Self::new(v)
     }
 
     /// Wrap an expression to perform some operation on it later.
@@ -1683,11 +1674,12 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::self_named_constructors)]
+    #[deprecated(since = "0.32.0", note = "Please use the [`SimpleExpr::new`] method")]
     pub fn expr<T>(expr: T) -> Self
     where
-        T: Into<SimpleExpr>,
+        T: Into<Self>,
     {
-        Self::new_with_left(expr)
+        Self::new(expr)
     }
 
     /// Express a [`Value`], returning a [`SimpleExpr`].
@@ -1718,9 +1710,9 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 AND 2.5 AND '3'"#
     /// );
     /// ```
-    pub fn value<V>(v: V) -> SimpleExpr
+    pub fn value<V>(v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         v.into()
     }
@@ -1751,7 +1743,7 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 = 1"#
     /// );
     /// ```
-    pub fn cust<T>(s: T) -> SimpleExpr
+    pub fn cust<T>(s: T) -> Self
     where
         T: Into<String>,
     {
@@ -1828,7 +1820,7 @@ impl Expr {
     ///     r#"SELECT data @? ('hello'::JSONPATH)"#
     /// );
     /// ```
-    pub fn cust_with_values<T, V, I>(s: T, v: I) -> SimpleExpr
+    pub fn cust_with_values<T, V, I>(s: T, v: I) -> Self
     where
         T: Into<String>,
         V: Into<Value>,
@@ -1876,93 +1868,21 @@ impl Expr {
     ///     r#"SELECT json_agg(DISTINCT "character")"#
     /// );
     /// ```
-    pub fn cust_with_expr<T, E>(s: T, expr: E) -> SimpleExpr
+    pub fn cust_with_expr<T, E>(s: T, expr: E) -> Self
     where
         T: Into<String>,
-        E: Into<SimpleExpr>,
+        E: Into<Self>,
     {
         SimpleExpr::CustomWithExpr(s.into(), vec![expr.into()])
     }
 
     /// Express any custom expression with [`SimpleExpr`]. Use this if your expression needs other expressions.
-    pub fn cust_with_exprs<T, I>(s: T, v: I) -> SimpleExpr
+    pub fn cust_with_exprs<T, I>(s: T, v: I) -> Self
     where
         T: Into<String>,
         I: IntoIterator<Item = SimpleExpr>,
     {
         SimpleExpr::CustomWithExpr(s.into(), v.into_iter().collect())
-    }
-
-    /// Express an equal (`=`) expression.
-    ///
-    /// This is equivalent to a newer [ExprTrait::eq] and may require more some wrapping beforehand.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .and_where(Expr::val("What!").eq("Nothing"))
-    ///     .and_where(Expr::col(Char::Id).eq(1))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 'What!' = 'Nothing' AND `id` = 1"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'What!' = 'Nothing' AND "id" = 1"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'What!' = 'Nothing' AND "id" = 1"#
-    /// );
-    /// ```
-    pub fn eq<V>(self, v: V) -> SimpleExpr
-    where
-        V: Into<SimpleExpr>,
-    {
-        ExprTrait::eq(self, v)
-    }
-
-    /// Express a not equal (`<>`) expression.
-    ///
-    /// This is equivalent to a newer [ExprTrait::ne] and may require more some wrapping beforehand.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .and_where(Expr::val("Morning").ne("Good"))
-    ///     .and_where(Expr::col(Char::Id).ne(1))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 'Morning' <> 'Good' AND `id` <> 1"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'Morning' <> 'Good' AND "id" <> 1"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'Morning' <> 'Good' AND "id" <> 1"#
-    /// );
-    /// ```
-    pub fn ne<V>(self, v: V) -> SimpleExpr
-    where
-        V: Into<SimpleExpr>,
-    {
-        ExprTrait::ne(self, v)
     }
 
     /// Express a equal expression between two table columns,
@@ -1994,7 +1914,7 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."font_id" = "font"."id""#
     /// );
     /// ```
-    pub fn equals<C>(self, col: C) -> SimpleExpr
+    pub fn equals<C>(self, col: C) -> Self
     where
         C: IntoColumnRef,
     {
@@ -2030,7 +1950,7 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."font_id" <> "font"."id""#
     /// );
     /// ```
-    pub fn not_equals<C>(self, col: C) -> SimpleExpr
+    pub fn not_equals<C>(self, col: C) -> Self
     where
         C: IntoColumnRef,
     {
@@ -2065,9 +1985,9 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" > 2"#
     /// );
     /// ```
-    pub fn gt<V>(self, v: V) -> SimpleExpr
+    pub fn gt<V>(self, v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::gt(self, v)
     }
@@ -2100,9 +2020,9 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" >= 2"#
     /// );
     /// ```
-    pub fn gte<V>(self, v: V) -> SimpleExpr
+    pub fn gte<V>(self, v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::gte(self, v)
     }
@@ -2135,9 +2055,9 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" < 2"#
     /// );
     /// ```
-    pub fn lt<V>(self, v: V) -> SimpleExpr
+    pub fn lt<V>(self, v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::lt(self, v)
     }
@@ -2170,155 +2090,11 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" <= 2"#
     /// );
     /// ```
-    pub fn lte<V>(self, v: V) -> SimpleExpr
+    pub fn lte<V>(self, v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::lte(self, v)
-    }
-
-    /// Express an arithmetic addition operation.
-    ///
-    /// This is equivalent to a newer [ExprTrait::add] and may require more some wrapping beforehand.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).add(1).eq(2))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 + 1 = 2"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 + 1 = 2"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 + 1 = 2"#
-    /// );
-    /// ```
-    #[allow(clippy::should_implement_trait)]
-    pub fn add<V>(self, v: V) -> SimpleExpr
-    where
-        V: Into<SimpleExpr>,
-    {
-        ExprTrait::add(self, v)
-    }
-
-    /// Express an arithmetic subtraction operation.
-    ///
-    /// This is equivalent to a newer [ExprTrait::sub] and may require more some wrapping beforehand.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).sub(1).eq(2))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 - 1 = 2"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 - 1 = 2"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 - 1 = 2"#
-    /// );
-    /// ```
-    #[allow(clippy::should_implement_trait)]
-    pub fn sub<V>(self, v: V) -> SimpleExpr
-    where
-        V: Into<SimpleExpr>,
-    {
-        ExprTrait::sub(self, v)
-    }
-
-    /// Express an arithmetic multiplication operation.
-    ///
-    /// This is equivalent to a newer [ExprTrait::mul] and may require more some wrapping beforehand.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).mul(1).eq(2))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 * 1 = 2"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 * 1 = 2"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 * 1 = 2"#
-    /// );
-    /// ```
-    #[allow(clippy::should_implement_trait)]
-    pub fn mul<V>(self, v: V) -> SimpleExpr
-    where
-        V: Into<SimpleExpr>,
-    {
-        ExprTrait::mul(self, v)
-    }
-
-    /// Express an arithmetic division operation.
-    ///
-    /// This is equivalent to a newer [ExprTrait::div] and may require more some wrapping beforehand.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .and_where(Expr::val(1).div(1).eq(2))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE 1 / 1 = 2"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 / 1 = 2"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 / 1 = 2"#
-    /// );
-    /// ```
-    #[allow(clippy::should_implement_trait)]
-    pub fn div<V>(self, v: V) -> SimpleExpr
-    where
-        V: Into<SimpleExpr>,
-    {
-        ExprTrait::div(self, v)
     }
 
     /// Express an arithmetic modulo operation.
@@ -2350,9 +2126,9 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::should_implement_trait)]
-    pub fn modulo<V>(self, v: V) -> SimpleExpr
+    pub fn modulo<V>(self, v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::modulo(self, v)
     }
@@ -2386,9 +2162,9 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::should_implement_trait)]
-    pub fn left_shift<V>(self, v: V) -> SimpleExpr
+    pub fn left_shift<V>(self, v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::left_shift(self, v)
     }
@@ -2422,9 +2198,9 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::should_implement_trait)]
-    pub fn right_shift<V>(self, v: V) -> SimpleExpr
+    pub fn right_shift<V>(self, v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::right_shift(self, v)
     }
@@ -2457,9 +2233,9 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" BETWEEN 1 AND 10"#
     /// );
     /// ```
-    pub fn between<V>(self, a: V, b: V) -> SimpleExpr
+    pub fn between<V>(self, a: V, b: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::between(self, a, b)
     }
@@ -2492,75 +2268,11 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."size_w" NOT BETWEEN 1 AND 10"#
     /// );
     /// ```
-    pub fn not_between<V>(self, a: V, b: V) -> SimpleExpr
+    pub fn not_between<V>(self, a: V, b: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::not_between(self, a, b)
-    }
-
-    /// Express a `LIKE` expression.
-    ///
-    /// This is equivalent to a newer [ExprTrait::like] and may require more some wrapping beforehand.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .and_where(Expr::col((Char::Table, Char::Character)).like("Ours'%"))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`character` LIKE 'Ours\'%'"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE E'Ours\'%'"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE 'Ours''%'"#
-    /// );
-    /// ```
-    ///
-    /// Like with ESCAPE
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .and_where(Expr::col((Char::Table, Char::Character)).like(LikeExpr::new(r"|_Our|_").escape('|')))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `character`.`character` LIKE '|_Our|_' ESCAPE '|'"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE '|_Our|_' ESCAPE '|'"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."character" LIKE '|_Our|_' ESCAPE '|'"#
-    /// );
-    /// ```
-    pub fn like<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
-        ExprTrait::like(self, like)
-    }
-
-    /// Express a `NOT LIKE` expression.
-    ///
-    /// This is equivalent to a newer [ExprTrait::not_like] and may require more some wrapping beforehand.
-    pub fn not_like<L: IntoLikeExpr>(self, like: L) -> SimpleExpr {
-        ExprTrait::not_like(self, like)
     }
 
     /// Express a `IS NULL` expression.
@@ -2592,7 +2304,7 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn is_null(self) -> SimpleExpr {
+    pub fn is_null(self) -> Self {
         ExprTrait::is_null(self)
     }
 
@@ -2624,9 +2336,9 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."ascii" IS TRUE"#
     /// );
     /// ```
-    pub fn is<V>(self, v: V) -> SimpleExpr
+    pub fn is<V>(self, v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::is(self, v)
     }
@@ -2660,7 +2372,7 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn is_not_null(self) -> SimpleExpr {
+    pub fn is_not_null(self) -> Self {
         ExprTrait::is_not_null(self)
     }
 
@@ -2692,85 +2404,11 @@ impl Expr {
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "character"."ascii" IS NOT TRUE"#
     /// );
     /// ```
-    pub fn is_not<V>(self, v: V) -> SimpleExpr
+    pub fn is_not<V>(self, v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
         ExprTrait::is_not(self, v)
-    }
-
-    /// Create any binary operation
-    ///
-    /// This is equivalent to a newer [ExprTrait::binary] and may require more some wrapping beforehand.
-    ///
-    /// # Examples
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     .cond_where(all![
-    ///         Expr::col(Char::SizeW).binary(BinOper::SmallerThan, 10),
-    ///         Expr::col(Char::SizeW).binary(BinOper::GreaterThan, Expr::col(Char::SizeH))
-    ///     ])
-    ///     .to_owned();
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE `size_w` < 10 AND `size_w` > `size_h`"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" < 10 AND "size_w" > "size_h""#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE "size_w" < 10 AND "size_w" > "size_h""#
-    /// );
-    /// ```
-    pub fn binary<O, T>(self, op: O, right: T) -> SimpleExpr
-    where
-        O: Into<BinOper>,
-        T: Into<SimpleExpr>,
-    {
-        ExprTrait::binary(self, op, right)
-    }
-
-    /// Negates an expression with `NOT`.
-    ///
-    /// This is equivalent to a newer [ExprTrait::not] and may require more some wrapping beforehand.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{*, tests_cfg::*};
-    ///
-    /// let query = Query::select()
-    ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
-    ///     .from(Char::Table)
-    ///     // Before 0.32.0, you had call `not` on an `Expr`, which had to be constructed using `Expr::expr`:
-    ///     .and_where(Expr::expr(Expr::col((Char::Table, Char::SizeW)).is_null()).not())
-    ///     .to_owned();
-    ///
-    /// // But since 0.32.0, this compiles too:
-    /// let _ = Expr::col((Char::Table, Char::SizeW)).is_null().not();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT `character`, `size_w`, `size_h` FROM `character` WHERE NOT `character`.`size_w` IS NULL"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE NOT "character"."size_w" IS NULL"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE NOT "character"."size_w" IS NULL"#
-    /// );
-    /// ```
-    #[allow(clippy::should_implement_trait)]
-    pub fn not(self) -> SimpleExpr {
-        ExprTrait::not(self)
     }
 
     /// Express a `MAX` function.
@@ -2798,8 +2436,8 @@ impl Expr {
     ///     r#"SELECT MAX("character"."size_w") FROM "character""#
     /// );
     /// ```
-    pub fn max(self) -> SimpleExpr {
-        Func::max(self.left).into()
+    pub fn max(self) -> Self {
+        Func::max(self).into()
     }
 
     /// Express a `MIN` function.
@@ -2827,8 +2465,8 @@ impl Expr {
     ///     r#"SELECT MIN("character"."size_w") FROM "character""#
     /// );
     /// ```
-    pub fn min(self) -> SimpleExpr {
-        Func::min(self.left).into()
+    pub fn min(self) -> Self {
+        Func::min(self).into()
     }
 
     /// Express a `SUM` function.
@@ -2856,8 +2494,8 @@ impl Expr {
     ///     r#"SELECT SUM("character"."size_w") FROM "character""#
     /// );
     /// ```
-    pub fn sum(self) -> SimpleExpr {
-        Func::sum(self.left).into()
+    pub fn sum(self) -> Self {
+        Func::sum(self).into()
     }
 
     /// Express a `COUNT` function.
@@ -2885,8 +2523,8 @@ impl Expr {
     ///     r#"SELECT COUNT("character"."size_w") FROM "character""#
     /// );
     /// ```
-    pub fn count(self) -> SimpleExpr {
-        Func::count(self.left).into()
+    pub fn count(self) -> Self {
+        Func::count(self).into()
     }
 
     /// Express a `COUNT` function with the DISTINCT modifier.
@@ -2914,8 +2552,8 @@ impl Expr {
     ///     r#"SELECT COUNT(DISTINCT "character"."size_w") FROM "character""#
     /// );
     /// ```
-    pub fn count_distinct(self) -> SimpleExpr {
-        Func::count_distinct(self.left).into()
+    pub fn count_distinct(self) -> Self {
+        Func::count_distinct(self).into()
     }
 
     /// Express a `IF NULL` function.
@@ -2943,11 +2581,11 @@ impl Expr {
     ///     r#"SELECT IFNULL("character"."size_w", 0) FROM "character""#
     /// );
     /// ```
-    pub fn if_null<V>(self, v: V) -> SimpleExpr
+    pub fn if_null<V>(self, v: V) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
     {
-        Func::if_null(self.left, v).into()
+        Func::if_null(self, v).into()
     }
 
     /// Express a `IN` expression.
@@ -3002,9 +2640,9 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn is_in<V, I>(self, v: I) -> SimpleExpr
+    pub fn is_in<V, I>(self, v: I) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
         I: IntoIterator<Item = V>,
     {
         ExprTrait::is_in(self, v)
@@ -3047,7 +2685,7 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn in_tuples<V, I>(self, v: I) -> SimpleExpr
+    pub fn in_tuples<V, I>(self, v: I) -> Self
     where
         V: IntoValueTuple,
         I: IntoIterator<Item = V>,
@@ -3107,9 +2745,9 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn is_not_in<V, I>(self, v: I) -> SimpleExpr
+    pub fn is_not_in<V, I>(self, v: I) -> Self
     where
-        V: Into<SimpleExpr>,
+        V: Into<Self>,
         I: IntoIterator<Item = V>,
     {
         ExprTrait::is_not_in(self, v)
@@ -3148,7 +2786,7 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn in_subquery(self, sel: SelectStatement) -> SimpleExpr {
+    pub fn in_subquery(self, sel: SelectStatement) -> Self {
         ExprTrait::in_subquery(self, sel)
     }
 
@@ -3185,7 +2823,7 @@ impl Expr {
     /// );
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn not_in_subquery(self, sel: SelectStatement) -> SimpleExpr {
+    pub fn not_in_subquery(self, sel: SelectStatement) -> Self {
         ExprTrait::not_in_subquery(self, sel)
     }
 
@@ -3214,7 +2852,7 @@ impl Expr {
     ///     r#"SELECT EXISTS(SELECT "id" FROM "character") AS "character_exists", EXISTS(SELECT "id" FROM "glyph") AS "glyph_exists""#
     /// );
     /// ```
-    pub fn exists(sel: SelectStatement) -> SimpleExpr {
+    pub fn exists(sel: SelectStatement) -> Self {
         SimpleExpr::SubQuery(
             Some(SubQueryOper::Exists),
             Box::new(sel.into_sub_query_statement()),
@@ -3245,7 +2883,7 @@ impl Expr {
     ///     r#"SELECT "id" FROM "character" WHERE "id" = ANY(SELECT "id" FROM "character")"#
     /// );
     /// ```
-    pub fn any(sel: SelectStatement) -> SimpleExpr {
+    pub fn any(sel: SelectStatement) -> Self {
         SimpleExpr::SubQuery(
             Some(SubQueryOper::Any),
             Box::new(sel.into_sub_query_statement()),
@@ -3276,7 +2914,7 @@ impl Expr {
     ///     r#"SELECT "id" FROM "character" WHERE "id" <> SOME(SELECT "id" FROM "character")"#
     /// );
     /// ```
-    pub fn some(sel: SelectStatement) -> SimpleExpr {
+    pub fn some(sel: SelectStatement) -> Self {
         SimpleExpr::SubQuery(
             Some(SubQueryOper::Some),
             Box::new(sel.into_sub_query_statement()),
@@ -3284,7 +2922,7 @@ impl Expr {
     }
 
     /// Express a `ALL` sub-query expression.
-    pub fn all(sel: SelectStatement) -> SimpleExpr {
+    pub fn all(sel: SelectStatement) -> Self {
         SimpleExpr::SubQuery(
             Some(SubQueryOper::All),
             Box::new(sel.into_sub_query_statement()),
@@ -3363,13 +3001,12 @@ impl Expr {
     ///     r#"INSERT INTO "character" ("font_size") VALUES ('large')"#
     /// );
     /// ```
-    pub fn as_enum<T>(self, type_name: T) -> SimpleExpr
+    pub fn as_enum<T>(self, type_name: T) -> Self
     where
         T: IntoIden,
     {
         ExprTrait::as_enum(self, type_name)
     }
-
     /// Adds new `CASE WHEN` to existing case statement.
     ///
     /// # Examples
@@ -3397,42 +3034,9 @@ impl Expr {
     pub fn case<C, T>(cond: C, then: T) -> CaseStatement
     where
         C: IntoCondition,
-        T: Into<SimpleExpr>,
+        T: Into<Self>,
     {
         CaseStatement::new().case(cond, then)
-    }
-
-    /// Express a `CAST AS` expression.
-    ///
-    /// This is equivalent to a newer [ExprTrait::cast_as] and may require more some wrapping beforehand.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sea_query::{tests_cfg::*, *};
-    ///
-    /// let query = Query::select()
-    ///     .expr(Expr::val("1").cast_as("integer"))
-    ///     .to_owned();
-    ///
-    /// assert_eq!(
-    ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT CAST('1' AS integer)"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(PostgresQueryBuilder),
-    ///     r#"SELECT CAST('1' AS integer)"#
-    /// );
-    /// assert_eq!(
-    ///     query.to_string(SqliteQueryBuilder),
-    ///     r#"SELECT CAST('1' AS integer)"#
-    /// );
-    /// ```
-    pub fn cast_as<T>(self, type_name: T) -> SimpleExpr
-    where
-        T: IntoIden,
-    {
-        ExprTrait::cast_as(self, type_name)
     }
 
     /// Keyword `CURRENT_DATE`.
@@ -3455,7 +3059,7 @@ impl Expr {
     /// );
     /// ```
     pub fn current_date() -> Expr {
-        Expr::new_with_left(Keyword::CurrentDate)
+        Expr::Keyword(Keyword::CurrentDate)
     }
 
     /// Keyword `CURRENT_TIMESTAMP`.
@@ -3478,7 +3082,7 @@ impl Expr {
     /// );
     /// ```
     pub fn current_time() -> Expr {
-        Expr::new_with_left(Keyword::CurrentTime)
+        Expr::Keyword(Keyword::CurrentTime)
     }
 
     /// Keyword `CURRENT_TIMESTAMP`.
@@ -3504,7 +3108,7 @@ impl Expr {
     /// );
     /// ```
     pub fn current_timestamp() -> Expr {
-        Expr::new_with_left(Keyword::CurrentTimestamp)
+        Expr::Keyword(Keyword::CurrentTimestamp)
     }
 
     /// Custom keyword.
@@ -3526,20 +3130,7 @@ impl Expr {
     where
         T: IntoIden,
     {
-        Expr::new_with_left(Keyword::Custom(i.into_iden()))
-    }
-}
-
-impl From<Expr> for SimpleExpr {
-    /// Convert into SimpleExpr
-    fn from(src: Expr) -> Self {
-        if let Some(uopr) = src.uopr {
-            SimpleExpr::Unary(uopr, Box::new(src.left))
-        } else if let Some(bopr) = src.bopr {
-            SimpleExpr::Binary(Box::new(src.left), bopr, Box::new(src.right.unwrap()))
-        } else {
-            src.left
-        }
+        Expr::Keyword(Keyword::Custom(i.into_iden()))
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1665,7 +1665,7 @@ impl SimpleExpr {
     /// );
     /// ```
     #[allow(clippy::self_named_constructors)]
-    #[deprecated(since = "0.32.0", note = "Please use the [`SimpleExpr::new`] method")]
+    #[deprecated(since = "1.0.0", note = "Please use the [`SimpleExpr::new`] method")]
     pub fn expr<T>(expr: T) -> Self
     where
         T: Into<Self>,

--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -203,7 +203,6 @@ pub trait PgExpr: ExprTrait {
 // replace all of this with `impl<T> PgExpr for T where T: ExprTrait {}`
 // (breaking change)
 impl PgExpr for Expr {}
-impl PgExpr for SimpleExpr {}
 impl PgExpr for FunctionCall {}
 impl PgExpr for ColumnRef {}
 impl PgExpr for Keyword {}

--- a/src/extension/postgres/func.rs
+++ b/src/extension/postgres/func.rs
@@ -426,7 +426,7 @@ impl PgFunc {
         T: Into<SimpleExpr>,
     {
         FunctionCall::new(Function::PgFunction(PgFunction::DateTrunc))
-            .args([Expr::val(unit.to_string()).into(), expr.into()])
+            .args([Expr::val(unit.to_string()), expr.into()])
     }
 
     /// Call the `JSON_AGG` function. Postgres only.

--- a/src/extension/sqlite/expr.rs
+++ b/src/extension/sqlite/expr.rs
@@ -109,7 +109,6 @@ pub trait SqliteExpr: ExprTrait {
 // replace all of this with `impl<T> SqliteExpr for T where T: ExprTrait {}`
 // (breaking change)
 impl SqliteExpr for Expr {}
-impl SqliteExpr for SimpleExpr {}
 impl SqliteExpr for FunctionCall {}
 impl SqliteExpr for ColumnRef {}
 impl SqliteExpr for Keyword {}


### PR DESCRIPTION
<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [x] SimpleExpr now has all methods from Expr.

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [x] Expr is now an alias of SimpleExpr.
  - How to migrate: if your code doesn't rely on these being two different types, everything should just work. But if you had impl Foo for Expr and impl Foo for SimpleExpr, your code won't compile and you need to delete one of the impls.

## Changes

- [x] Deprecate `SimpleExpr::expr` and add `SimpleExpr::new` which is more consistent with Rust conventions.