### PR TITLE
Enable clippy::nursery

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+channel = "1.85"
+components = [
+	"rustfmt",
+	"clippy",
+]

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -92,9 +92,7 @@ impl QueryBuilder for MysqlQueryBuilder {
     ) {
         use std::ops::Deref;
 
-        if from.is_empty() {
-            self.prepare_iden(column, sql);
-        } else {
+        if !from.is_empty() {
             if let Some(table) = table {
                 // Support only "naked" table names with no schema or alias.
                 if let TableRef::Table(TableName(None, table), None) = table.deref() {
@@ -103,8 +101,8 @@ impl QueryBuilder for MysqlQueryBuilder {
                     return;
                 }
             }
-            self.prepare_iden(column, sql);
         }
+        self.prepare_iden(column, sql)
     }
 
     fn prepare_update_condition(

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -282,7 +282,7 @@ impl PostgresQueryBuilder {
         f(column_def, sql);
 
         for column_spec in column_def.spec.iter() {
-            if let ColumnSpec::AutoIncrement = column_spec {
+            if matches!(column_spec, ColumnSpec::AutoIncrement) {
                 continue;
             }
             if let ColumnSpec::Comment(_) = column_spec {

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -262,11 +262,12 @@ impl PostgresQueryBuilder {
                 .spec
                 .iter()
                 .position(|s| matches!(s, ColumnSpec::AutoIncrement));
+
+            write!(sql, " ").unwrap();
+
             if is_auto_increment.is_some() {
-                write!(sql, " ").unwrap();
                 self.prepare_column_auto_increment(column_type, sql);
             } else {
-                write!(sql, " ").unwrap();
                 self.prepare_column_type(column_type, sql);
             }
         }

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -13,11 +13,11 @@ impl TableBuilder for SqliteQueryBuilder {
         let mut is_auto_increment = false;
 
         for column_spec in column_def.spec.iter() {
-            if let ColumnSpec::PrimaryKey = column_spec {
+            if matches!(column_spec, ColumnSpec::PrimaryKey) {
                 is_primary_key = true;
                 continue;
             }
-            if let ColumnSpec::AutoIncrement = column_spec {
+            if matches!(column_spec, ColumnSpec::AutoIncrement) {
                 is_auto_increment = true;
                 continue;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,14 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![warn(clippy::nursery)]
 #![deny(missing_debug_implementations)]
 #![forbid(unsafe_code)]
+#![allow(
+    clippy::derive_partial_eq_without_eq,
+    clippy::option_if_let_else,
+    clippy::redundant_pub_crate,
+    clippy::use_self,
+    clippy::missing_const_for_fn
+)]
 
 //! <div align="center">
 //!

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -592,11 +592,7 @@ impl SelectStatement {
         T: IntoColumnRef,
         I: IntoIterator<Item = T>,
     {
-        self.exprs(
-            cols.into_iter()
-                .map(|c| Expr::Column(c.into_column_ref()))
-                .collect::<Vec<Expr>>(),
-        )
+        self.exprs(cols.into_iter().map(|c| Expr::Column(c.into_column_ref())))
     }
 
     /// Select column.
@@ -1794,11 +1790,7 @@ impl SelectStatement {
         T: IntoColumnRef,
         I: IntoIterator<Item = T>,
     {
-        self.add_group_by(
-            cols.into_iter()
-                .map(|c| Expr::Column(c.into_column_ref()))
-                .collect::<Vec<_>>(),
-        )
+        self.add_group_by(cols.into_iter().map(|c| Expr::Column(c.into_column_ref())))
     }
 
     /// Add a group by column.

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -242,10 +242,11 @@ impl Search {
     }
 }
 
-/// For recursive [`WithQuery`] [`WithClauses`](WithClause) the CYCLE sql clause can be specified to avoid creating
+/// For recursive [WithQuery] [WithClauses](WithClause) the CYCLE sql clause can be specified to avoid creating
 /// an infinite traversals that loops on graph cycles indefinitely.
 ///
 /// You specify an expression that identifies a node in the graph, which is used during the query execution iteration, to determine newly appended values are distinct new nodes or are already visited, and therefore they should be added into the result again.
+///
 /// A query can have both SEARCH and CYCLE clauses.
 ///
 /// Setting [Self::set], [Self::expr] and [Self::using] is mandatory.

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -242,12 +242,10 @@ impl Search {
     }
 }
 
-/// For recursive [WithQuery] [WithClause]s the CYCLE sql clause can be specified to avoid creating
-/// an infinite traversals that loops on graph cycles indefinitely. You specify an expression that
-/// identifies a node in the graph and that will be used to determine during the iteration of
-/// the execution of the query when appending of new values whether the new values are distinct new
-/// nodes or are already visited and therefore they should be added again into the result.
+/// For recursive [`WithQuery`] [`WithClauses`](WithClause) the CYCLE sql clause can be specified to avoid creating
+/// an infinite traversals that loops on graph cycles indefinitely.
 ///
+/// You specify an expression that identifies a node in the graph, which is used during the query execution iteration, to determine newly appended values are distinct new nodes or are already visited, and therefore they should be added into the result again.
 /// A query can have both SEARCH and CYCLE clauses.
 ///
 /// Setting [Self::set], [Self::expr] and [Self::using] is mandatory.

--- a/src/value.rs
+++ b/src/value.rs
@@ -320,6 +320,7 @@ pub enum Value {
 }
 
 /// This test is to check if the size of [`Value`] exceeds the limit.
+///
 /// If the size exceeds the limit, you should box the variant.
 /// Previously, the size was 24. We bumped it to 32 such that `String`
 /// can be unboxed.


### PR DESCRIPTION
## PR Info
I’ve enabled `clippy::nursery`, which helps us write more readable code.
for example, from:

```
if from.is_empty() {
    self.prepare_iden(column, sql);
} else {
    if let Some(table) = table {
        if let TableRef::Table(table) = table.deref() {
            self.prepare_column_ref(
                &ColumnRef::TableColumn(table.clone(), column.clone()),
                sql,
            );
            return;
        }
    }
    self.prepare_iden(column, sql);
}
```

to:
```rust
if !from.is_empty()
    && let Some(table) = table
    && let TableRef::Table(table) = table.deref()
{
    self.prepare_column_ref(&ColumnRef::TableColumn(table.clone(), column.clone()), sql);
} else {
    self.prepare_iden(column, sql);
}
```

## Changes

- [x] Some functions are marked as const
