### PR TITLE
Make `ConditionExpression` private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ pub struct DynIden(pub(crate) Cow<'static, str>); // new
 pub struct SeaRc<I>(pub(crate) RcOrArc<I>);       // old
 pub struct SeaRc;                                 // new
 ```
+* `impl From<Expr> for Condition`. Now you can use that instead of
+  `ConditionExpression`, which has been removed.
 
 ### Breaking Changes
 
@@ -114,6 +116,8 @@ impl Iden for Glyph {
     }
 }
 ```
+* Removed `ConditionExpression` from the public API. Instead, just convert
+  between `Condition` and `Expr` using `From`/`Into`.
 * Blanket-implemented `SqliteExpr` and `PgExpr` for `T where T: ExprTrait`.
 
   Now you can use database-specific operators with all expression types.

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -735,10 +735,10 @@ fn select_48() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            Cond::all().add_option(Some(ConditionExpression::Expr(
+            Cond::all().add_option(Some(
                 Expr::tuple([Expr::col(Glyph::Aspect).into(), Expr::value(100)])
                     .lt(Expr::tuple([Expr::value(8), Expr::value(100)])),
-            ))),
+            )),
         )
         .to_string(MysqlQueryBuilder);
 
@@ -754,13 +754,13 @@ fn select_48a() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            Cond::all().add_option(Some(ConditionExpression::Expr(
+            Cond::all().add_option(Some(
                 Expr::tuple([
                     Expr::col(Glyph::Aspect).into(),
                     Expr::value(String::from("100")),
                 ])
                 .in_tuples([(8, String::from("100"))]),
-            ))),
+            )),
         )
         .to_string(MysqlQueryBuilder);
 

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -821,10 +821,10 @@ fn select_48() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            Cond::all().add_option(Some(ConditionExpression::Expr(
+            Cond::all().add_option(Some(
                 Expr::tuple([Expr::col(Glyph::Aspect).into(), Expr::value(100)])
                     .lt(Expr::tuple([Expr::value(8), Expr::value(100)])),
-            ))),
+            )),
         )
         .to_string(PostgresQueryBuilder);
 
@@ -840,13 +840,13 @@ fn select_48a() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            Cond::all().add_option(Some(ConditionExpression::Expr(
+            Cond::all().add_option(Some(
                 Expr::tuple([
                     Expr::col(Glyph::Aspect).into(),
                     Expr::value(String::from("100")),
                 ])
                 .in_tuples([(8, String::from("100"))]),
-            ))),
+            )),
         )
         .to_string(PostgresQueryBuilder);
 

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -736,10 +736,10 @@ fn select_48() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            Cond::all().add_option(Some(ConditionExpression::Expr(
+            Cond::all().add_option(Some(
                 Expr::tuple([Expr::col(Glyph::Aspect).into(), Expr::value(100)])
                     .lt(Expr::tuple([Expr::value(8), Expr::value(100)])),
-            ))),
+            )),
         )
         .to_string(SqliteQueryBuilder);
 
@@ -755,13 +755,13 @@ fn select_48a() {
         .column(Glyph::Id)
         .from(Glyph::Table)
         .cond_where(
-            Cond::all().add_option(Some(ConditionExpression::Expr(
+            Cond::all().add_option(Some(
                 Expr::tuple([
                     Expr::col(Glyph::Aspect).into(),
                     Expr::value(String::from("100")),
                 ])
                 .in_tuples([(8, String::from("100"))]),
-            ))),
+            )),
         )
         .to_string(SqliteQueryBuilder);
 


### PR DESCRIPTION
Previously described in https://github.com/SeaQL/sea-query/discussions/795.

## New Features

- [x] `impl From<Expr> for Condition`

## Breaking Changes

- [x] Made `ConditionExpression` private.
- [x] Replaced `Into<ConditionExpression>` with `Into<Condition>` in `Condition::add` and `Condition::add_option`.