### PR TITLE
Remove Expr::new

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1523,10 +1523,6 @@ where
 }
 
 impl Expr {
-    pub fn new(expr: impl Into<Self>) -> Self {
-        expr.into()
-    }
-
     #[deprecated(since = "0.29.0", note = "Please use the [`Asterisk`]")]
     pub fn asterisk() -> Self {
         Self::col(Asterisk)


### PR DESCRIPTION
https://github.com/SeaQL/sea-query/pull/897#issuecomment-2954569983

> I'm considering removing Expr::new, since we already have Expr::from.
> As @Expurple mentioned here, I checked my codebase and found that using Expr::from makes the intent clearer. Moreover, accepting Into<Self> in the new method is not idiomatic in Rust.