### PR TITLE
New iden paradigm

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,18 +158,13 @@ pub enum Character {
 
 // Mapping between Enum variant and its corresponding string value
 impl Iden for Character {
-    fn unquoted(&self, s: &mut dyn std::fmt::Write) {
-        write!(
-            s,
-            "{}",
-            match self {
-                Self::Table => "character",
-                Self::Id => "id",
-                Self::FontId => "font_id",
-                Self::FontSize => "font_size",
-            }
-        )
-        .unwrap();
+    fn unquoted(&self) -> &str {
+        match self {
+            Self::Table => "character",
+            Self::Id => "id",
+            Self::FontId => "font_id",
+            Self::FontSize => "font_size",
+        }
     }
 }
 ```
@@ -198,7 +193,7 @@ assert_eq!(Glyph.to_string(), "glyph");
 
 ```rust
 #[cfg(feature = "derive")]
-use sea_query::{enum_def, Iden};
+use sea_query::{Iden, enum_def};
 
 #[enum_def]
 struct Character {
@@ -476,8 +471,8 @@ assert_eq!(
 struct MyFunction;
 
 impl Iden for MyFunction {
-    fn unquoted(&self, s: &mut dyn Write) {
-        write!(s, "MY_FUNCTION").unwrap();
+    fn unquoted(&self) -> &str {
+        "MY_FUNCTION"
     }
 }
 
@@ -574,12 +569,7 @@ assert_eq!(
 ```rust
 let table = Table::alter()
     .table(Font::Table)
-    .add_column(
-        ColumnDef::new("new_col")
-            .integer()
-            .not_null()
-            .default(100),
-    )
+    .add_column(ColumnDef::new("new_col").integer().not_null().default(100))
     .to_owned();
 
 assert_eq!(
@@ -621,9 +611,7 @@ assert_eq!(
 ### Table Rename
 
 ```rust
-let table = Table::rename()
-    .table(Font::Table, "font_new")
-    .to_owned();
+let table = Table::rename().table(Font::Table, "font_new").to_owned();
 
 assert_eq!(
     table.to_string(MysqlQueryBuilder),

--- a/sea-query-derive/Cargo.toml
+++ b/sea-query-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sea-query-derive"
 version = "0.4.3"
 authors = [ "Follpvosten <wolfi@karpador.xyz>", "Rene Leveille <rene@nestingsafe.com>" ]
-edition = "2024"
+edition = "2021"
 description = "Derive macro for sea-query's Iden trait"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/sea-query"

--- a/sea-query-derive/src/iden/mod.rs
+++ b/sea-query-derive/src/iden/mod.rs
@@ -13,11 +13,11 @@ pub(crate) struct DeriveIden;
 
 impl WriteArm for DeriveIden {
     fn variant(variant: TokenStream, name: TokenStream) -> TokenStream {
-        quote! { Self::#variant => write!(s, "{}", #name).unwrap() }
+        quote! { Self::#variant => #name }
     }
 
     fn flattened(variant: TokenStream, name: &Ident) -> TokenStream {
-        quote! { Self::#variant => #name.unquoted(s) }
+        quote! { Self::#variant => #name.unquoted() }
     }
 }
 

--- a/sea-query-derive/src/iden/write_arm.rs
+++ b/sea-query-derive/src/iden/write_arm.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use heck::ToSnakeCase;
 use proc_macro2::{Span, TokenStream};
-use quote::{ToTokens, TokenStreamExt, quote};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Error, Fields, FieldsNamed, Ident, Variant};
 
 use super::{attr::IdenAttr, error::ErrorMsg};

--- a/sea-query-derive/src/iden/write_arm.rs
+++ b/sea-query-derive/src/iden/write_arm.rs
@@ -7,7 +7,7 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Error, Fields, FieldsNamed, Ident, Variant};
 
 use super::{attr::IdenAttr, error::ErrorMsg};
-use crate::{find_attr, must_be_valid_iden};
+use crate::{find_attr, is_static_iden};
 
 pub(crate) trait WriteArm {
     fn variant(variant: TokenStream, name: TokenStream) -> TokenStream;
@@ -159,7 +159,7 @@ where
         T::variant(variant, name)
     }
 
-    pub(crate) fn must_be_valid_iden(&self) -> bool {
+    pub(crate) fn is_static_iden(&self) -> bool {
         let name: String = match &self.attr {
             Some(a) => match a {
                 IdenAttr::Rename(name) => name.to_owned(),
@@ -169,7 +169,7 @@ where
             None => self.table_or_snake_case(),
         };
 
-        must_be_valid_iden(&name)
+        is_static_iden(&name)
     }
 }
 

--- a/sea-query-derive/src/lib.rs
+++ b/sea-query-derive/src/lib.rs
@@ -166,7 +166,7 @@ fn impl_iden_for_unit_struct(
     if is_static_iden(table_name) {
         quote! {
             impl #sea_query_path::Iden for #ident {
-                fn quoted(&self, q: sea_query::Quote) -> std::borrow::Cow<'static, str> {
+                fn quoted(&self) -> std::borrow::Cow<'static, str> {
                     std::borrow::Cow::Borrowed(self.unquoted_static())
                 }
 
@@ -217,7 +217,7 @@ where
     if is_all_static_iden {
         quote! {
             impl #sea_query_path::Iden for #ident {
-                fn quoted(&self, q: sea_query::Quote) -> std::borrow::Cow<'static, str> {
+                fn quoted(&self) -> std::borrow::Cow<'static, str> {
                     std::borrow::Cow::Borrowed(self.unquoted_static())
                 }
 

--- a/sea-query-derive/src/lib.rs
+++ b/sea-query-derive/src/lib.rs
@@ -167,14 +167,10 @@ fn impl_iden_for_unit_struct(
         quote! {
             impl #sea_query_path::Iden for #ident {
                 fn quoted(&self) -> std::borrow::Cow<'static, str> {
-                    std::borrow::Cow::Borrowed(self.unquoted_static())
+                    std::borrow::Cow::Borrowed(#table_name)
                 }
 
                 fn unquoted(&self) -> &str {
-                    self.unquoted_static()
-                }
-
-                fn unquoted_static(&self) -> &'static str {
                     #table_name
                 }
             }
@@ -218,14 +214,12 @@ where
         quote! {
             impl #sea_query_path::Iden for #ident {
                 fn quoted(&self) -> std::borrow::Cow<'static, str> {
-                    std::borrow::Cow::Borrowed(self.unquoted_static())
+                    std::borrow::Cow::Borrowed(match self {
+                        #(#match_arms),*
+                    })
                 }
 
                 fn unquoted(&self) -> &str {
-                    self.unquoted_static()
-                }
-
-                fn unquoted_static(&self) -> &'static str {
                     match self {
                         #(#match_arms),*
                     }

--- a/sea-query-derive/tests/pass-static/flattened_unnamed.rs
+++ b/sea-query-derive/tests/pass-static/flattened_unnamed.rs
@@ -10,17 +10,12 @@ enum Asset {
     Creation(CreationInfo),
 }
 
-#[derive(Copy, Clone, IdenStatic)]
+#[derive(Default, Copy, Clone, IdenStatic)]
 enum CreationInfo {
+    #[default]
     UserId,
     #[iden = "creation_date"]
     Date,
-}
-
-impl Default for CreationInfo {
-    fn default() -> Self {
-        Self::UserId
-    }
 }
 
 fn main() {

--- a/sea-query-derive/tests/pass-static/meta_list_renaming_everything.rs
+++ b/sea-query-derive/tests/pass-static/meta_list_renaming_everything.rs
@@ -1,4 +1,4 @@
-use sea_query::{Iden, IdenStatic};
+use sea_query::{Iden, IdenStatic, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
 use strum::{EnumIter, IntoEnumIterator};
 
 #[derive(IdenStatic, EnumIter, Copy, Clone)]
@@ -39,10 +39,10 @@ fn main() {
         .for_each(|(iden, exp)| assert_eq!(iden, exp));
     
     let mut string = String::new();
-    Custom::Email(0).prepare(&mut string, '"'.into());
+    PostgresQueryBuilder.prepare_iden(&Custom::Email(0), &mut string);
     assert_eq!(string, "\"EM`ail\"");
 
     let mut string = String::new();
-    Custom::Email(0).prepare(&mut string, b'`'.into());
+    MysqlQueryBuilder.prepare_iden(&Custom::Email(0), &mut string);
     assert_eq!(string, "`EM``ail`");
 }

--- a/sea-query-derive/tests/pass-static/meta_list_renaming_everything.rs
+++ b/sea-query-derive/tests/pass-static/meta_list_renaming_everything.rs
@@ -39,10 +39,10 @@ fn main() {
         .for_each(|(iden, exp)| assert_eq!(iden, exp));
     
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_dyn_iden(&Custom::Email(0).into_iden(), &mut string);
+    PostgresQueryBuilder.prepare_iden(&Custom::Email(0).into_iden(), &mut string);
     assert_eq!(string, "\"EM`ail\"");
 
     let mut string = String::new();
-    MysqlQueryBuilder.prepare_dyn_iden(&Custom::Email(0).into_iden(), &mut string);
+    MysqlQueryBuilder.prepare_iden(&Custom::Email(0).into_iden(), &mut string);
     assert_eq!(string, "`EM``ail`");
 }

--- a/sea-query-derive/tests/pass-static/meta_list_renaming_everything.rs
+++ b/sea-query-derive/tests/pass-static/meta_list_renaming_everything.rs
@@ -1,4 +1,4 @@
-use sea_query::{Iden, IdenStatic, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
+use sea_query::{Iden, IntoIden, IdenStatic, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
 use strum::{EnumIter, IntoEnumIterator};
 
 #[derive(IdenStatic, EnumIter, Copy, Clone)]
@@ -39,10 +39,10 @@ fn main() {
         .for_each(|(iden, exp)| assert_eq!(iden, exp));
     
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_iden(&Custom::Email(0), &mut string);
+    PostgresQueryBuilder.prepare_dyn_iden(&Custom::Email(0).into_iden(), &mut string);
     assert_eq!(string, "\"EM`ail\"");
 
     let mut string = String::new();
-    MysqlQueryBuilder.prepare_iden(&Custom::Email(0), &mut string);
+    MysqlQueryBuilder.prepare_dyn_iden(&Custom::Email(0).into_iden(), &mut string);
     assert_eq!(string, "`EM``ail`");
 }

--- a/sea-query-derive/tests/pass-static/simple_unit_struct.rs
+++ b/sea-query-derive/tests/pass-static/simple_unit_struct.rs
@@ -1,4 +1,4 @@
-use sea_query::{Iden, IdenStatic, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
+use sea_query::{Iden, IntoIden, IdenStatic, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
 
 #[derive(Copy, Clone, IdenStatic)]
 pub struct SomeType;
@@ -12,14 +12,14 @@ fn main() {
     assert_eq!(SomeTypeWithRename.to_string(), "Hel`lo");
 
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_iden(&SomeType, &mut string);
+    PostgresQueryBuilder.prepare_dyn_iden(&SomeType.into_iden(), &mut string);
     assert_eq!(string, "\"some_type\"");
 
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_iden(&SomeTypeWithRename, &mut string);
+    PostgresQueryBuilder.prepare_dyn_iden(&SomeTypeWithRename.into_iden(), &mut string);
     assert_eq!(string, "\"Hel`lo\"");
 
     let mut string = String::new();
-    MysqlQueryBuilder.prepare_iden(&SomeTypeWithRename, &mut string);
+    MysqlQueryBuilder.prepare_dyn_iden(&SomeTypeWithRename.into_iden(), &mut string);
     assert_eq!(string, "`Hel``lo`");
 }

--- a/sea-query-derive/tests/pass-static/simple_unit_struct.rs
+++ b/sea-query-derive/tests/pass-static/simple_unit_struct.rs
@@ -1,4 +1,4 @@
-use sea_query::{Iden, IdenStatic};
+use sea_query::{Iden, IdenStatic, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
 
 #[derive(Copy, Clone, IdenStatic)]
 pub struct SomeType;
@@ -12,14 +12,14 @@ fn main() {
     assert_eq!(SomeTypeWithRename.to_string(), "Hel`lo");
 
     let mut string = String::new();
-    SomeType.prepare(&mut string, '"'.into());
+    PostgresQueryBuilder.prepare_iden(&SomeType, &mut string);
     assert_eq!(string, "\"some_type\"");
 
     let mut string = String::new();
-    SomeTypeWithRename.prepare(&mut string, '"'.into());
+    PostgresQueryBuilder.prepare_iden(&SomeTypeWithRename, &mut string);
     assert_eq!(string, "\"Hel`lo\"");
 
     let mut string = String::new();
-    SomeTypeWithRename.prepare(&mut string, b'`'.into());
+    MysqlQueryBuilder.prepare_iden(&SomeTypeWithRename, &mut string);
     assert_eq!(string, "`Hel``lo`");
 }

--- a/sea-query-derive/tests/pass-static/simple_unit_struct.rs
+++ b/sea-query-derive/tests/pass-static/simple_unit_struct.rs
@@ -12,14 +12,14 @@ fn main() {
     assert_eq!(SomeTypeWithRename.to_string(), "Hel`lo");
 
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_dyn_iden(&SomeType.into_iden(), &mut string);
+    PostgresQueryBuilder.prepare_iden(&SomeType.into_iden(), &mut string);
     assert_eq!(string, "\"some_type\"");
 
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_dyn_iden(&SomeTypeWithRename.into_iden(), &mut string);
+    PostgresQueryBuilder.prepare_iden(&SomeTypeWithRename.into_iden(), &mut string);
     assert_eq!(string, "\"Hel`lo\"");
 
     let mut string = String::new();
-    MysqlQueryBuilder.prepare_dyn_iden(&SomeTypeWithRename.into_iden(), &mut string);
+    MysqlQueryBuilder.prepare_iden(&SomeTypeWithRename.into_iden(), &mut string);
     assert_eq!(string, "`Hel``lo`");
 }

--- a/sea-query-derive/tests/pass/flattened_named.rs
+++ b/sea-query-derive/tests/pass/flattened_named.rs
@@ -1,5 +1,6 @@
-use sea_query::Iden;
+use sea_query::{Iden, QuotedBuilder, MysqlQueryBuilder};
 use strum::{EnumIter, IntoEnumIterator};
+use std::borrow::Cow;
 
 #[derive(Copy, Clone, Iden, EnumIter)]
 enum Asset {
@@ -35,5 +36,6 @@ fn main() {
         .zip(expected)
         .for_each(|(var, exp)| {
             assert_eq!(var.to_string(), exp);
+            assert_eq!(var.quoted(MysqlQueryBuilder.quote()), Cow::Borrowed(exp));
         })
 }

--- a/sea-query-derive/tests/pass/flattened_named.rs
+++ b/sea-query-derive/tests/pass/flattened_named.rs
@@ -1,4 +1,4 @@
-use sea_query::{Iden, QuotedBuilder, MysqlQueryBuilder};
+use sea_query::Iden;
 use strum::{EnumIter, IntoEnumIterator};
 use std::borrow::Cow;
 
@@ -36,6 +36,6 @@ fn main() {
         .zip(expected)
         .for_each(|(var, exp)| {
             assert_eq!(var.to_string(), exp);
-            assert_eq!(var.quoted(MysqlQueryBuilder.quote()), Cow::Borrowed(exp));
+            assert_eq!(var.quoted(), Cow::Borrowed(exp));
         })
 }

--- a/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
+++ b/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
@@ -1,4 +1,4 @@
-use sea_query::{Iden, QuotedBuilder, MysqlQueryBuilder};
+use sea_query::{Iden, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
 use strum::{EnumIter, IntoEnumIterator};
 use std::borrow::Cow;
 
@@ -40,11 +40,11 @@ fn main() {
         .for_each(|(iden, exp)| assert_eq!(iden, exp));
     
     let mut string = String::new();
-    Custom::Email("".to_owned()).prepare(&mut string, '"'.into());
+    PostgresQueryBuilder.prepare_iden(&Custom::Email("".to_owned()), &mut string);
     assert_eq!(string, "\"EM`ail\"");
 
     let mut string = String::new();
-    Custom::Email("".to_owned()).prepare(&mut string, b'`'.into());
+    MysqlQueryBuilder.prepare_iden(&Custom::Email("".to_owned()), &mut string);
     assert_eq!(string, "`EM``ail`");
 
     assert!(matches!(Custom::FirstName.quoted(MysqlQueryBuilder.quote()), Cow::Owned(_)));

--- a/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
+++ b/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
@@ -1,5 +1,6 @@
-use sea_query::Iden;
+use sea_query::{Iden, QuotedBuilder, MysqlQueryBuilder};
 use strum::{EnumIter, IntoEnumIterator};
+use std::borrow::Cow;
 
 #[derive(Iden, EnumIter)]
 // Outer iden attributes overrides what's used for "Table"...
@@ -45,4 +46,6 @@ fn main() {
     let mut string = String::new();
     Custom::Email("".to_owned()).prepare(&mut string, b'`'.into());
     assert_eq!(string, "`EM``ail`");
+
+    assert!(matches!(Custom::FirstName.quoted(MysqlQueryBuilder.quote()), Cow::Owned(_)));
 }

--- a/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
+++ b/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
@@ -47,5 +47,5 @@ fn main() {
     MysqlQueryBuilder.prepare_iden(&Custom::Email("".to_owned()), &mut string);
     assert_eq!(string, "`EM``ail`");
 
-    assert!(matches!(Custom::FirstName.quoted(MysqlQueryBuilder.quote()), Cow::Owned(_)));
+    assert!(matches!(Custom::FirstName.quoted(), Cow::Owned(_)));
 }

--- a/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
+++ b/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
@@ -1,4 +1,4 @@
-use sea_query::{Iden, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
+use sea_query::{Iden, IntoIden, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
 use strum::{EnumIter, IntoEnumIterator};
 use std::borrow::Cow;
 
@@ -40,11 +40,11 @@ fn main() {
         .for_each(|(iden, exp)| assert_eq!(iden, exp));
     
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_iden(&Custom::Email("".to_owned()), &mut string);
+    PostgresQueryBuilder.prepare_dyn_iden(&Custom::Email("".to_owned()).into_iden(), &mut string);
     assert_eq!(string, "\"EM`ail\"");
 
     let mut string = String::new();
-    MysqlQueryBuilder.prepare_iden(&Custom::Email("".to_owned()), &mut string);
+    MysqlQueryBuilder.prepare_dyn_iden(&Custom::Email("".to_owned()).into_iden(), &mut string);
     assert_eq!(string, "`EM``ail`");
 
     assert!(matches!(Custom::FirstName.quoted(), Cow::Owned(_)));

--- a/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
+++ b/sea-query-derive/tests/pass/meta_list_renaming_everything.rs
@@ -40,11 +40,11 @@ fn main() {
         .for_each(|(iden, exp)| assert_eq!(iden, exp));
     
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_dyn_iden(&Custom::Email("".to_owned()).into_iden(), &mut string);
+    PostgresQueryBuilder.prepare_iden(&Custom::Email("".to_owned()).into_iden(), &mut string);
     assert_eq!(string, "\"EM`ail\"");
 
     let mut string = String::new();
-    MysqlQueryBuilder.prepare_dyn_iden(&Custom::Email("".to_owned()).into_iden(), &mut string);
+    MysqlQueryBuilder.prepare_iden(&Custom::Email("".to_owned()).into_iden(), &mut string);
     assert_eq!(string, "`EM``ail`");
 
     assert!(matches!(Custom::FirstName.quoted(), Cow::Owned(_)));

--- a/sea-query-derive/tests/pass/simple_unit_struct.rs
+++ b/sea-query-derive/tests/pass/simple_unit_struct.rs
@@ -1,4 +1,4 @@
-use sea_query::{Iden, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
+use sea_query::{Iden, IntoIden, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
 
 #[derive(Copy, Clone, Iden)]
 pub struct SomeType;
@@ -12,14 +12,14 @@ fn main() {
     assert_eq!(SomeTypeWithRename.to_string(), "Hel`lo");
 
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_iden(&SomeType, &mut string);
+    PostgresQueryBuilder.prepare_dyn_iden(&SomeType.into_iden(), &mut string);
     assert_eq!(string, "\"some_type\"");
 
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_iden(&SomeTypeWithRename, &mut string);
+    PostgresQueryBuilder.prepare_dyn_iden(&SomeTypeWithRename.into_iden(), &mut string);
     assert_eq!(string, "\"Hel`lo\"");
 
     let mut string = String::new();
-    MysqlQueryBuilder.prepare_iden(&SomeTypeWithRename, &mut string);
+    MysqlQueryBuilder.prepare_dyn_iden(&SomeTypeWithRename.into_iden(), &mut string);
     assert_eq!(string, "`Hel``lo`");
 }

--- a/sea-query-derive/tests/pass/simple_unit_struct.rs
+++ b/sea-query-derive/tests/pass/simple_unit_struct.rs
@@ -1,4 +1,4 @@
-use sea_query::Iden;
+use sea_query::{Iden, MysqlQueryBuilder, PostgresQueryBuilder, QuotedBuilder};
 
 #[derive(Copy, Clone, Iden)]
 pub struct SomeType;
@@ -12,14 +12,14 @@ fn main() {
     assert_eq!(SomeTypeWithRename.to_string(), "Hel`lo");
 
     let mut string = String::new();
-    SomeType.prepare(&mut string, '"'.into());
+    PostgresQueryBuilder.prepare_iden(&SomeType, &mut string);
     assert_eq!(string, "\"some_type\"");
 
     let mut string = String::new();
-    SomeTypeWithRename.prepare(&mut string, '"'.into());
+    PostgresQueryBuilder.prepare_iden(&SomeTypeWithRename, &mut string);
     assert_eq!(string, "\"Hel`lo\"");
 
     let mut string = String::new();
-    SomeTypeWithRename.prepare(&mut string, b'`'.into());
+    MysqlQueryBuilder.prepare_iden(&SomeTypeWithRename, &mut string);
     assert_eq!(string, "`Hel``lo`");
 }

--- a/sea-query-derive/tests/pass/simple_unit_struct.rs
+++ b/sea-query-derive/tests/pass/simple_unit_struct.rs
@@ -12,14 +12,14 @@ fn main() {
     assert_eq!(SomeTypeWithRename.to_string(), "Hel`lo");
 
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_dyn_iden(&SomeType.into_iden(), &mut string);
+    PostgresQueryBuilder.prepare_iden(&SomeType.into_iden(), &mut string);
     assert_eq!(string, "\"some_type\"");
 
     let mut string = String::new();
-    PostgresQueryBuilder.prepare_dyn_iden(&SomeTypeWithRename.into_iden(), &mut string);
+    PostgresQueryBuilder.prepare_iden(&SomeTypeWithRename.into_iden(), &mut string);
     assert_eq!(string, "\"Hel`lo\"");
 
     let mut string = String::new();
-    MysqlQueryBuilder.prepare_dyn_iden(&SomeTypeWithRename.into_iden(), &mut string);
+    MysqlQueryBuilder.prepare_iden(&SomeTypeWithRename.into_iden(), &mut string);
     assert_eq!(string, "`Hel``lo`");
 }

--- a/src/backend/index_builder.rs
+++ b/src/backend/index_builder.rs
@@ -63,7 +63,7 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
         column: &IndexColumnTableColumn,
         sql: &mut dyn SqlWriter,
     ) {
-        self.prepare_dyn_iden(&column.name, sql);
+        self.prepare_iden(&column.name, sql);
         self.write_column_index_prefix(&column.prefix, sql);
         if let Some(order) = &column.order {
             match order {

--- a/src/backend/index_builder.rs
+++ b/src/backend/index_builder.rs
@@ -63,7 +63,7 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
         column: &IndexColumnTableColumn,
         sql: &mut dyn SqlWriter,
     ) {
-        column.name.prepare(sql.as_writer(), self.quote());
+        self.prepare_dyn_iden(&column.name, sql);
         self.write_column_index_prefix(&column.prefix, sql);
         if let Some(order) = &column.order {
             match order {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -41,7 +41,7 @@ pub trait QuotedBuilder {
     fn quote(&self) -> Quote;
 
     /// To prepare iden and write to SQL.
-    fn prepare_dyn_iden(&self, iden: &DynIden, sql: &mut dyn SqlWriter) {
+    fn prepare_iden(&self, iden: &DynIden, sql: &mut dyn SqlWriter) {
         let q = self.quote();
         let byte = [q.1];
         let qq: &str = std::str::from_utf8(&byte).unwrap();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,6 +1,7 @@
 //! Translating the SQL AST into engine-specific SQL statements.
 
 use crate::*;
+use std::ops::Deref;
 
 #[cfg(feature = "backend-mysql")]
 #[cfg_attr(docsrs, doc(cfg(feature = "backend-mysql")))]
@@ -38,6 +39,16 @@ pub trait SchemaBuilder: TableBuilder + IndexBuilder + ForeignKeyBuilder {}
 pub trait QuotedBuilder {
     /// The type of quote the builder uses.
     fn quote(&self) -> Quote;
+
+    /// To prepare iden and write to SQL.
+    fn prepare_iden(&self, iden: &dyn Iden, sql: &mut dyn SqlWriter) {
+        let q = self.quote();
+        write!(sql, "{}{}{}", q.left(), iden.quoted(q), q.right()).unwrap();
+    }
+
+    fn prepare_dyn_iden(&self, iden: &DynIden, sql: &mut dyn SqlWriter) {
+        self.prepare_iden(iden.deref(), sql);
+    }
 }
 
 pub trait EscapeBuilder {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,7 +1,7 @@
 //! Translating the SQL AST into engine-specific SQL statements.
 
 use crate::*;
-use std::{borrow::Cow, ops::Deref};
+use std::borrow::Cow;
 
 #[cfg(feature = "backend-mysql")]
 #[cfg_attr(docsrs, doc(cfg(feature = "backend-mysql")))]
@@ -41,13 +41,13 @@ pub trait QuotedBuilder {
     fn quote(&self) -> Quote;
 
     /// To prepare iden and write to SQL.
-    fn prepare_iden(&self, iden: &dyn Iden, sql: &mut dyn SqlWriter) {
+    fn prepare_dyn_iden(&self, iden: &DynIden, sql: &mut dyn SqlWriter) {
         let q = self.quote();
         let byte = [q.1];
         let qq: &str = std::str::from_utf8(&byte).unwrap();
 
         let string;
-        let quoted = match iden.quoted() {
+        let quoted: &str = match &iden.0 {
             Cow::Borrowed(s) => s,
             Cow::Owned(s) => {
                 string = s.replace(qq, qq.repeat(2).as_str());
@@ -55,10 +55,6 @@ pub trait QuotedBuilder {
             }
         };
         write!(sql, "{}{}{}", q.left(), quoted, q.right()).unwrap();
-    }
-
-    fn prepare_dyn_iden(&self, iden: &DynIden, sql: &mut dyn SqlWriter) {
-        self.prepare_iden(iden.deref(), sql);
     }
 }
 

--- a/src/backend/mysql/foreign_key.rs
+++ b/src/backend/mysql/foreign_key.rs
@@ -71,7 +71,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            self.prepare_dyn_iden(col, sql);
+            self.prepare_iden(col, sql);
             false
         });
         write!(sql, ")").unwrap();
@@ -91,7 +91,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                self.prepare_dyn_iden(col, sql);
+                self.prepare_iden(col, sql);
                 false
             });
         write!(sql, ")").unwrap();

--- a/src/backend/mysql/foreign_key.rs
+++ b/src/backend/mysql/foreign_key.rs
@@ -71,7 +71,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            col.prepare(sql.as_writer(), self.quote());
+            self.prepare_dyn_iden(col, sql);
             false
         });
         write!(sql, ")").unwrap();
@@ -91,7 +91,7 @@ impl ForeignKeyBuilder for MysqlQueryBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                col.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(col, sql);
                 false
             });
         write!(sql, ")").unwrap();

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -28,19 +28,19 @@ impl QueryBuilder for MysqlQueryBuilder {
                     write!(sql, "USE INDEX ",).unwrap();
                     self.prepare_index_hint_scope(&hint.scope, sql);
                     write!(sql, "(").unwrap();
-                    self.prepare_dyn_iden(&hint.index, sql);
+                    self.prepare_iden(&hint.index, sql);
                 }
                 IndexHintType::Ignore => {
                     write!(sql, "IGNORE INDEX ",).unwrap();
                     self.prepare_index_hint_scope(&hint.scope, sql);
                     write!(sql, "(").unwrap();
-                    self.prepare_dyn_iden(&hint.index, sql);
+                    self.prepare_iden(&hint.index, sql);
                 }
                 IndexHintType::Force => {
                     write!(sql, "FORCE INDEX ",).unwrap();
                     self.prepare_index_hint_scope(&hint.scope, sql);
                     write!(sql, "(").unwrap();
-                    self.prepare_dyn_iden(&hint.index, sql);
+                    self.prepare_iden(&hint.index, sql);
                 }
             }
             write!(sql, ")").unwrap();
@@ -93,7 +93,7 @@ impl QueryBuilder for MysqlQueryBuilder {
         use std::ops::Deref;
 
         if from.is_empty() {
-            self.prepare_dyn_iden(column, sql);
+            self.prepare_iden(column, sql);
         } else {
             if let Some(table) = table {
                 if let TableRef::Table(table) = table.deref() {
@@ -104,7 +104,7 @@ impl QueryBuilder for MysqlQueryBuilder {
                     return;
                 }
             }
-            self.prepare_dyn_iden(column, sql);
+            self.prepare_iden(column, sql);
         }
     }
 
@@ -166,9 +166,9 @@ impl QueryBuilder for MysqlQueryBuilder {
                         if !first {
                             write!(sql, ", ").unwrap()
                         }
-                        self.prepare_dyn_iden(pk_col, sql);
+                        self.prepare_iden(pk_col, sql);
                         write!(sql, " = ").unwrap();
-                        self.prepare_dyn_iden(pk_col, sql);
+                        self.prepare_iden(pk_col, sql);
                         false
                     });
                 } else {
@@ -189,7 +189,7 @@ impl QueryBuilder for MysqlQueryBuilder {
 
     fn prepare_on_conflict_excluded_table(&self, col: &DynIden, sql: &mut dyn SqlWriter) {
         write!(sql, "VALUES(").unwrap();
-        self.prepare_dyn_iden(col, sql);
+        self.prepare_iden(col, sql);
         write!(sql, ")").unwrap();
     }
 

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -28,19 +28,19 @@ impl QueryBuilder for MysqlQueryBuilder {
                     write!(sql, "USE INDEX ",).unwrap();
                     self.prepare_index_hint_scope(&hint.scope, sql);
                     write!(sql, "(").unwrap();
-                    hint.index.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(&hint.index, sql);
                 }
                 IndexHintType::Ignore => {
                     write!(sql, "IGNORE INDEX ",).unwrap();
                     self.prepare_index_hint_scope(&hint.scope, sql);
                     write!(sql, "(").unwrap();
-                    hint.index.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(&hint.index, sql);
                 }
                 IndexHintType::Force => {
                     write!(sql, "FORCE INDEX ",).unwrap();
                     self.prepare_index_hint_scope(&hint.scope, sql);
                     write!(sql, "(").unwrap();
-                    hint.index.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(&hint.index, sql);
                 }
             }
             write!(sql, ")").unwrap();
@@ -93,7 +93,7 @@ impl QueryBuilder for MysqlQueryBuilder {
         use std::ops::Deref;
 
         if from.is_empty() {
-            column.prepare(sql.as_writer(), self.quote());
+            self.prepare_dyn_iden(column, sql);
         } else {
             if let Some(table) = table {
                 if let TableRef::Table(table) = table.deref() {
@@ -104,7 +104,7 @@ impl QueryBuilder for MysqlQueryBuilder {
                     return;
                 }
             }
-            column.prepare(sql.as_writer(), self.quote());
+            self.prepare_dyn_iden(column, sql);
         }
     }
 
@@ -166,9 +166,9 @@ impl QueryBuilder for MysqlQueryBuilder {
                         if !first {
                             write!(sql, ", ").unwrap()
                         }
-                        pk_col.prepare(sql.as_writer(), self.quote());
+                        self.prepare_dyn_iden(pk_col, sql);
                         write!(sql, " = ").unwrap();
-                        pk_col.prepare(sql.as_writer(), self.quote());
+                        self.prepare_dyn_iden(pk_col, sql);
                         false
                     });
                 } else {
@@ -189,7 +189,7 @@ impl QueryBuilder for MysqlQueryBuilder {
 
     fn prepare_on_conflict_excluded_table(&self, col: &DynIden, sql: &mut dyn SqlWriter) {
         write!(sql, "VALUES(").unwrap();
-        col.prepare(sql.as_writer(), self.quote());
+        self.prepare_dyn_iden(col, sql);
         write!(sql, ")").unwrap();
     }
 

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -11,7 +11,7 @@ impl TableBuilder for MysqlQueryBuilder {
     }
 
     fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter) {
-        column_def.name.prepare(sql.as_writer(), self.quote());
+        self.prepare_dyn_iden(&column_def.name, sql);
 
         if let Some(column_type) = &column_def.types {
             write!(sql, " ").unwrap();
@@ -144,13 +144,13 @@ impl TableBuilder for MysqlQueryBuilder {
                 }
                 TableAlterOption::RenameColumn(from_name, to_name) => {
                     write!(sql, "RENAME COLUMN ").unwrap();
-                    from_name.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(from_name, sql);
                     write!(sql, " TO ").unwrap();
-                    to_name.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(to_name, sql);
                 }
                 TableAlterOption::DropColumn(column_name) => {
                     write!(sql, "DROP COLUMN ").unwrap();
-                    column_name.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(column_name, sql);
                 }
                 TableAlterOption::DropForeignKey(name) => {
                     let mut foreign_key = TableForeignKey::new();

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -11,7 +11,7 @@ impl TableBuilder for MysqlQueryBuilder {
     }
 
     fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter) {
-        self.prepare_dyn_iden(&column_def.name, sql);
+        self.prepare_iden(&column_def.name, sql);
 
         if let Some(column_type) = &column_def.types {
             write!(sql, " ").unwrap();
@@ -144,13 +144,13 @@ impl TableBuilder for MysqlQueryBuilder {
                 }
                 TableAlterOption::RenameColumn(from_name, to_name) => {
                     write!(sql, "RENAME COLUMN ").unwrap();
-                    self.prepare_dyn_iden(from_name, sql);
+                    self.prepare_iden(from_name, sql);
                     write!(sql, " TO ").unwrap();
-                    self.prepare_dyn_iden(to_name, sql);
+                    self.prepare_iden(to_name, sql);
                 }
                 TableAlterOption::DropColumn(column_name) => {
                     write!(sql, "DROP COLUMN ").unwrap();
-                    self.prepare_dyn_iden(column_name, sql);
+                    self.prepare_iden(column_name, sql);
                 }
                 TableAlterOption::DropForeignKey(name) => {
                     let mut foreign_key = TableForeignKey::new();

--- a/src/backend/postgres/foreign_key.rs
+++ b/src/backend/postgres/foreign_key.rs
@@ -63,7 +63,7 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            self.prepare_dyn_iden(col, sql);
+            self.prepare_iden(col, sql);
             false
         });
         write!(sql, ")").unwrap();
@@ -83,7 +83,7 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                self.prepare_dyn_iden(col, sql);
+                self.prepare_iden(col, sql);
                 false
             });
         write!(sql, ")").unwrap();

--- a/src/backend/postgres/foreign_key.rs
+++ b/src/backend/postgres/foreign_key.rs
@@ -63,7 +63,7 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            col.prepare(sql.as_writer(), self.quote());
+            self.prepare_dyn_iden(col, sql);
             false
         });
         write!(sql, ")").unwrap();
@@ -83,7 +83,7 @@ impl ForeignKeyBuilder for PostgresQueryBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                col.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(col, sql);
                 false
             });
         write!(sql, ")").unwrap();

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -173,7 +173,7 @@ impl IndexBuilder for PostgresQueryBuilder {
 }
 
 impl PostgresQueryBuilder {
-    fn prepare_include_columns(&self, columns: &[SeaRc<dyn Iden>], sql: &mut dyn SqlWriter) {
+    fn prepare_include_columns(&self, columns: &[DynIden], sql: &mut dyn SqlWriter) {
         write!(sql, "INCLUDE (").unwrap();
         columns.iter().fold(true, |first, col| {
             if !first {

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -97,7 +97,7 @@ impl IndexBuilder for PostgresQueryBuilder {
             match table {
                 TableRef::Table(_) => {}
                 TableRef::SchemaTable(schema, _) => {
-                    schema.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(schema, sql);
                     write!(sql, ".").unwrap();
                 }
                 _ => panic!("Not supported"),
@@ -179,7 +179,7 @@ impl PostgresQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            col.prepare(sql.as_writer(), self.quote());
+            self.prepare_dyn_iden(col, sql);
             false
         });
         write!(sql, ")").unwrap();

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -97,7 +97,7 @@ impl IndexBuilder for PostgresQueryBuilder {
             match table {
                 TableRef::Table(_) => {}
                 TableRef::SchemaTable(schema, _) => {
-                    self.prepare_dyn_iden(schema, sql);
+                    self.prepare_iden(schema, sql);
                     write!(sql, ".").unwrap();
                 }
                 _ => panic!("Not supported"),
@@ -179,7 +179,7 @@ impl PostgresQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            self.prepare_dyn_iden(col, sql);
+            self.prepare_iden(col, sql);
             false
         });
         write!(sql, ")").unwrap();

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -133,7 +133,7 @@ impl TableBuilder for PostgresQueryBuilder {
                 TableAlterOption::ModifyColumn(column_def) => {
                     if let Some(column_type) = &column_def.types {
                         write!(sql, "ALTER COLUMN ").unwrap();
-                        column_def.name.prepare(sql.as_writer(), self.quote());
+                        self.prepare_dyn_iden(&column_def.name, sql);
                         write!(sql, " TYPE ").unwrap();
                         self.prepare_column_type(column_type, sql);
                     }
@@ -154,28 +154,28 @@ impl TableBuilder for PostgresQueryBuilder {
                             ColumnSpec::AutoIncrement => {}
                             ColumnSpec::Null => {
                                 write!(sql, "ALTER COLUMN ").unwrap();
-                                column_def.name.prepare(sql.as_writer(), self.quote());
+                                self.prepare_dyn_iden(&column_def.name, sql);
                                 write!(sql, " DROP NOT NULL").unwrap();
                             }
                             ColumnSpec::NotNull => {
                                 write!(sql, "ALTER COLUMN ").unwrap();
-                                column_def.name.prepare(sql.as_writer(), self.quote());
+                                self.prepare_dyn_iden(&column_def.name, sql);
                                 write!(sql, " SET NOT NULL").unwrap()
                             }
                             ColumnSpec::Default(v) => {
                                 write!(sql, "ALTER COLUMN ").unwrap();
-                                column_def.name.prepare(sql.as_writer(), self.quote());
+                                self.prepare_dyn_iden(&column_def.name, sql);
                                 write!(sql, " SET DEFAULT ").unwrap();
                                 QueryBuilder::prepare_simple_expr(self, v, sql);
                             }
                             ColumnSpec::UniqueKey => {
                                 write!(sql, "ADD UNIQUE (").unwrap();
-                                column_def.name.prepare(sql.as_writer(), self.quote());
+                                self.prepare_dyn_iden(&column_def.name, sql);
                                 write!(sql, ")").unwrap();
                             }
                             ColumnSpec::PrimaryKey => {
                                 write!(sql, "ADD PRIMARY KEY (").unwrap();
-                                column_def.name.prepare(sql.as_writer(), self.quote());
+                                self.prepare_dyn_iden(&column_def.name, sql);
                                 write!(sql, ")").unwrap();
                             }
                             ColumnSpec::Check(check) => self.prepare_check_constraint(check, sql),
@@ -192,13 +192,13 @@ impl TableBuilder for PostgresQueryBuilder {
                 }
                 TableAlterOption::RenameColumn(from_name, to_name) => {
                     write!(sql, "RENAME COLUMN ").unwrap();
-                    from_name.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(from_name, sql);
                     write!(sql, " TO ").unwrap();
-                    to_name.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(to_name, sql);
                 }
                 TableAlterOption::DropColumn(column_name) => {
                     write!(sql, "DROP COLUMN ").unwrap();
-                    column_name.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(column_name, sql);
                 }
                 TableAlterOption::DropForeignKey(name) => {
                     let mut foreign_key = TableForeignKey::new();
@@ -274,7 +274,7 @@ impl PostgresQueryBuilder {
     where
         F: Fn(&ColumnDef, &mut dyn SqlWriter),
     {
-        column_def.name.prepare(sql.as_writer(), self.quote());
+        self.prepare_dyn_iden(&column_def.name, sql);
 
         f(column_def, sql);
 

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -133,7 +133,7 @@ impl TableBuilder for PostgresQueryBuilder {
                 TableAlterOption::ModifyColumn(column_def) => {
                     if let Some(column_type) = &column_def.types {
                         write!(sql, "ALTER COLUMN ").unwrap();
-                        self.prepare_dyn_iden(&column_def.name, sql);
+                        self.prepare_iden(&column_def.name, sql);
                         write!(sql, " TYPE ").unwrap();
                         self.prepare_column_type(column_type, sql);
                     }
@@ -154,28 +154,28 @@ impl TableBuilder for PostgresQueryBuilder {
                             ColumnSpec::AutoIncrement => {}
                             ColumnSpec::Null => {
                                 write!(sql, "ALTER COLUMN ").unwrap();
-                                self.prepare_dyn_iden(&column_def.name, sql);
+                                self.prepare_iden(&column_def.name, sql);
                                 write!(sql, " DROP NOT NULL").unwrap();
                             }
                             ColumnSpec::NotNull => {
                                 write!(sql, "ALTER COLUMN ").unwrap();
-                                self.prepare_dyn_iden(&column_def.name, sql);
+                                self.prepare_iden(&column_def.name, sql);
                                 write!(sql, " SET NOT NULL").unwrap()
                             }
                             ColumnSpec::Default(v) => {
                                 write!(sql, "ALTER COLUMN ").unwrap();
-                                self.prepare_dyn_iden(&column_def.name, sql);
+                                self.prepare_iden(&column_def.name, sql);
                                 write!(sql, " SET DEFAULT ").unwrap();
                                 QueryBuilder::prepare_simple_expr(self, v, sql);
                             }
                             ColumnSpec::UniqueKey => {
                                 write!(sql, "ADD UNIQUE (").unwrap();
-                                self.prepare_dyn_iden(&column_def.name, sql);
+                                self.prepare_iden(&column_def.name, sql);
                                 write!(sql, ")").unwrap();
                             }
                             ColumnSpec::PrimaryKey => {
                                 write!(sql, "ADD PRIMARY KEY (").unwrap();
-                                self.prepare_dyn_iden(&column_def.name, sql);
+                                self.prepare_iden(&column_def.name, sql);
                                 write!(sql, ")").unwrap();
                             }
                             ColumnSpec::Check(check) => self.prepare_check_constraint(check, sql),
@@ -192,13 +192,13 @@ impl TableBuilder for PostgresQueryBuilder {
                 }
                 TableAlterOption::RenameColumn(from_name, to_name) => {
                     write!(sql, "RENAME COLUMN ").unwrap();
-                    self.prepare_dyn_iden(from_name, sql);
+                    self.prepare_iden(from_name, sql);
                     write!(sql, " TO ").unwrap();
-                    self.prepare_dyn_iden(to_name, sql);
+                    self.prepare_iden(to_name, sql);
                 }
                 TableAlterOption::DropColumn(column_name) => {
                     write!(sql, "DROP COLUMN ").unwrap();
-                    self.prepare_dyn_iden(column_name, sql);
+                    self.prepare_iden(column_name, sql);
                 }
                 TableAlterOption::DropForeignKey(name) => {
                     let mut foreign_key = TableForeignKey::new();
@@ -274,7 +274,7 @@ impl PostgresQueryBuilder {
     where
         F: Fn(&ColumnDef, &mut dyn SqlWriter),
     {
-        self.prepare_dyn_iden(&column_def.name, sql);
+        self.prepare_iden(&column_def.name, sql);
 
         f(column_def, sql);
 

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -721,7 +721,7 @@ pub trait QueryBuilder:
     /// Translate [`Function`] into SQL statement.
     fn prepare_function_name_common(&self, function: &Function, sql: &mut dyn SqlWriter) {
         if let Function::Custom(iden) = function {
-            iden.unquoted(sql.as_writer());
+            write!(sql, "{}", iden.unquoted()).unwrap()
         } else {
             write!(
                 sql,
@@ -1047,7 +1047,7 @@ pub trait QueryBuilder:
             Keyword::CurrentDate => write!(sql, "CURRENT_DATE").unwrap(),
             Keyword::CurrentTime => write!(sql, "CURRENT_TIME").unwrap(),
             Keyword::CurrentTimestamp => write!(sql, "CURRENT_TIMESTAMP").unwrap(),
-            Keyword::Custom(iden) => iden.unquoted(sql.as_writer()),
+            Keyword::Custom(iden) => write!(sql, "{}", iden.unquoted()).unwrap(),
         }
     }
 

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -724,7 +724,7 @@ pub trait QueryBuilder:
     /// Translate [`Function`] into SQL statement.
     fn prepare_function_name_common(&self, function: &Function, sql: &mut dyn SqlWriter) {
         if let Function::Custom(iden) = function {
-            write!(sql, "{}", iden.unquoted()).unwrap()
+            write!(sql, "{}", iden).unwrap()
         } else {
             write!(
                 sql,
@@ -1032,7 +1032,7 @@ pub trait QueryBuilder:
             Keyword::CurrentDate => write!(sql, "CURRENT_DATE").unwrap(),
             Keyword::CurrentTime => write!(sql, "CURRENT_TIME").unwrap(),
             Keyword::CurrentTimestamp => write!(sql, "CURRENT_TIMESTAMP").unwrap(),
-            Keyword::Custom(iden) => write!(sql, "{}", iden.unquoted()).unwrap(),
+            Keyword::Custom(iden) => write!(sql, "{}", iden).unwrap(),
         }
     }
 

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -45,7 +45,7 @@ pub trait QueryBuilder:
                 if !first {
                     write!(sql, ", ").unwrap()
                 }
-                self.prepare_dyn_iden(col, sql);
+                self.prepare_iden(col, sql);
                 false
             });
             write!(sql, ")").unwrap();
@@ -183,7 +183,7 @@ pub trait QueryBuilder:
 
         if let Some((name, query)) = &select.window {
             write!(sql, " WINDOW ").unwrap();
-            self.prepare_dyn_iden(name, sql);
+            self.prepare_iden(name, sql);
             write!(sql, " AS ").unwrap();
             self.prepare_window_statement(query, sql);
         }
@@ -271,7 +271,7 @@ pub trait QueryBuilder:
         column: &DynIden,
         sql: &mut dyn SqlWriter,
     ) {
-        self.prepare_dyn_iden(column, sql);
+        self.prepare_iden(column, sql);
     }
 
     fn prepare_update_condition(
@@ -454,7 +454,7 @@ pub trait QueryBuilder:
                 self.prepare_constant(val, sql);
             }
             Expr::TypeName(iden) => {
-                self.prepare_dyn_iden(iden, sql);
+                self.prepare_iden(iden, sql);
             }
         }
     }
@@ -532,7 +532,7 @@ pub trait QueryBuilder:
         match &select_expr.window {
             Some(WindowSelectType::Name(name)) => {
                 write!(sql, " OVER ").unwrap();
-                self.prepare_dyn_iden(name, sql);
+                self.prepare_iden(name, sql);
             }
             Some(WindowSelectType::Query(window)) => {
                 write!(sql, " OVER ").unwrap();
@@ -545,7 +545,7 @@ pub trait QueryBuilder:
 
         if let Some(alias) = &select_expr.alias {
             write!(sql, " AS ").unwrap();
-            self.prepare_dyn_iden(alias, sql);
+            self.prepare_iden(alias, sql);
         };
     }
 
@@ -574,20 +574,20 @@ pub trait QueryBuilder:
                 self.prepare_select_statement(query, sql);
                 write!(sql, ")").unwrap();
                 write!(sql, " AS ").unwrap();
-                self.prepare_dyn_iden(alias, sql);
+                self.prepare_iden(alias, sql);
             }
             TableRef::ValuesList(values, alias) => {
                 write!(sql, "(").unwrap();
                 self.prepare_values_list(values, sql);
                 write!(sql, ")").unwrap();
                 write!(sql, " AS ").unwrap();
-                self.prepare_dyn_iden(alias, sql);
+                self.prepare_iden(alias, sql);
             }
             TableRef::FunctionCall(func, alias) => {
                 self.prepare_function_name(&func.func, sql);
                 self.prepare_function_arguments(func, sql);
                 write!(sql, " AS ").unwrap();
-                self.prepare_dyn_iden(alias, sql);
+                self.prepare_iden(alias, sql);
             }
             _ => self.prepare_table_ref_iden(table_ref, sql),
         }
@@ -595,24 +595,24 @@ pub trait QueryBuilder:
 
     fn prepare_column_ref(&self, column_ref: &ColumnRef, sql: &mut dyn SqlWriter) {
         match column_ref {
-            ColumnRef::Column(column) => self.prepare_dyn_iden(column, sql),
+            ColumnRef::Column(column) => self.prepare_iden(column, sql),
             ColumnRef::TableColumn(table, column) => {
-                self.prepare_dyn_iden(table, sql);
+                self.prepare_iden(table, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(column, sql);
+                self.prepare_iden(column, sql);
             }
             ColumnRef::SchemaTableColumn(schema, table, column) => {
-                self.prepare_dyn_iden(schema, sql);
+                self.prepare_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(table, sql);
+                self.prepare_iden(table, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(column, sql);
+                self.prepare_iden(column, sql);
             }
             ColumnRef::Asterisk => {
                 write!(sql, "*").unwrap();
             }
             ColumnRef::TableAsterisk(table) => {
-                self.prepare_dyn_iden(table, sql);
+                self.prepare_iden(table, sql);
                 write!(sql, ".*").unwrap();
             }
         };
@@ -809,7 +809,7 @@ pub trait QueryBuilder:
 
                 write!(sql, " SET ").unwrap();
 
-                self.prepare_dyn_iden(search.expr.as_ref().unwrap().alias.as_ref().unwrap(), sql);
+                self.prepare_iden(search.expr.as_ref().unwrap().alias.as_ref().unwrap(), sql);
                 write!(sql, " ").unwrap();
             }
             if let Some(cycle) = &with_clause.cycle {
@@ -819,9 +819,9 @@ pub trait QueryBuilder:
 
                 write!(sql, " SET ").unwrap();
 
-                self.prepare_dyn_iden(cycle.set_as.as_ref().unwrap(), sql);
+                self.prepare_iden(cycle.set_as.as_ref().unwrap(), sql);
                 write!(sql, " USING ").unwrap();
-                self.prepare_dyn_iden(cycle.using.as_ref().unwrap(), sql);
+                self.prepare_iden(cycle.using.as_ref().unwrap(), sql);
                 write!(sql, " ").unwrap();
             }
         }
@@ -850,7 +850,7 @@ pub trait QueryBuilder:
         cte: &CommonTableExpression,
         sql: &mut dyn SqlWriter,
     ) {
-        self.prepare_dyn_iden(cte.table_name.as_ref().unwrap(), sql);
+        self.prepare_iden(cte.table_name.as_ref().unwrap(), sql);
 
         if cte.cols.is_empty() {
             write!(sql, " ").unwrap();
@@ -863,7 +863,7 @@ pub trait QueryBuilder:
                     write!(sql, ", ").unwrap();
                 }
                 col_first = false;
-                self.prepare_dyn_iden(col, sql);
+                self.prepare_iden(col, sql);
             }
 
             write!(sql, ") ").unwrap();
@@ -1222,7 +1222,7 @@ pub trait QueryBuilder:
             }
             match target {
                 OnConflictTarget::ConflictColumn(col) => {
-                    self.prepare_dyn_iden(col, sql);
+                    self.prepare_iden(col, sql);
                 }
 
                 OnConflictTarget::ConflictExpr(expr) => {
@@ -1262,12 +1262,12 @@ pub trait QueryBuilder:
                         }
                         match update_strat {
                             OnConflictUpdate::Column(col) => {
-                                self.prepare_dyn_iden(col, sql);
+                                self.prepare_iden(col, sql);
                                 write!(sql, " = ").unwrap();
                                 self.prepare_on_conflict_excluded_table(col, sql);
                             }
                             OnConflictUpdate::Expr(col, expr) => {
-                                self.prepare_dyn_iden(col, sql);
+                                self.prepare_iden(col, sql);
                                 write!(sql, " = ").unwrap();
                                 self.prepare_simple_expr(expr, sql);
                             }
@@ -1302,7 +1302,7 @@ pub trait QueryBuilder:
         )
         .unwrap();
         write!(sql, ".").unwrap();
-        self.prepare_dyn_iden(col, sql);
+        self.prepare_iden(col, sql);
     }
 
     #[doc(hidden)]

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -45,7 +45,7 @@ pub trait QueryBuilder:
                 if !first {
                     write!(sql, ", ").unwrap()
                 }
-                col.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(col, sql);
                 false
             });
             write!(sql, ")").unwrap();
@@ -183,7 +183,7 @@ pub trait QueryBuilder:
 
         if let Some((name, query)) = &select.window {
             write!(sql, " WINDOW ").unwrap();
-            name.prepare(sql.as_writer(), self.quote());
+            self.prepare_dyn_iden(name, sql);
             write!(sql, " AS ").unwrap();
             self.prepare_window_statement(query, sql);
         }
@@ -271,7 +271,7 @@ pub trait QueryBuilder:
         column: &DynIden,
         sql: &mut dyn SqlWriter,
     ) {
-        column.prepare(sql.as_writer(), self.quote());
+        self.prepare_dyn_iden(column, sql);
     }
 
     fn prepare_update_condition(
@@ -453,6 +453,9 @@ pub trait QueryBuilder:
             Expr::Constant(val) => {
                 self.prepare_constant(val, sql);
             }
+            Expr::TypeName(iden) => {
+                self.prepare_dyn_iden(iden, sql);
+            }
         }
     }
 
@@ -529,7 +532,7 @@ pub trait QueryBuilder:
         match &select_expr.window {
             Some(WindowSelectType::Name(name)) => {
                 write!(sql, " OVER ").unwrap();
-                name.prepare(sql.as_writer(), self.quote())
+                self.prepare_dyn_iden(name, sql);
             }
             Some(WindowSelectType::Query(window)) => {
                 write!(sql, " OVER ").unwrap();
@@ -542,7 +545,7 @@ pub trait QueryBuilder:
 
         if let Some(alias) = &select_expr.alias {
             write!(sql, " AS ").unwrap();
-            alias.prepare(sql.as_writer(), self.quote());
+            self.prepare_dyn_iden(alias, sql);
         };
     }
 
@@ -571,20 +574,20 @@ pub trait QueryBuilder:
                 self.prepare_select_statement(query, sql);
                 write!(sql, ")").unwrap();
                 write!(sql, " AS ").unwrap();
-                alias.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(alias, sql);
             }
             TableRef::ValuesList(values, alias) => {
                 write!(sql, "(").unwrap();
                 self.prepare_values_list(values, sql);
                 write!(sql, ")").unwrap();
                 write!(sql, " AS ").unwrap();
-                alias.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(alias, sql);
             }
             TableRef::FunctionCall(func, alias) => {
                 self.prepare_function_name(&func.func, sql);
                 self.prepare_function_arguments(func, sql);
                 write!(sql, " AS ").unwrap();
-                alias.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(alias, sql);
             }
             _ => self.prepare_table_ref_iden(table_ref, sql),
         }
@@ -592,24 +595,24 @@ pub trait QueryBuilder:
 
     fn prepare_column_ref(&self, column_ref: &ColumnRef, sql: &mut dyn SqlWriter) {
         match column_ref {
-            ColumnRef::Column(column) => column.prepare(sql.as_writer(), self.quote()),
+            ColumnRef::Column(column) => self.prepare_dyn_iden(column, sql),
             ColumnRef::TableColumn(table, column) => {
-                table.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(table, sql);
                 write!(sql, ".").unwrap();
-                column.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(column, sql);
             }
             ColumnRef::SchemaTableColumn(schema, table, column) => {
-                schema.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                table.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(table, sql);
                 write!(sql, ".").unwrap();
-                column.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(column, sql);
             }
             ColumnRef::Asterisk => {
                 write!(sql, "*").unwrap();
             }
             ColumnRef::TableAsterisk(table) => {
-                table.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(table, sql);
                 write!(sql, ".*").unwrap();
             }
         };
@@ -806,14 +809,7 @@ pub trait QueryBuilder:
 
                 write!(sql, " SET ").unwrap();
 
-                search
-                    .expr
-                    .as_ref()
-                    .unwrap()
-                    .alias
-                    .as_ref()
-                    .unwrap()
-                    .prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(search.expr.as_ref().unwrap().alias.as_ref().unwrap(), sql);
                 write!(sql, " ").unwrap();
             }
             if let Some(cycle) = &with_clause.cycle {
@@ -823,17 +819,9 @@ pub trait QueryBuilder:
 
                 write!(sql, " SET ").unwrap();
 
-                cycle
-                    .set_as
-                    .as_ref()
-                    .unwrap()
-                    .prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(cycle.set_as.as_ref().unwrap(), sql);
                 write!(sql, " USING ").unwrap();
-                cycle
-                    .using
-                    .as_ref()
-                    .unwrap()
-                    .prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(cycle.using.as_ref().unwrap(), sql);
                 write!(sql, " ").unwrap();
             }
         }
@@ -862,10 +850,7 @@ pub trait QueryBuilder:
         cte: &CommonTableExpression,
         sql: &mut dyn SqlWriter,
     ) {
-        cte.table_name
-            .as_ref()
-            .unwrap()
-            .prepare(sql.as_writer(), self.quote());
+        self.prepare_dyn_iden(cte.table_name.as_ref().unwrap(), sql);
 
         if cte.cols.is_empty() {
             write!(sql, " ").unwrap();
@@ -878,7 +863,7 @@ pub trait QueryBuilder:
                     write!(sql, ", ").unwrap();
                 }
                 col_first = false;
-                col.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(col, sql);
             }
 
             write!(sql, ") ").unwrap();
@@ -1237,7 +1222,7 @@ pub trait QueryBuilder:
             }
             match target {
                 OnConflictTarget::ConflictColumn(col) => {
-                    col.prepare(sql.as_writer(), self.quote());
+                    self.prepare_dyn_iden(col, sql);
                 }
 
                 OnConflictTarget::ConflictExpr(expr) => {
@@ -1277,12 +1262,12 @@ pub trait QueryBuilder:
                         }
                         match update_strat {
                             OnConflictUpdate::Column(col) => {
-                                col.prepare(sql.as_writer(), self.quote());
+                                self.prepare_dyn_iden(col, sql);
                                 write!(sql, " = ").unwrap();
                                 self.prepare_on_conflict_excluded_table(col, sql);
                             }
                             OnConflictUpdate::Expr(col, expr) => {
-                                col.prepare(sql.as_writer(), self.quote());
+                                self.prepare_dyn_iden(col, sql);
                                 write!(sql, " = ").unwrap();
                                 self.prepare_simple_expr(expr, sql);
                             }
@@ -1317,7 +1302,7 @@ pub trait QueryBuilder:
         )
         .unwrap();
         write!(sql, ".").unwrap();
-        col.prepare(sql.as_writer(), self.quote());
+        self.prepare_dyn_iden(col, sql);
     }
 
     #[doc(hidden)]
@@ -1655,7 +1640,8 @@ pub(crate) fn common_inner_expr_well_known_greater_precedence(
         | Expr::Value(_)
         | Expr::Keyword(_)
         | Expr::Case(_)
-        | Expr::SubQuery(_, _) => true,
+        | Expr::SubQuery(_, _)
+        | Expr::TypeName(_) => true,
         Expr::Binary(_, inner_oper, _) => {
             #[cfg(feature = "option-more-parentheses")]
             {

--- a/src/backend/sqlite/foreign_key.rs
+++ b/src/backend/sqlite/foreign_key.rs
@@ -50,7 +50,7 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            self.prepare_dyn_iden(col, sql);
+            self.prepare_iden(col, sql);
             false
         });
         write!(sql, ")").unwrap();
@@ -68,7 +68,7 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                self.prepare_dyn_iden(col, sql);
+                self.prepare_iden(col, sql);
                 false
             });
         write!(sql, ")").unwrap();

--- a/src/backend/sqlite/foreign_key.rs
+++ b/src/backend/sqlite/foreign_key.rs
@@ -50,7 +50,7 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
             if !first {
                 write!(sql, ", ").unwrap();
             }
-            col.prepare(sql.as_writer(), self.quote());
+            self.prepare_dyn_iden(col, sql);
             false
         });
         write!(sql, ")").unwrap();
@@ -68,7 +68,7 @@ impl ForeignKeyBuilder for SqliteQueryBuilder {
                 if !first {
                     write!(sql, ", ").unwrap();
                 }
-                col.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(col, sql);
                 false
             });
         write!(sql, ")").unwrap();

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl TableBuilder for SqliteQueryBuilder {
     fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter) {
-        self.prepare_dyn_iden(&column_def.name, sql);
+        self.prepare_iden(&column_def.name, sql);
 
         if let Some(column_type) = &column_def.types {
             write!(sql, " ").unwrap();
@@ -83,13 +83,13 @@ impl TableBuilder for SqliteQueryBuilder {
             }
             TableAlterOption::RenameColumn(from_name, to_name) => {
                 write!(sql, "RENAME COLUMN ").unwrap();
-                self.prepare_dyn_iden(from_name, sql);
+                self.prepare_iden(from_name, sql);
                 write!(sql, " TO ").unwrap();
-                self.prepare_dyn_iden(to_name, sql);
+                self.prepare_iden(to_name, sql);
             }
             TableAlterOption::DropColumn(col_name) => {
                 write!(sql, "DROP COLUMN ").unwrap();
-                self.prepare_dyn_iden(col_name, sql);
+                self.prepare_iden(col_name, sql);
             }
             TableAlterOption::DropForeignKey(_) => {
                 panic!(

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl TableBuilder for SqliteQueryBuilder {
     fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut dyn SqlWriter) {
-        column_def.name.prepare(sql.as_writer(), self.quote());
+        self.prepare_dyn_iden(&column_def.name, sql);
 
         if let Some(column_type) = &column_def.types {
             write!(sql, " ").unwrap();
@@ -83,13 +83,13 @@ impl TableBuilder for SqliteQueryBuilder {
             }
             TableAlterOption::RenameColumn(from_name, to_name) => {
                 write!(sql, "RENAME COLUMN ").unwrap();
-                from_name.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(from_name, sql);
                 write!(sql, " TO ").unwrap();
-                to_name.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(to_name, sql);
             }
             TableAlterOption::DropColumn(col_name) => {
                 write!(sql, "DROP COLUMN ").unwrap();
-                col_name.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(col_name, sql);
             }
             TableAlterOption::DropForeignKey(_) => {
                 panic!(

--- a/src/backend/table_ref_builder.rs
+++ b/src/backend/table_ref_builder.rs
@@ -5,40 +5,40 @@ pub trait TableRefBuilder: QuotedBuilder {
     fn prepare_table_ref_iden(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(iden) => {
-                iden.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(iden, sql);
             }
             TableRef::SchemaTable(schema, table) => {
-                schema.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                table.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(table, sql);
             }
             TableRef::DatabaseSchemaTable(database, schema, table) => {
-                database.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(database, sql);
                 write!(sql, ".").unwrap();
-                schema.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                table.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(table, sql);
             }
             TableRef::TableAlias(iden, alias) => {
-                iden.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(iden, sql);
                 write!(sql, " AS ").unwrap();
-                alias.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(alias, sql);
             }
             TableRef::SchemaTableAlias(schema, table, alias) => {
-                schema.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                table.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(table, sql);
                 write!(sql, " AS ").unwrap();
-                alias.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(alias, sql);
             }
             TableRef::DatabaseSchemaTableAlias(database, schema, table, alias) => {
-                database.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(database, sql);
                 write!(sql, ".").unwrap();
-                schema.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                table.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(table, sql);
                 write!(sql, " AS ").unwrap();
-                alias.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(alias, sql);
             }
             TableRef::SubQuery(_, _)
             | TableRef::ValuesList(_, _)

--- a/src/backend/table_ref_builder.rs
+++ b/src/backend/table_ref_builder.rs
@@ -5,40 +5,40 @@ pub trait TableRefBuilder: QuotedBuilder {
     fn prepare_table_ref_iden(&self, table_ref: &TableRef, sql: &mut dyn SqlWriter) {
         match table_ref {
             TableRef::Table(iden) => {
-                self.prepare_dyn_iden(iden, sql);
+                self.prepare_iden(iden, sql);
             }
             TableRef::SchemaTable(schema, table) => {
-                self.prepare_dyn_iden(schema, sql);
+                self.prepare_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(table, sql);
+                self.prepare_iden(table, sql);
             }
             TableRef::DatabaseSchemaTable(database, schema, table) => {
-                self.prepare_dyn_iden(database, sql);
+                self.prepare_iden(database, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(schema, sql);
+                self.prepare_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(table, sql);
+                self.prepare_iden(table, sql);
             }
             TableRef::TableAlias(iden, alias) => {
-                self.prepare_dyn_iden(iden, sql);
+                self.prepare_iden(iden, sql);
                 write!(sql, " AS ").unwrap();
-                self.prepare_dyn_iden(alias, sql);
+                self.prepare_iden(alias, sql);
             }
             TableRef::SchemaTableAlias(schema, table, alias) => {
-                self.prepare_dyn_iden(schema, sql);
+                self.prepare_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(table, sql);
+                self.prepare_iden(table, sql);
                 write!(sql, " AS ").unwrap();
-                self.prepare_dyn_iden(alias, sql);
+                self.prepare_iden(alias, sql);
             }
             TableRef::DatabaseSchemaTableAlias(database, schema, table, alias) => {
-                self.prepare_dyn_iden(database, sql);
+                self.prepare_iden(database, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(schema, sql);
+                self.prepare_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(table, sql);
+                self.prepare_iden(table, sql);
                 write!(sql, " AS ").unwrap();
-                self.prepare_dyn_iden(alias, sql);
+                self.prepare_iden(alias, sql);
             }
             TableRef::SubQuery(_, _)
             | TableRef::ValuesList(_, _)

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -43,6 +43,7 @@ pub enum Expr {
     AsEnum(DynIden, Box<Expr>),
     Case(Box<CaseStatement>),
     Constant(Value),
+    TypeName(DynIden),
 }
 
 /// "Operator" methods for building expressions.
@@ -2347,16 +2348,6 @@ impl From<LikeExpr> for Expr {
 }
 
 impl Expr {
-    /// Soft deprecated. This is not meant to be in the public API.
-    #[doc(hidden)]
-    pub fn cast_as_quoted<T>(self, type_name: T, q: Quote) -> Self
-    where
-        T: IntoIden,
-    {
-        let func = Func::cast_as_quoted(self, type_name, q);
-        Self::FunctionCall(func)
-    }
-
     pub(crate) fn is_binary(&self) -> bool {
         matches!(self, Self::Binary(_, _, _))
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -70,6 +70,8 @@ pub trait ExprTrait: Sized {
     ///
     /// # Examples
     ///
+    /// Adding literal values
+    ///
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
@@ -90,6 +92,54 @@ pub trait ExprTrait: Sized {
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 1 + 1 = 2"#
+    /// );
+    /// ```
+    ///
+    /// Adding columns and values
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Expr::col(Char::SizeW).add(1))
+    ///     .from(Char::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `size_w` + 1 FROM `character`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "size_w" + 1 FROM "character""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "size_w" + 1 FROM "character""#
+    /// );
+    /// ```
+    ///
+    /// Adding columns
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Expr::col(Char::SizeW).add(Expr::col(Char::SizeH)))
+    ///     .from(Char::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `size_w` + `size_h` FROM `character`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "size_w" + "size_h" FROM "character""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "size_w" + "size_h" FROM "character""#
     /// );
     /// ```
     fn add<R>(self, right: R) -> Expr
@@ -304,8 +354,7 @@ pub trait ExprTrait: Sized {
     /// let query = Query::select()
     ///     .columns([Char::Character, Char::SizeW, Char::SizeH])
     ///     .from(Char::Table)
-    ///     // Sometimes, you'll have to qualify the call because of conflicting std traits.
-    ///     .and_where(ExprTrait::eq("What!", "Nothing"))
+    ///     .and_where(Expr::val("What!").eq("Nothing"))
     ///     .and_where(Char::Id.into_column_ref().eq(1))
     ///     .to_owned();
     ///
@@ -320,6 +369,31 @@ pub trait ExprTrait: Sized {
     /// assert_eq!(
     ///     query.to_string(SqliteQueryBuilder),
     ///     r#"SELECT "character", "size_w", "size_h" FROM "character" WHERE 'What!' = 'Nothing' AND "id" = 1"#
+    /// );
+    /// ```
+    ///
+    /// Note how you should express a string being a literal vs an identifier
+    ///
+    /// ```
+    /// use sea_query::{*, tests_cfg::*};
+    ///
+    /// let query = Query::select()
+    ///     .column(Char::Character)
+    ///     .from(Char::Table)
+    ///     .and_where(Expr::col("name").eq("Something"))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character` FROM `character` WHERE `name` = 'Something'"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character" FROM "character" WHERE "name" = 'Something'"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "character" FROM "character" WHERE "name" = 'Something'"#
     /// );
     /// ```
     fn eq<R>(self, right: R) -> Expr

--- a/src/extension/mysql/column.rs
+++ b/src/extension/mysql/column.rs
@@ -9,12 +9,11 @@ pub enum MySqlType {
 }
 
 impl Iden for MySqlType {
-    fn unquoted(&self, s: &mut dyn std::fmt::Write) {
-        let ty = match self {
+    fn unquoted(&self) -> &str {
+        match self {
             Self::TinyBlob => "tinyblob",
             Self::MediumBlob => "mediumblob",
             Self::LongBlob => "longblob",
-        };
-        write!(s, "{ty}").unwrap();
+        }
     }
 }

--- a/src/extension/postgres/ltree.rs
+++ b/src/extension/postgres/ltree.rs
@@ -51,8 +51,8 @@ use crate::Iden;
 pub struct PgLTree;
 
 impl Iden for PgLTree {
-    fn unquoted(&self, s: &mut dyn std::fmt::Write) {
-        write!(s, "ltree").unwrap();
+    fn unquoted(&self) -> &str {
+        "ltree"
     }
 }
 

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -122,19 +122,19 @@ pub trait TypeBuilder: QuotedBuilder {
     fn prepare_type_ref(&self, type_ref: &TypeRef, sql: &mut dyn SqlWriter) {
         match type_ref {
             TypeRef::Type(name) => {
-                name.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(name, sql);
             }
             TypeRef::SchemaType(schema, name) => {
-                schema.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                name.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(name, sql);
             }
             TypeRef::DatabaseSchemaType(database, schema, name) => {
-                database.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(database, sql);
                 write!(sql, ".").unwrap();
-                schema.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                name.prepare(sql.as_writer(), self.quote());
+                self.prepare_dyn_iden(name, sql);
             }
         }
     }

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -167,22 +167,13 @@ impl TypeCreateStatement {
     /// ```
     /// use sea_query::{extension::postgres::Type, *};
     ///
+    /// #[derive(Iden)]
     /// enum FontFamily {
+    ///     #[iden = "font_family"]
     ///     Type,
     ///     Serif,
     ///     Sans,
     ///     Monospace,
-    /// }
-    ///
-    /// impl Iden for FontFamily {
-    ///     fn unquoted(&self) -> &str {
-    ///         match self {
-    ///             Self::Type => "font_family",
-    ///             Self::Serif => "serif",
-    ///             Self::Sans => "sans",
-    ///             Self::Monospace => "monospace",
-    ///         }
-    ///     }
     /// }
     ///
     /// assert_eq!(

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -175,18 +175,13 @@ impl TypeCreateStatement {
     /// }
     ///
     /// impl Iden for FontFamily {
-    ///     fn unquoted(&self, s: &mut dyn Write) {
-    ///         write!(
-    ///             s,
-    ///             "{}",
-    ///             match self {
-    ///                 Self::Type => "font_family",
-    ///                 Self::Serif => "serif",
-    ///                 Self::Sans => "sans",
-    ///                 Self::Monospace => "monospace",
-    ///             }
-    ///         )
-    ///         .unwrap();
+    ///     fn unquoted(&self) -> &str {
+    ///         match self {
+    ///             Self::Type => "font_family",
+    ///             Self::Serif => "serif",
+    ///             Self::Sans => "sans",
+    ///             Self::Monospace => "monospace",
+    ///         }
     ///     }
     /// }
     ///
@@ -232,8 +227,8 @@ impl TypeDropStatement {
     /// struct FontFamily;
     ///
     /// impl Iden for FontFamily {
-    ///     fn unquoted(&self, s: &mut dyn Write) {
-    ///         write!(s, "{}", "font_family").unwrap();
+    ///     fn unquoted(&self) -> &str {
+    ///         "font_family"
     ///     }
     /// }
     ///
@@ -335,18 +330,13 @@ impl TypeAlterStatement {
     /// }
     ///
     /// impl Iden for FontFamily {
-    ///     fn unquoted(&self, s: &mut dyn Write) {
-    ///         write!(
-    ///             s,
-    ///             "{}",
-    ///             match self {
-    ///                 Self::Type => "font_family",
-    ///                 Self::Serif => "serif",
-    ///                 Self::Sans => "sans",
-    ///                 Self::Monospace => "monospace",
-    ///             }
-    ///         )
-    ///         .unwrap();
+    ///     fn unquoted(&self) -> &str {
+    ///         match self {
+    ///             Self::Type => "font_family",
+    ///             Self::Serif => "serif",
+    ///             Self::Sans => "sans",
+    ///             Self::Monospace => "monospace",
+    ///         }
     ///     }
     /// }
     ///

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -122,19 +122,19 @@ pub trait TypeBuilder: QuotedBuilder {
     fn prepare_type_ref(&self, type_ref: &TypeRef, sql: &mut dyn SqlWriter) {
         match type_ref {
             TypeRef::Type(name) => {
-                self.prepare_dyn_iden(name, sql);
+                self.prepare_iden(name, sql);
             }
             TypeRef::SchemaType(schema, name) => {
-                self.prepare_dyn_iden(schema, sql);
+                self.prepare_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(name, sql);
+                self.prepare_iden(name, sql);
             }
             TypeRef::DatabaseSchemaType(database, schema, name) => {
-                self.prepare_dyn_iden(database, sql);
+                self.prepare_iden(database, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(schema, sql);
+                self.prepare_iden(schema, sql);
                 write!(sql, ".").unwrap();
-                self.prepare_dyn_iden(name, sql);
+                self.prepare_iden(name, sql);
             }
         }
     }

--- a/src/func.rs
+++ b/src/func.rs
@@ -547,12 +547,12 @@ impl Func {
     /// use sea_query::{tests_cfg::*, *};
     ///
     /// let query = Query::select()
-    ///     .expr(Func::cast_as_quoted("hello", "MyType", '"'.into()))
+    ///     .expr(Func::cast_as_quoted("hello", "MyType"))
     ///     .to_owned();
     ///
     /// assert_eq!(
     ///     query.to_string(MysqlQueryBuilder),
-    ///     r#"SELECT CAST('hello' AS "MyType")"#
+    ///     r#"SELECT CAST('hello' AS `MyType`)"#
     /// );
     /// assert_eq!(
     ///     query.to_string(PostgresQueryBuilder),
@@ -563,16 +563,14 @@ impl Func {
     ///     r#"SELECT CAST('hello' AS "MyType")"#
     /// );
     /// ```
-    pub fn cast_as_quoted<V, I>(expr: V, iden: I, q: Quote) -> FunctionCall
+    pub fn cast_as_quoted<V, I>(expr: V, iden: I) -> FunctionCall
     where
         V: Into<Expr>,
         I: IntoIden,
     {
         let expr: Expr = expr.into();
-        let mut quoted_type = String::new();
-        iden.into_iden().prepare(&mut quoted_type, q);
         FunctionCall::new(Function::Cast)
-            .arg(expr.binary(BinOper::As, Expr::cust(quoted_type.as_str())))
+            .arg(expr.binary(BinOper::As, Expr::TypeName(iden.into_iden())))
     }
 
     /// Call `COALESCE` function.

--- a/src/func.rs
+++ b/src/func.rs
@@ -112,8 +112,8 @@ impl Func {
     /// struct MyFunction;
     ///
     /// impl Iden for MyFunction {
-    ///     fn unquoted(&self, s: &mut dyn Write) {
-    ///         write!(s, "MY_FUNCTION").unwrap();
+    ///     fn unquoted(&self) -> &str {
+    ///         "MY_FUNCTION"
     ///     }
     /// }
     ///

--- a/src/func.rs
+++ b/src/func.rs
@@ -109,13 +109,10 @@ impl Func {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// struct MyFunction;
     ///
-    /// impl Iden for MyFunction {
-    ///     fn unquoted(&self) -> &str {
-    ///         "MY_FUNCTION"
-    ///     }
-    /// }
+    /// #[derive(Iden)]
+    /// #[iden = "MY_FUNCTION"]
+    /// struct MyFunction;
     ///
     /// let query = Query::select()
     ///     .expr(Func::cust(MyFunction).arg("hello"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,18 +163,13 @@
 //!
 //! // Mapping between Enum variant and its corresponding string value
 //! impl Iden for Character {
-//!     fn unquoted(&self, s: &mut dyn std::fmt::Write) {
-//!         write!(
-//!             s,
-//!             "{}",
-//!             match self {
-//!                 Self::Table => "character",
-//!                 Self::Id => "id",
-//!                 Self::FontId => "font_id",
-//!                 Self::FontSize => "font_size",
-//!             }
-//!         )
-//!         .unwrap();
+//!     fn unquoted(&self) -> &str {
+//!         match self {
+//!             Self::Table => "character",
+//!             Self::Id => "id",
+//!             Self::FontId => "font_id",
+//!             Self::FontSize => "font_size",
+//!         }
 //!     }
 //! }
 //! ```
@@ -503,8 +498,8 @@
 //! struct MyFunction;
 //!
 //! impl Iden for MyFunction {
-//!     fn unquoted(&self, s: &mut dyn Write) {
-//!         write!(s, "MY_FUNCTION").unwrap();
+//!     fn unquoted(&self) -> &str {
+//!         "MY_FUNCTION"
 //!     }
 //! }
 //!

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -606,9 +606,11 @@ impl SelectStatement {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
+    /// let alias: String = "C".into();
+    ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .expr_as(Expr::col(Char::Character), "C")
+    ///     .expr_as(Expr::col(Char::Character), alias)
     ///     .to_owned();
     ///
     /// assert_eq!(

--- a/src/tests_cfg.rs
+++ b/src/tests_cfg.rs
@@ -1,7 +1,5 @@
 //! Configurations for test cases and examples. Not intended for actual use.
 
-use std::fmt;
-
 #[cfg(feature = "with-json")]
 pub use serde_json::json;
 
@@ -30,24 +28,19 @@ pub enum Character {
 pub type Char = Character;
 
 impl Iden for Character {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
-        write!(
-            s,
-            "{}",
-            match self {
-                Self::Table => "character",
-                Self::Id => "id",
-                Self::Character => "character",
-                Self::FontSize => "font_size",
-                Self::SizeW => "size_w",
-                Self::SizeH => "size_h",
-                Self::FontId => "font_id",
-                Self::Ascii => "ascii",
-                Self::CreatedAt => "created_at",
-                Self::UserData => "user_data",
-            }
-        )
-        .unwrap();
+    fn unquoted(&self) -> &str {
+        match self {
+            Self::Table => "character",
+            Self::Id => "id",
+            Self::Character => "character",
+            Self::FontSize => "font_size",
+            Self::SizeW => "size_w",
+            Self::SizeH => "size_h",
+            Self::FontId => "font_id",
+            Self::Ascii => "ascii",
+            Self::CreatedAt => "created_at",
+            Self::UserData => "user_data",
+        }
     }
 }
 
@@ -66,19 +59,14 @@ pub enum Font {
 }
 
 impl Iden for Font {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
-        write!(
-            s,
-            "{}",
-            match self {
-                Self::Table => "font",
-                Self::Id => "id",
-                Self::Name => "name",
-                Self::Variant => "variant",
-                Self::Language => "language",
-            }
-        )
-        .unwrap();
+    fn unquoted(&self) -> &str {
+        match self {
+            Self::Table => "font",
+            Self::Id => "id",
+            Self::Name => "name",
+            Self::Variant => "variant",
+            Self::Language => "language",
+        }
     }
 }
 
@@ -97,19 +85,14 @@ pub enum Glyph {
 }
 
 impl Iden for Glyph {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
-        write!(
-            s,
-            "{}",
-            match self {
-                Self::Table => "glyph",
-                Self::Id => "id",
-                Self::Image => "image",
-                Self::Aspect => "aspect",
-                Self::Tokens => "tokens",
-            }
-        )
-        .unwrap();
+    fn unquoted(&self) -> &str {
+        match self {
+            Self::Table => "glyph",
+            Self::Id => "id",
+            Self::Image => "image",
+            Self::Aspect => "aspect",
+            Self::Tokens => "tokens",
+        }
     }
 }
 
@@ -126,16 +109,11 @@ pub enum Task {
 }
 
 impl Iden for Task {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
-        write!(
-            s,
-            "{}",
-            match self {
-                Self::Table => "task",
-                Self::Id => "id",
-                Self::IsDone => "is_done",
-            }
-        )
-        .unwrap();
+    fn unquoted(&self) -> &str {
+        match self {
+            Self::Table => "task",
+            Self::Id => "id",
+            Self::IsDone => "is_done",
+        }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,10 +28,6 @@ macro_rules! iden_trait {
     ($($bounds:ident),*) => {
         /// Identifier
         pub trait Iden where $(Self: $bounds),* {
-            fn prepare(&self, s: &mut dyn fmt::Write, q: Quote) {
-                write!(s, "{}{}{}", q.left(), self.quoted(q), q.right()).unwrap();
-            }
-
             /// Return the escaped version of the identifier, using the proper
             /// quote for the database backend.
             ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -612,13 +612,15 @@ impl Alias {
     }
 }
 
-// Regaring potential `impl for String` and the need for `Alias`,
-// see discussions on https://github.com/SeaQL/sea-query/pull/882
+impl IntoIden for Alias {
+    fn into_iden(self) -> DynIden {
+        DynIden(Cow::Owned(self.0))
+    }
+}
 
-/// Reuses the `impl` for the underlying [str].
-impl Iden for Alias {
-    fn unquoted(&self) -> &str {
-        self.0.as_str()
+impl IntoIden for String {
+    fn into_iden(self) -> DynIden {
+        DynIden(Cow::Owned(self))
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,16 +46,14 @@ macro_rules! iden_trait {
             /// representation is distinct from [`Display`][std::fmt::Display]
             /// and can be different.
             fn to_string(&self) -> String {
-                let mut s = String::new();
-                self.unquoted(&mut s);
-                s
+                self.unquoted().to_owned()
             }
 
             /// Write a raw identifier string without quotes.
             ///
             /// We indentionally don't reuse [`Display`][std::fmt::Display] for
             /// this, because we want to allow it to have a different logic.
-            fn unquoted(&self, s: &mut dyn fmt::Write);
+            fn unquoted(&self) -> &str;
         }
 
         /// Identifier
@@ -124,8 +122,7 @@ pub trait IdenList {
 
 impl fmt::Debug for dyn Iden {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.unquoted(formatter);
-        Ok(())
+        write!(formatter, "{}", self.unquoted())
     }
 }
 
@@ -635,8 +632,8 @@ impl Alias {
 
 /// Reuses the `impl` for the underlying [str].
 impl Iden for Alias {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
-        self.0.as_str().unquoted(s);
+    fn unquoted(&self) -> &str {
+        self.0.as_str()
     }
 }
 
@@ -644,8 +641,8 @@ impl Iden for Alias {
 ///
 /// Reused for other string-like types.
 impl Iden for &str {
-    fn unquoted(&self, s: &mut dyn fmt::Write) {
-        s.write_str(self).unwrap();
+    fn unquoted(&self) -> &str {
+        self
     }
 }
 
@@ -656,7 +653,9 @@ impl NullAlias {
 }
 
 impl Iden for NullAlias {
-    fn unquoted(&self, _s: &mut dyn fmt::Write) {}
+    fn unquoted(&self) -> &str {
+        ""
+    }
 }
 
 impl LikeExpr {

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,25 +28,25 @@ macro_rules! iden_trait {
     ($($bounds:ident),*) => {
         /// Identifier
         pub trait Iden where $(Self: $bounds),* {
-            /// Return the escaped version of the identifier, using the proper
-            /// quote for the database backend.
+            /// Return the prepared version of the identifier.
             ///
-            /// For example, for MySQL "hel`lo`" would become "hel``lo".
+            /// If you're **sure** that the identifier doesn't need to be escaped,
+            /// return `'static str`.
+            /// This is generally only safe to deduce at compile-time via macros.
             ///
-            /// If you're sure that the identifier doesn't need to be escaped,
-            /// you can override this by:
+            /// For example, for MySQL "hel`lo`" would have to be escaped as "hel``lo".
+            ///
+            /// You can override this impl by:
             /// ```ignore
-            /// fn quoted(&self, q: sea_query::Quote) -> std::borrow::Cow<'static, str> {
+            /// fn quoted(&self) -> std::borrow::Cow<'static, str> {
             ///     std::borrow::Cow::Borrowed(self.unquoted_static())
             /// }
             /// fn unquoted_static(&self) -> &'static str {
             ///     // implement
             /// }
             /// ```
-            fn quoted(&self, q: Quote) -> Cow<'static, str> {
-                let byte = [q.1];
-                let qq: &str = std::str::from_utf8(&byte).unwrap();
-                Cow::Owned(self.unquoted().replace(qq, qq.repeat(2).as_str()))
+            fn quoted(&self) -> Cow<'static, str> {
+                Cow::Owned(self.to_string())
             }
 
             /// A shortcut for writing an [`unquoted`][Iden::unquoted]

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,5 +1,3 @@
-pub use std::fmt::Write as FmtWrite;
-
 #[cfg(feature = "with-json")]
 pub use serde_json::json;
 
@@ -24,21 +22,16 @@ pub enum BinaryType {
 }
 
 impl Iden for BinaryType {
-    fn unquoted(&self, s: &mut dyn FmtWrite) {
-        write!(
-            s,
-            "{}",
-            match self {
-                Self::Table => "binary_type",
-                Self::BinaryLen => "binlen",
-                Self::Binary => "bin",
-                Self::BlobSize => "defb",
-                Self::TinyBlob => "tb",
-                Self::Blob => "b",
-                Self::MediumBlob => "mb",
-                Self::LongBlob => "lb",
-            }
-        )
-        .unwrap();
+    fn unquoted(&self) -> &str {
+        match self {
+            Self::Table => "binary_type",
+            Self::BinaryLen => "binlen",
+            Self::Binary => "bin",
+            Self::BlobSize => "defb",
+            Self::TinyBlob => "tb",
+            Self::Blob => "b",
+            Self::MediumBlob => "mb",
+            Self::LongBlob => "lb",
+        }
     }
 }

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -41,17 +41,12 @@ fn create_3() {
     }
 
     impl sea_query::Iden for Tea {
-        fn unquoted(&self, s: &mut dyn std::fmt::Write) {
-            write!(
-                s,
-                "{}",
-                match self {
-                    Self::Enum => "tea",
-                    Self::EverydayTea => "EverydayTea",
-                    Self::BreakfastTea => "BreakfastTea",
-                }
-            )
-            .unwrap();
+        fn unquoted(&self) -> &str {
+            match self {
+                Self::Enum => "tea",
+                Self::EverydayTea => "EverydayTea",
+                Self::BreakfastTea => "BreakfastTea",
+            }
         }
     }
 }


### PR DESCRIPTION
As discussed, `Arc`, `vtable` tricks are removed.

The biggest behaviour change is late binding to early binding. previously the Iden is only rendered when the AST is being serialized, now that we pre-render it as we store that into the AST.

For majority of usecases in SeaORM though, since they're `'static str` anyway, there should be no difference.

It is still possible to have `struct MyIden(String)` with some dynamic behaviour, it's just that constructing new String on the fly is no longer possible.