### PR TITLE
Remove `SeaRc::new` from docs and internal code

### DIFF
--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -264,10 +264,7 @@ impl TypeDropStatement {
     /// assert_eq!(
     ///     Type::drop()
     ///         .if_exists()
-    ///         .names([
-    ///             SeaRc::new(KycStatus::Type) as DynIden,
-    ///             SeaRc::new(FontFamily::Type) as DynIden,
-    ///         ])
+    ///         .names([KycStatus::Type.into_iden(), FontFamily::Type.into_iden()])
     ///         .cascade()
     ///         .to_string(PostgresQueryBuilder),
     ///     r#"DROP TYPE IF EXISTS "kyc_status", "font_family" CASCADE"#

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -90,7 +90,7 @@ impl DeleteStatement {
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().deleted_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// assert_eq!(query.audit_unwrap().selected_tables(), []);
     /// ```
@@ -136,11 +136,11 @@ impl DeleteStatement {
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().deleted_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().selected_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn returning(&mut self, returning_cols: ReturningClause) -> &mut Self {
@@ -249,11 +249,11 @@ impl DeleteStatement {
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().deleted_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().selected_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn with(self, clause: WithClause) -> WithQuery {
@@ -298,11 +298,11 @@ impl DeleteStatement {
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().deleted_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().selected_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn with_cte<C: Into<WithClause>>(&mut self, clause: C) -> &mut Self {

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -43,7 +43,7 @@ pub(crate) enum InsertValueSource {
 /// );
 /// assert_eq!(
 ///     query.audit().unwrap().inserted_tables(),
-///     [SeaRc::new(Glyph::Table)]
+///     [Glyph::Table.into_iden()]
 /// );
 /// ```
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -168,11 +168,11 @@ impl InsertStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().inserted_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// ```
     ///
@@ -216,11 +216,11 @@ impl InsertStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Font::Table)]
+    ///     [Font::Table.into_iden()]
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().inserted_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn select_from<S>(&mut self, select: S) -> Result<&mut Self>
@@ -360,7 +360,7 @@ impl InsertStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().inserted_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn values_from_panic<I, J>(&mut self, values_iter: J) -> &mut Self

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -606,11 +606,9 @@ impl SelectStatement {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let alias: String = "C".into();
-    ///
     /// let query = Query::select()
     ///     .from(Char::Table)
-    ///     .expr_as(Expr::col(Char::Character), alias)
+    ///     .expr_as(Expr::col(Char::Character), "C")
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -948,11 +946,9 @@ impl SelectStatement {
     /// ```
     /// use sea_query::{tests_cfg::*, *};
     ///
-    /// let table_as: DynIden = SeaRc::new("char");
-    ///
     /// let query = Query::select()
-    ///     .from_as(Char::Table, table_as.clone())
-    ///     .column((table_as.clone(), Char::Character))
+    ///     .from_as(Char::Table, "char")
+    ///     .column(("char", Char::Character))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -972,11 +968,9 @@ impl SelectStatement {
     /// ```
     /// use sea_query::{audit::*, tests_cfg::*, *};
     ///
-    /// let table_as = "alias";
-    ///
     /// let query = Query::select()
-    ///     .from_as((Font::Table, Char::Table), table_as.clone())
-    ///     .column((table_as, Char::Character))
+    ///     .from_as((Font::Table, Char::Table), "alias")
+    ///     .column(("alias", Char::Character))
     ///     .to_owned();
     ///
     /// assert_eq!(
@@ -994,8 +988,8 @@ impl SelectStatement {
     /// assert_eq!(
     ///     query.audit().unwrap().selects(),
     ///     [SchemaTable(
-    ///         Some(SeaRc::new(Font::Table)),
-    ///         SeaRc::new(Char::Table)
+    ///         Some(Font::Table.into_iden()),
+    ///         Char::Table.into_iden()
     ///     )]
     /// );
     /// ```
@@ -1039,7 +1033,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn from_subquery<T>(&mut self, query: SelectStatement, alias: T) -> &mut Self
@@ -1147,7 +1141,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Char::Table), SeaRc::new(Font::Table)]
+    ///     [Char::Table.into_iden(), Font::Table.into_iden()]
     /// );
     ///
     /// // Constructing chained join conditions
@@ -1213,7 +1207,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Char::Table), SeaRc::new(Font::Table)]
+    ///     [Char::Table.into_iden(), Font::Table.into_iden()]
     /// );
     ///
     /// // Constructing chained join conditions
@@ -1457,7 +1451,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Char::Table), SeaRc::new(Font::Table)]
+    ///     [Char::Table.into_iden(), Font::Table.into_iden()]
     /// );
     ///
     /// // Constructing chained join conditions
@@ -1489,7 +1483,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Char::Table), SeaRc::new(Font::Table)]
+    ///     [Char::Table.into_iden(), Font::Table.into_iden()]
     /// );
     /// ```
     pub fn join<R, C>(&mut self, join: JoinType, tbl_ref: R, condition: C) -> &mut Self
@@ -1586,15 +1580,14 @@ impl SelectStatement {
     /// ```
     /// use sea_query::{tests_cfg::*, audit::*, *};
     ///
-    /// let sub_glyph: DynIden = SeaRc::new("sub_glyph");
     /// let query = Query::select()
     ///     .column(Font::Name)
     ///     .from(Font::Table)
     ///     .join_subquery(
     ///         JoinType::LeftJoin,
     ///         Query::select().column(Glyph::Id).from(Glyph::Table).take(),
-    ///         sub_glyph.clone(),
-    ///         Expr::col((Font::Table, Font::Id)).equals((sub_glyph.clone(), Glyph::Id))
+    ///         "sub_glyph",
+    ///         Expr::col((Font::Table, Font::Id)).equals(("sub_glyph", Glyph::Id))
     ///     )
     ///     .to_owned();
     ///
@@ -1612,7 +1605,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Font::Table), SeaRc::new(Glyph::Table)]
+    ///     [Font::Table.into_iden(), Glyph::Table.into_iden()]
     /// );
     ///
     /// // Constructing chained join conditions
@@ -1623,17 +1616,17 @@ impl SelectStatement {
     ///         .join_subquery(
     ///             JoinType::LeftJoin,
     ///             Query::select().column(Glyph::Id).from(Glyph::Table).take(),
-    ///             sub_glyph.clone(),
+    ///             "sub_glyph",
     ///             Condition::all()
-    ///                 .add(Expr::col((Font::Table, Font::Id)).equals((sub_glyph.clone(), Glyph::Id)))
-    ///                 .add(Expr::col((Font::Table, Font::Id)).equals((sub_glyph.clone(), Glyph::Id)))
+    ///                 .add(Expr::col((Font::Table, Font::Id)).equals(("sub_glyph", Glyph::Id)))
+    ///                 .add(Expr::col((Font::Table, Font::Id)).equals(("sub_glyph", Glyph::Id)))
     ///         )
     ///         .to_string(MysqlQueryBuilder),
     ///     r#"SELECT `name` FROM `font` LEFT JOIN (SELECT `id` FROM `glyph`) AS `sub_glyph` ON `font`.`id` = `sub_glyph`.`id` AND `font`.`id` = `sub_glyph`.`id`"#
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Font::Table), SeaRc::new(Glyph::Table)]
+    ///     [Font::Table.into_iden(), Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn join_subquery<T, C>(
@@ -1664,15 +1657,14 @@ impl SelectStatement {
     /// ```
     /// use sea_query::{audit::*, tests_cfg::*, *};
     ///
-    /// let sub_glyph: DynIden = SeaRc::new("sub_glyph");
     /// let query = Query::select()
     ///     .column(Font::Name)
     ///     .from(Font::Table)
     ///     .join_lateral(
     ///         JoinType::LeftJoin,
     ///         Query::select().column(Glyph::Id).from(Glyph::Table).take(),
-    ///         sub_glyph.clone(),
-    ///         Expr::col((Font::Table, Font::Id)).equals((sub_glyph.clone(), Glyph::Id))
+    ///         "sub_glyph",
+    ///         Expr::col((Font::Table, Font::Id)).equals(("sub_glyph", Glyph::Id))
     ///     )
     ///     .to_owned();
     ///
@@ -1686,7 +1678,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Font::Table), SeaRc::new(Glyph::Table)]
+    ///     [Font::Table.into_iden(), Glyph::Table.into_iden()]
     /// );
     ///
     /// // Constructing chained join conditions
