### PR TITLE
Accept `IntoColumnRef` in `cast_as_quoted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.0.0 - pending
 
+### Enhancements
+
+* Removed unnecessary `'static` bounds from type signatures.
+
 ### New features
 
 * Unify `Expr` and `SimpleExpr` as one type. `SimpleExpr` is kept as an alias of `Expr`, but they can now be used interchangably. There may be a few compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Enhancements
 
 * Removed unnecessary `'static` bounds from type signatures.
+* `cast_as_quoted` now allows you to [qualify the type
+  name](https://github.com/SeaQL/sea-query/issues/827).
 
 ### New features
 

--- a/src/func.rs
+++ b/src/func.rs
@@ -537,6 +537,8 @@ impl Func {
 
     /// Call `CAST` function with a case-sensitive custom type.
     ///
+    /// Type can be qualified with a schema name.
+    ///
     /// # Examples
     ///
     /// ```
@@ -558,15 +560,34 @@ impl Func {
     ///     query.to_string(SqliteQueryBuilder),
     ///     r#"SELECT CAST('hello' AS "MyType")"#
     /// );
+    ///
+    /// // Also works with a schema-qualified type name:
+    ///
+    /// let query = Query::select()
+    ///     .expr(Func::cast_as_quoted("hello", ("MySchema", "MyType")))
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT CAST('hello' AS `MySchema`.`MyType`)"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT CAST('hello' AS "MySchema"."MyType")"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT CAST('hello' AS "MySchema"."MyType")"#
+    /// );
     /// ```
-    pub fn cast_as_quoted<V, I>(expr: V, iden: I) -> FunctionCall
+    pub fn cast_as_quoted<V, I>(expr: V, col: I) -> FunctionCall
     where
         V: Into<Expr>,
-        I: IntoIden,
+        I: IntoColumnRef,
     {
         let expr: Expr = expr.into();
         FunctionCall::new(Function::Cast)
-            .arg(expr.binary(BinOper::As, Expr::TypeName(iden.into_iden())))
+            .arg(expr.binary(BinOper::As, Expr::Column(col.into_column_ref())))
     }
 
     /// Call `COALESCE` function.

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -473,7 +473,7 @@ impl WithClause {
     /// execute the argument query with this WITH clause.
     pub fn query<T>(self, query: T) -> WithQuery
     where
-        T: Into<SubQueryStatement> + 'static,
+        T: Into<SubQueryStatement>,
     {
         WithQuery::new().with_clause(self).query(query).to_owned()
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -454,7 +454,7 @@ impl From<(u8, u8)> for Quote {
     }
 }
 
-impl<T: 'static> IntoIden for T
+impl<T> IntoIden for T
 where
     T: Iden,
 {
@@ -511,7 +511,7 @@ impl IntoColumnRef for ColumnRef {
     }
 }
 
-impl<T: 'static> IntoColumnRef for T
+impl<T> IntoColumnRef for T
 where
     T: IntoIden,
 {
@@ -526,7 +526,7 @@ impl IntoColumnRef for Asterisk {
     }
 }
 
-impl<S: 'static, T: 'static> IntoColumnRef for (S, T)
+impl<S, T> IntoColumnRef for (S, T)
 where
     S: IntoIden,
     T: IntoIden,
@@ -536,7 +536,7 @@ where
     }
 }
 
-impl<T: 'static> IntoColumnRef for (T, Asterisk)
+impl<T> IntoColumnRef for (T, Asterisk)
 where
     T: IntoIden,
 {
@@ -545,7 +545,7 @@ where
     }
 }
 
-impl<S: 'static, T: 'static, U: 'static> IntoColumnRef for (S, T, U)
+impl<S, T, U> IntoColumnRef for (S, T, U)
 where
     S: IntoIden,
     T: IntoIden,
@@ -562,7 +562,7 @@ impl IntoTableRef for TableRef {
     }
 }
 
-impl<T: 'static> IntoTableRef for T
+impl<T> IntoTableRef for T
 where
     T: IntoIden,
 {
@@ -571,7 +571,7 @@ where
     }
 }
 
-impl<S: 'static, T: 'static> IntoTableRef for (S, T)
+impl<S, T> IntoTableRef for (S, T)
 where
     S: IntoIden,
     T: IntoIden,
@@ -581,7 +581,7 @@ where
     }
 }
 
-impl<S: 'static, T: 'static, U: 'static> IntoTableRef for (S, T, U)
+impl<S, T, U> IntoTableRef for (S, T, U)
 where
     S: IntoIden,
     T: IntoIden,


### PR DESCRIPTION
As discussed here: https://github.com/SeaQL/sea-query/issues/827#issuecomment-3125338008

Merge after #921. Marking as draft until then. The first commit comes as a dependency from that PR. If you want to review the diff before merging that PR, review only the second commit.

## PR Info

- Closes #827

- Dependencies:
  - #921

## Changes

- [x] Accept `IntoColumnRef` as the type name in `cast_as_quoted`.

This is backwards-compatible because there's an

```rust
impl<T> IntoColumnRef for T
where
    T: IntoIden
```