### PR TITLE
Forbid unsafe code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Enhancements
 
+* `#![forbid(unsafe_code)]` in all workspace crates.
+
 * Removed unnecessary `'static` bounds from type signatures.
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ See [examples](https://github.com/SeaQL/sea-query/blob/master/examples) for usag
 
 SeaQuery is the foundation of [SeaORM](https://github.com/SeaQL/sea-orm), an async & dynamic ORM for Rust.
 
+SeaQuery is written in 100% safe Rust. All workspace crates `#![forbid(unsafe_code)]`.
+
 [![GitHub stars](https://img.shields.io/github/stars/SeaQL/sea-query.svg?style=social&label=Star&maxAge=1)](https://github.com/SeaQL/sea-query/stargazers/)
 If you like what we do, consider starring, commenting, sharing and contributing!
 

--- a/sea-query-binder/src/lib.rs
+++ b/sea-query-binder/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 //! Driver library for using SeaQuery with SQLx
 //!
 //! This library introduces various traits that add methods to the query types from `sea-query`.

--- a/sea-query-derive/src/lib.rs
+++ b/sea-query-derive/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use std::convert::{TryFrom, TryInto};
 
 use darling::FromMeta;

--- a/sea-query-diesel/src/lib.rs
+++ b/sea-query-diesel/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use diesel::backend::Backend;
 use diesel::result::QueryResult;
 use sea_query::{DeleteStatement, InsertStatement, SelectStatement, UpdateStatement, WithQuery};

--- a/sea-query-postgres/src/lib.rs
+++ b/sea-query-postgres/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use std::error::Error;
 
 use bytes::BytesMut;

--- a/sea-query-rbatis/src/lib.rs
+++ b/sea-query-rbatis/src/lib.rs
@@ -1,5 +1,7 @@
-use rbs::to_value;
+#![forbid(unsafe_code)]
+
 use rbs::Value as RbValue;
+use rbs::to_value;
 use sea_query::*;
 pub trait SqlxBinder {
     fn build_rbs<T: QueryBuilder>(&self, query_builder: T) -> (String, Vec<rbs::Value>);
@@ -79,19 +81,35 @@ fn to_rb_values(values: Values) -> Vec<rbs::Value> {
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTime(t) => {
-                args.push(Value::ChronoDateTime(t).chrono_as_naive_utc_in_string().to());
+                args.push(
+                    Value::ChronoDateTime(t)
+                        .chrono_as_naive_utc_in_string()
+                        .to(),
+                );
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeUtc(t) => {
-                args.push(Value::ChronoDateTimeUtc(t).chrono_as_naive_utc_in_string().to());
+                args.push(
+                    Value::ChronoDateTimeUtc(t)
+                        .chrono_as_naive_utc_in_string()
+                        .to(),
+                );
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeLocal(t) => {
-                args.push(Value::ChronoDateTimeLocal(t).chrono_as_naive_utc_in_string().to());
+                args.push(
+                    Value::ChronoDateTimeLocal(t)
+                        .chrono_as_naive_utc_in_string()
+                        .to(),
+                );
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(t) => {
-                args.push(Value::ChronoDateTimeWithTimeZone(t).chrono_as_naive_utc_in_string().to());
+                args.push(
+                    Value::ChronoDateTimeWithTimeZone(t)
+                        .chrono_as_naive_utc_in_string()
+                        .to(),
+                );
             }
             #[cfg(feature = "with-time")]
             Value::TimeDate(t) => {
@@ -107,7 +125,11 @@ fn to_rb_values(values: Values) -> Vec<rbs::Value> {
             }
             #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(t) => {
-                args.push(Value::TimeDateTimeWithTimeZone(t).time_as_naive_utc_in_string().to());
+                args.push(
+                    Value::TimeDateTimeWithTimeZone(t)
+                        .time_as_naive_utc_in_string()
+                        .to(),
+                );
             }
             #[cfg(feature = "with-uuid")]
             Value::Uuid(uuid) => {

--- a/sea-query-rusqlite/src/lib.rs
+++ b/sea-query-rusqlite/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use rusqlite::{
     Result, ToSql,
     types::{Null, ToSqlOutput},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_debug_implementations)]
+#![forbid(unsafe_code)]
 
 //! <div align="center">
 //!
@@ -24,6 +25,8 @@
 //! We provide integration for [SQLx](https://crates.io/crates/sqlx),
 //! [postgres](https://crates.io/crates/postgres) and [rusqlite](https://crates.io/crates/rusqlite).
 //! See [examples](https://github.com/SeaQL/sea-query/blob/master/examples) for usage.
+//!
+//! SeaQuery is written in 100% safe Rust. All workspace crates `#![forbid(unsafe_code)]`.
 //!
 //! SeaQuery is the foundation of [SeaORM](https://github.com/SeaQL/sea-orm), an async & dynamic ORM for Rust.
 //!


### PR DESCRIPTION
## Changes

- [x] `#![forbid(unsafe_code)]` in all workspace crates.

Now that we don't have that weird `PartialEq` impl, we can do this and advertise it.