@@ -1697,10 +1689,10 @@ impl SelectStatement {
     ///         .join_lateral(
     ///             JoinType::LeftJoin,
     ///             Query::select().column(Glyph::Id).from(Glyph::Table).take(),
-    ///             sub_glyph.clone(),
+    ///             "sub_glyph",
     ///             Condition::all()
-    ///                 .add(Expr::col((Font::Table, Font::Id)).equals((sub_glyph.clone(), Glyph::Id)))
-    ///                 .add(Expr::col((Font::Table, Font::Id)).equals((sub_glyph.clone(), Glyph::Id)))
+    ///                 .add(Expr::col((Font::Table, Font::Id)).equals(("sub_glyph", Glyph::Id)))
+    ///                 .add(Expr::col((Font::Table, Font::Id)).equals(("sub_glyph", Glyph::Id)))
     ///         )
     ///         .to_string(MysqlQueryBuilder),
     ///     r#"SELECT `name` FROM `font` LEFT JOIN LATERAL (SELECT `id` FROM `glyph`) AS `sub_glyph` ON `font`.`id` = `sub_glyph`.`id` AND `font`.`id` = `sub_glyph`.`id`"#
@@ -2279,7 +2271,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Char::Table)]
+    ///     [Char::Table.into_iden()]
     /// );
     /// ```
     pub fn union(&mut self, union_type: UnionType, query: SelectStatement) -> &mut Self {
@@ -2325,7 +2317,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Char::Table), SeaRc::new(Glyph::Table)]
+    ///     [Char::Table.into_iden(), Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn unions<T: IntoIterator<Item = (UnionType, SelectStatement)>>(
@@ -2399,7 +2391,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Task::Table)]
+    ///     [Task::Table.into_iden()]
     /// );
     /// ```
     pub fn with(self, clause: WithClause) -> WithQuery {
@@ -2468,7 +2460,7 @@ impl SelectStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Task::Table)]
+    ///     [Task::Table.into_iden()]
     /// );
     /// ```
     pub fn with_cte<C: Into<WithClause>>(&mut self, clause: C) -> &mut Self {

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -118,11 +118,11 @@ impl UpdateStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().updated_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Char::Table)]
+    ///     [Char::Table.into_iden()]
     /// );
     /// ```
     pub fn from<R>(&mut self, tbl_ref: R) -> &mut Self
