### PR TITLE
Remove unnecessary `'static` bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.0.0 - pending
 
+### Enhancements
+
+* Removed unnecessary `'static` bounds from type signatures.
+
 ### New features
 
 * Unify `Expr` and `SimpleExpr` as one type. `SimpleExpr` is kept as an alias of `Expr`, but they can now be used interchangably. There may be a few compile

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -473,7 +473,7 @@ impl WithClause {
     /// execute the argument query with this WITH clause.
     pub fn query<T>(self, query: T) -> WithQuery
     where
-        T: Into<SubQueryStatement> + 'static,
+        T: Into<SubQueryStatement>,
     {
         WithQuery::new().with_clause(self).query(query).to_owned()
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -454,7 +454,7 @@ impl From<(u8, u8)> for Quote {
     }
 }
 
-impl<T: 'static> IntoIden for T
+impl<T> IntoIden for T
 where
     T: Iden,
 {
@@ -511,7 +511,7 @@ impl IntoColumnRef for ColumnRef {
     }
 }
 
-impl<T: 'static> IntoColumnRef for T
+impl<T> IntoColumnRef for T
 where
     T: IntoIden,
 {
@@ -526,7 +526,7 @@ impl IntoColumnRef for Asterisk {
     }
 }
 
-impl<S: 'static, T: 'static> IntoColumnRef for (S, T)
+impl<S, T> IntoColumnRef for (S, T)
 where
     S: IntoIden,
     T: IntoIden,
@@ -536,7 +536,7 @@ where
     }
 }
 
-impl<T: 'static> IntoColumnRef for (T, Asterisk)
+impl<T> IntoColumnRef for (T, Asterisk)
 where
     T: IntoIden,
 {
@@ -545,7 +545,7 @@ where
     }
 }
 
-impl<S: 'static, T: 'static, U: 'static> IntoColumnRef for (S, T, U)
+impl<S, T, U> IntoColumnRef for (S, T, U)
 where
     S: IntoIden,
     T: IntoIden,
@@ -562,7 +562,7 @@ impl IntoTableRef for TableRef {
     }
 }
 
-impl<T: 'static> IntoTableRef for T
+impl<T> IntoTableRef for T
 where
     T: IntoIden,
 {
@@ -571,7 +571,7 @@ where
     }
 }
 
-impl<S: 'static, T: 'static> IntoTableRef for (S, T)
+impl<S, T> IntoTableRef for (S, T)
 where
     S: IntoIden,
     T: IntoIden,
@@ -581,7 +581,7 @@ where
     }
 }
 
-impl<S: 'static, T: 'static, U: 'static> IntoTableRef for (S, T, U)
+impl<S, T, U> IntoTableRef for (S, T, U)
 where
     S: IntoIden,
     T: IntoIden,


### PR DESCRIPTION
As discussed here: https://github.com/SeaQL/sea-query/issues/827#issuecomment-3125338008

## PR Info

- Dependents:
  - #922

## Changes

- [x] Removed unnecessary `'static` bounds from type signatures.