### PR TITLE
Blanket-implement PgExpr and SqliteExpr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
     | TableRef::FunctionCall(_, tbl) => SeaRc::clone(tbl),
  -> | &_ => todo!(),
 ```
-* `ExprTrait::eq` collided with `std::cmp::Eq`. If you encounter the following error, please use `std::cmp::PartialEq::eq(a, b)` or 
+* `ExprTrait::eq` collided with `std::cmp::Eq`. If you encounter the following error, please use `std::cmp::PartialEq::eq(a, b)` or
 `sea_query::ExprTrait::eq(a, b)` explicitly https://github.com/SeaQL/sea-query/pull/890
 ```rust
 error[E0308]: mismatched types
@@ -114,6 +114,12 @@ impl Iden for Glyph {
     }
 }
 ```
+* Blanket-implemented `SqliteExpr` and `PgExpr` for `T where T: ExprTrait`.
+
+  Now you can use database-specific operators with all expression types.
+
+  If you had custom implementations in your own code, some may no longer compile
+  and may need to be deleted.
 
 ### Upgrades
 
@@ -123,7 +129,7 @@ impl Iden for Glyph {
 
 ### Enhancements
 
-* impl From<Condition> and From<ConditionExpression> for SimpleExpr https://github.com/SeaQL/sea-query/pull/886
+* impl `From<Condition>` and `From<ConditionExpression>` for `SimpleExpr` https://github.com/SeaQL/sea-query/pull/886
 
 ## 0.32.5 - 2025-05-07
 
@@ -350,7 +356,7 @@ assert_eq!(
 
 ### New Features
 
-* Construct Postgres query with vector extension https://github.com/SeaQL/sea-query/pull/774    
+* Construct Postgres query with vector extension https://github.com/SeaQL/sea-query/pull/774
     * Added `postgres-vector` feature flag
     * Added `Value::Vector`, `ColumnType::Vector`, `ColumnDef::vector()`, `PgBinOper::EuclideanDistance`, `PgBinOper::NegativeInnerProduct` and `PgBinOper::CosineDistance`
     ```rust
@@ -1012,7 +1018,7 @@ Enum {
 
 ### New Features
 
-* Added support `DROP COLUMN` for SQLite https://github.com/SeaQL/sea-query/pull/455 
+* Added support `DROP COLUMN` for SQLite https://github.com/SeaQL/sea-query/pull/455
 
 ### Bug Fixes
 

--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -197,12 +197,5 @@ pub trait PgExpr: ExprTrait {
     }
 }
 
-// TODO: https://github.com/SeaQL/sea-query/discussions/795:
-// replace all of this with `impl<T> PgExpr for T where T: ExprTrait {}`
-// (breaking change)
-impl PgExpr for Expr {}
-impl PgExpr for FunctionCall {}
-impl PgExpr for ColumnRef {}
-impl PgExpr for Keyword {}
-impl PgExpr for LikeExpr {}
-impl PgExpr for Value {}
+/// You should be able to use Postgres-specific operators with all types of expressions.
+impl<T> PgExpr for T where T: ExprTrait {}

--- a/src/extension/postgres/expr.rs
+++ b/src/extension/postgres/expr.rs
@@ -1,5 +1,5 @@
 use super::PgBinOper;
-use crate::{ColumnRef, Expr, ExprTrait, FunctionCall, IntoLikeExpr, Keyword, LikeExpr, Value};
+use crate::{Expr, ExprTrait, IntoLikeExpr};
 
 /// Postgres-specific operator methods for building expressions.
 pub trait PgExpr: ExprTrait {

--- a/src/extension/sqlite/expr.rs
+++ b/src/extension/sqlite/expr.rs
@@ -1,4 +1,4 @@
-use crate::{ColumnRef, Expr, ExprTrait, FunctionCall, Keyword, LikeExpr, Value};
+use crate::{Expr, ExprTrait};
 
 use super::SqliteBinOper;
 

--- a/src/extension/sqlite/expr.rs
+++ b/src/extension/sqlite/expr.rs
@@ -105,12 +105,5 @@ pub trait SqliteExpr: ExprTrait {
     }
 }
 
-// TODO: https://github.com/SeaQL/sea-query/discussions/795:
-// replace all of this with `impl<T> SqliteExpr for T where T: ExprTrait {}`
-// (breaking change)
-impl SqliteExpr for Expr {}
-impl SqliteExpr for FunctionCall {}
-impl SqliteExpr for ColumnRef {}
-impl SqliteExpr for Keyword {}
-impl SqliteExpr for LikeExpr {}
-impl SqliteExpr for Value {}
+/// You should be able to use SQLite-specific operators with all types of expressions.
+impl<T> SqliteExpr for T where T: ExprTrait {}


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [x] Blanket-implemented `SqliteExpr` and `PgExpr` for `T where T: ExprTrait`.

    This was planned in https://github.com/SeaQL/sea-query/discussions/795.
    Makes a lot of sense. Database-specific operators should be available on all types of expressions.

    However, existing impls in the user code may no longer compile if the type implements `ExprTrait`.
    The right fix is to delete such implementations.

## Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->