@@ -167,7 +167,7 @@ impl UpdateStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().updated_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// assert_eq!(query.audit().unwrap().selected_tables(), []);
     /// ```
@@ -271,11 +271,11 @@ impl UpdateStatement {
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().updated_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// assert_eq!(
     ///     query.audit().unwrap().selected_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn returning(&mut self, returning: ReturningClause) -> &mut Self {
@@ -389,11 +389,11 @@ impl UpdateStatement {
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().updated_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().selected_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn with(self, clause: WithClause) -> WithQuery {
@@ -439,11 +439,11 @@ impl UpdateStatement {
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().updated_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// assert_eq!(
     ///     query.audit_unwrap().selected_tables(),
-    ///     [SeaRc::new(Glyph::Table)]
+    ///     [Glyph::Table.into_iden()]
     /// );
     /// ```
     pub fn with_cte<C: Into<WithClause>>(&mut self, clause: C) -> &mut Self {

--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -810,7 +810,7 @@ impl ColumnDef {
     pub fn take(&mut self) -> Self {
         Self {
             table: self.table.take(),
-            name: std::mem::replace(&mut self.name, SeaRc::new(NullAlias::new())),
+            name: std::mem::replace(&mut self.name, NullAlias::new().into_iden()),
             types: self.types.take(),
             spec: std::mem::take(&mut self.spec),
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -459,7 +459,7 @@ where
     T: Iden,
 {
     fn into_iden(self) -> DynIden {
-        SeaRc::new(self)
+        DynIden(self.quoted())
     }
 }
 

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -41,7 +41,7 @@ fn select_3() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Char::Table)]
+        [Char::Table.into_iden()]
     );
 }
 
@@ -63,7 +63,7 @@ fn select_4() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -80,7 +80,7 @@ fn select_5() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -99,7 +99,7 @@ fn select_6() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -131,7 +131,7 @@ fn select_8() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Char::Table), SeaRc::new(Font::Table)]
+        [Char::Table.into_iden(), Font::Table.into_iden()]
     );
 }
 
@@ -156,9 +156,9 @@ fn select_9() {
     assert_eq!(
         query.audit_unwrap().selected_tables(),
         [
-            SeaRc::new(Char::Table),
-            SeaRc::new(Font::Table),
-            SeaRc::new(Glyph::Table),
+            Char::Table.into_iden(),
+            Font::Table.into_iden(),
+            Glyph::Table.into_iden(),
         ]
     );
 }
@@ -181,7 +181,7 @@ fn select_10() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Char::Table), SeaRc::new(Font::Table)]
+        [Char::Table.into_iden(), Font::Table.into_iden()]
     );
 }
 
@@ -359,7 +359,7 @@ fn select_22() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Char::Table)]
+        [Char::Table.into_iden()]
     );
 }
 
@@ -497,7 +497,7 @@ fn select_32() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Char::Table)]
+        [Char::Table.into_iden()]
     );
 }
 
@@ -517,7 +517,7 @@ fn select_33a() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -541,7 +541,7 @@ fn select_33b() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table), SeaRc::new(Font::Table)]
+        [Glyph::Table.into_iden(), Font::Table.into_iden()]
     );
 }
 
@@ -708,7 +708,7 @@ fn select_41() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1002,7 +1002,7 @@ fn select_55() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Char::Table), SeaRc::new(Font::Table)]
+        [Char::Table.into_iden(), Font::Table.into_iden()]
     );
 }
 
@@ -1101,7 +1101,7 @@ fn select_58() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1124,7 +1124,7 @@ fn select_59() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1220,7 +1220,7 @@ fn select_63() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1241,7 +1241,7 @@ fn insert_2() {
     );
     assert_eq!(
         query.audit_unwrap().inserted_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1335,11 +1335,11 @@ fn insert_from_select() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Font::Table)]
+        [Font::Table.into_iden()]
     );
     assert_eq!(
         query.audit_unwrap().inserted_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1377,11 +1377,11 @@ fn insert_6() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
     assert_eq!(
         query.audit_unwrap().inserted_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1398,7 +1398,7 @@ fn insert_7() {
     assert_eq!(query.audit_unwrap().selected_tables(), []);
     assert_eq!(
         query.audit_unwrap().inserted_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1415,11 +1415,11 @@ fn insert_8() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
     assert_eq!(
         query.audit_unwrap().inserted_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1491,11 +1491,11 @@ fn insert_11() {
     );
     assert_eq!(
         insert.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
     assert_eq!(
         insert.audit_unwrap().inserted_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1527,7 +1527,7 @@ fn insert_on_conflict_1() {
     assert_eq!(query.audit_unwrap().selected_tables(), []);
     assert_eq!(
         query.audit_unwrap().inserted_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1828,11 +1828,11 @@ fn insert_returning_specific_columns() {
     );
     assert_eq!(
         query.audit_unwrap().selected_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
     assert_eq!(
         query.audit_unwrap().inserted_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1855,7 +1855,7 @@ fn update_1() {
     );
     assert_eq!(
         query.audit_unwrap().updated_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 
@@ -1939,7 +1939,7 @@ fn delete_1() {
     );
     assert_eq!(
         query.audit_unwrap().deleted_tables(),
-        [SeaRc::new(Glyph::Table)]
+        [Glyph::Table.into_iden()]
     );
 }
 

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1797,19 +1797,19 @@ fn recursive_with_multiple_ctes() {
         .column(Asterisk)
         .from(Char::Table)
         .to_owned();
-    let sub_select1_name = SeaRc::new("sub1");
+    let sub_select1_name = "sub1";
     let mut sub_select1_cte = CommonTableExpression::new();
-    sub_select1_cte.table_name(sub_select1_name.clone());
-    sub_select1_cte.column(SeaRc::new("a"));
+    sub_select1_cte.table_name(sub_select1_name);
+    sub_select1_cte.column("a");
     sub_select1_cte.query(sub_select1);
     let sub_select2 = Query::select()
         .column(Asterisk)
         .from(Char::Table)
         .to_owned();
-    let sub_select2_name = SeaRc::new("sub2");
+    let sub_select2_name = "sub2";
     let mut sub_select2_cte = CommonTableExpression::new();
-    sub_select2_cte.table_name(sub_select2_name.clone());
-    sub_select2_cte.column(SeaRc::new("b"));
+    sub_select2_cte.table_name(sub_select2_name);
+    sub_select2_cte.column("b");
     sub_select2_cte.query(sub_select2);
 
     let mut with = WithClause::new();
@@ -1820,11 +1820,11 @@ fn recursive_with_multiple_ctes() {
     let mut main_sel2 = Query::select();
     main_sel2
         .expr(Expr::col(Asterisk))
-        .from(TableRef::Table(sub_select2_name));
+        .from(TableRef::Table(sub_select2_name.into_iden()));
     let mut main_sel1 = Query::select();
     main_sel1
         .expr(Expr::col(Asterisk))
-        .from(TableRef::Table(sub_select1_name))
+        .from(TableRef::Table(sub_select1_name.into_iden()))
         .union(UnionType::All, main_sel2);
 
     let query = with.query(main_sel1);


### PR DESCRIPTION
`SeaRc::new` is a compatibility hack that's going to be deprecated in the future. Let's start moving away from it.