### PR TITLE
Remove unneeded allocations

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -69,16 +69,16 @@ pub trait EscapeBuilder {
     fn write_escaped(&self, buffer: &mut dyn Write, string: &str) {
         for c in string.chars() {
             match c {
-                '\\' => write!(buffer, "\\\\"),
-                '"' => write!(buffer, "\\\""),
-                '\'' => write!(buffer, "\\'"),
-                '\0' => write!(buffer, "\\0"),
-                '\x08' => write!(buffer, "\\b"),
-                '\x09' => write!(buffer, "\\t"),
-                '\x1a' => write!(buffer, "\\z"),
-                '\n' => write!(buffer, "\\n"),
-                '\r' => write!(buffer, "\\r"),
-                _ => write!(buffer, "{}", c),
+                '\\' => buffer.write_str("\\\\"),
+                '"' => buffer.write_str("\\\""),
+                '\'' => buffer.write_str("\\'"),
+                '\0' => buffer.write_str("\\0"),
+                '\x08' => buffer.write_str("\\b"),
+                '\x09' => buffer.write_str("\\t"),
+                '\x1a' => buffer.write_str("\\z"),
+                '\n' => buffer.write_str("\\n"),
+                '\r' => buffer.write_str("\\r"),
+                _ => buffer.write_char(c),
             }
             .unwrap()
         }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -58,6 +58,15 @@ pub trait QuotedBuilder {
     }
 }
 
+pub(crate) fn need_escape(s: &str) -> bool {
+    s.chars().any(|c| {
+        matches!(
+            c,
+            '\r' | '\n' | '\x1a' | '\x09' | '\x08' | '\0' | '\'' | '"' | '\\'
+        )
+    })
+}
+
 pub trait EscapeBuilder {
     /// Escape a SQL string literal
     fn escape_string(&self, string: &str) -> String {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -61,16 +61,27 @@ pub trait QuotedBuilder {
 pub trait EscapeBuilder {
     /// Escape a SQL string literal
     fn escape_string(&self, string: &str) -> String {
-        string
-            .replace('\\', "\\\\")
-            .replace('"', "\\\"")
-            .replace('\'', "\\'")
-            .replace('\0', "\\0")
-            .replace('\x08', "\\b")
-            .replace('\x09', "\\t")
-            .replace('\x1a', "\\z")
-            .replace('\n', "\\n")
-            .replace('\r', "\\r")
+        let mut escaped = String::with_capacity(string.len() + 8);
+        self.write_escaped(&mut escaped, string);
+        escaped
+    }
+
+    fn write_escaped(&self, buffer: &mut dyn Write, string: &str) {
+        for c in string.chars() {
+            match c {
+                '\\' => write!(buffer, "\\\\"),
+                '"' => write!(buffer, "\\\""),
+                '\'' => write!(buffer, "\\'"),
+                '\0' => write!(buffer, "\\0"),
+                '\x08' => write!(buffer, "\\b"),
+                '\x09' => write!(buffer, "\\t"),
+                '\x1a' => write!(buffer, "\\z"),
+                '\n' => write!(buffer, "\\n"),
+                '\r' => write!(buffer, "\\r"),
+                _ => write!(buffer, "{}", c),
+            }
+            .unwrap()
+        }
     }
 
     /// Unescape a SQL string literal

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -174,14 +174,14 @@ impl QueryBuilder for PostgresQueryBuilder {
         sql.push_param(value, self as _);
     }
 
-    fn write_string_quoted(&self, string: &str, buffer: &mut String) {
-        let escaped = self.escape_string(string);
-        let string = if escaped.find('\\').is_some() {
-            "E'".to_owned() + &escaped + "'"
+    fn write_string_quoted(&self, string: &str, buffer: &mut dyn Write) {
+        if need_escape(string) {
+            buffer.write_str("E'").unwrap();
         } else {
-            "'".to_owned() + &escaped + "'"
-        };
-        write!(buffer, "{string}").unwrap()
+            buffer.write_str("'").unwrap();
+        }
+        self.write_escaped(buffer, string);
+        buffer.write_str("'").unwrap();
     }
 
     fn write_bytes(&self, bytes: &[u8], buffer: &mut String) {

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -184,7 +184,7 @@ impl QueryBuilder for PostgresQueryBuilder {
         buffer.write_str("'").unwrap();
     }
 
-    fn write_bytes(&self, bytes: &[u8], buffer: &mut String) {
+    fn write_bytes(&self, bytes: &[u8], buffer: &mut dyn Write) {
         write!(buffer, "'\\x").unwrap();
         for b in bytes {
             write!(buffer, "{b:02X}").unwrap();

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1688,24 +1688,33 @@ where
                 if v.is_empty() {
                     write!(s, "'{{}}'").unwrap()
                 } else {
-                    write!(
-                        s,
-                        "ARRAY [{}]",
-                        v.iter()
-                            .map(|element| self.value_to_string(element))
-                            .collect::<Vec<String>>()
-                            .join(",")
-                    )
-                    .unwrap()
+                    write!(s, "ARRAY [").unwrap();
+
+                    let mut viter = v.iter();
+
+                    if let Some(element) = viter.next() {
+                        self.write_value(s, element);
+                    }
+
+                    for element in viter {
+                        write!(s, ", ").unwrap();
+                        self.write_value(s, element);
+                    }
+
+                    write!(s, "]").unwrap();
                 }
             }
             #[cfg(feature = "postgres-vector")]
             Value::Vector(Some(v)) => {
                 write!(s, "'[").unwrap();
-                for (i, &element) in v.as_slice().iter().enumerate() {
-                    if i != 0 {
-                        write!(s, ",").unwrap();
-                    }
+                let mut viter = v.as_slice().iter();
+
+                if let Some(element) = viter.next() {
+                    write!(s, "{element}").unwrap();
+                }
+
+                for element in viter {
+                    write!(s, ",").unwrap();
                     write!(s, "{element}").unwrap();
                 }
                 write!(s, "]'").unwrap();

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1118,7 +1118,7 @@ pub trait QueryBuilder:
             Value::Char(Some(v)) => {
                 self.write_string_quoted(std::str::from_utf8(&[*v as u8]).unwrap(), buffer)
             }
-            Value::Bytes(Some(v)) => self.write_bytes_dyn(v, buffer),
+            Value::Bytes(Some(v)) => self.write_bytes(v, buffer),
             #[cfg(feature = "with-json")]
             Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), buffer),
             #[cfg(feature = "with-chrono")]
@@ -1545,17 +1545,7 @@ pub trait QueryBuilder:
 
     #[doc(hidden)]
     /// Write bytes enclosed with engine specific byte syntax
-    fn write_bytes(&self, bytes: &[u8], buffer: &mut String) {
-        write!(buffer, "x'").unwrap();
-        for b in bytes {
-            write!(buffer, "{b:02X}").unwrap();
-        }
-        write!(buffer, "'").unwrap();
-    }
-
-    #[doc(hidden)]
-    /// Write bytes enclosed with engine specific byte syntax
-    fn write_bytes_dyn(&self, bytes: &[u8], buffer: &mut dyn Write) {
+    fn write_bytes(&self, bytes: &[u8], buffer: &mut dyn Write) {
         write!(buffer, "x'").unwrap();
         for b in bytes {
             write!(buffer, "{b:02X}").unwrap();

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1043,7 +1043,7 @@ pub trait QueryBuilder:
     }
 
     #[doc(hidden)]
-    fn write_value(&self, s: &mut String, value: &Value) {
+    fn write_value(&self, buffer: &mut dyn Write, value: &Value) {
         match value {
             Value::Bool(None)
             | Value::TinyInt(None)
@@ -1058,106 +1058,111 @@ pub trait QueryBuilder:
             | Value::Double(None)
             | Value::String(None)
             | Value::Char(None)
-            | Value::Bytes(None) => write!(s, "NULL").unwrap(),
+            | Value::Bytes(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-json")]
-            Value::Json(None) => write!(s, "NULL").unwrap(),
+            Value::Json(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDate(None) => write!(s, "NULL").unwrap(),
+            Value::ChronoDate(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoTime(None) => write!(s, "NULL").unwrap(),
+            Value::ChronoTime(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTime(None) => write!(s, "NULL").unwrap(),
+            Value::ChronoDateTime(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeUtc(None) => write!(s, "NULL").unwrap(),
+            Value::ChronoDateTimeUtc(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeLocal(None) => write!(s, "NULL").unwrap(),
+            Value::ChronoDateTimeLocal(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            Value::ChronoDateTimeWithTimeZone(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
-            Value::TimeDate(None) => write!(s, "NULL").unwrap(),
+            Value::TimeDate(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
-            Value::TimeTime(None) => write!(s, "NULL").unwrap(),
+            Value::TimeTime(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
-            Value::TimeDateTime(None) => write!(s, "NULL").unwrap(),
+            Value::TimeDateTime(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-time")]
-            Value::TimeDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            Value::TimeDateTimeWithTimeZone(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffDate(None) => write!(s, "NULL").unwrap(),
+            Value::JiffDate(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffTime(None) => write!(s, "NULL").unwrap(),
+            Value::JiffTime(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffDateTime(None) => write!(s, "NULL").unwrap(),
+            Value::JiffDateTime(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffTimestamp(None) => write!(s, "NULL").unwrap(),
+            Value::JiffTimestamp(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffZoned(None) => write!(s, "NULL").unwrap(),
+            Value::JiffZoned(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-rust_decimal")]
-            Value::Decimal(None) => write!(s, "NULL").unwrap(),
+            Value::Decimal(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-bigdecimal")]
-            Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
+            Value::BigDecimal(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-uuid")]
-            Value::Uuid(None) => write!(s, "NULL").unwrap(),
+            Value::Uuid(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-ipnetwork")]
-            Value::IpNetwork(None) => write!(s, "NULL").unwrap(),
+            Value::IpNetwork(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "with-mac_address")]
-            Value::MacAddress(None) => write!(s, "NULL").unwrap(),
+            Value::MacAddress(None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "postgres-array")]
-            Value::Array(_, None) => write!(s, "NULL").unwrap(),
+            Value::Array(_, None) => write!(buffer, "NULL").unwrap(),
             #[cfg(feature = "postgres-vector")]
-            Value::Vector(None) => write!(s, "NULL").unwrap(),
-            Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
-            Value::TinyInt(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::SmallInt(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Int(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::BigInt(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::TinyUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::SmallUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Unsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::BigUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Float(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Double(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::String(Some(v)) => self.write_string_quoted(v, s),
-            Value::Char(Some(v)) => {
-                self.write_string_quoted(std::str::from_utf8(&[*v as u8]).unwrap(), s)
+            Value::Vector(None) => write!(buffer, "NULL").unwrap(),
+            Value::Bool(Some(b)) => {
+                write!(buffer, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap()
             }
-            Value::Bytes(Some(v)) => self.write_bytes(v, s),
+            Value::TinyInt(Some(v)) => write!(buffer, "{v}").unwrap(),
+            Value::SmallInt(Some(v)) => write!(buffer, "{v}").unwrap(),
+            Value::Int(Some(v)) => write!(buffer, "{v}").unwrap(),
+            Value::BigInt(Some(v)) => write!(buffer, "{v}").unwrap(),
+            Value::TinyUnsigned(Some(v)) => write!(buffer, "{v}").unwrap(),
+            Value::SmallUnsigned(Some(v)) => write!(buffer, "{v}").unwrap(),
+            Value::Unsigned(Some(v)) => write!(buffer, "{v}").unwrap(),
+            Value::BigUnsigned(Some(v)) => write!(buffer, "{v}").unwrap(),
+            Value::Float(Some(v)) => write!(buffer, "{v}").unwrap(),
+            Value::Double(Some(v)) => write!(buffer, "{v}").unwrap(),
+            Value::String(Some(v)) => self.write_string_quoted_dyn(v, buffer),
+            Value::Char(Some(v)) => {
+                self.write_string_quoted_dyn(std::str::from_utf8(&[*v as u8]).unwrap(), buffer)
+            }
+            Value::Bytes(Some(v)) => self.write_bytes_dyn(v, buffer),
             #[cfg(feature = "with-json")]
-            Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), s),
+            Value::Json(Some(v)) => self.write_string_quoted_dyn(&v.to_string(), buffer),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDate(Some(v)) => write!(s, "'{}'", v.format("%Y-%m-%d")).unwrap(),
+            Value::ChronoDate(Some(v)) => write!(buffer, "'{}'", v.format("%Y-%m-%d")).unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoTime(Some(v)) => write!(s, "'{}'", v.format("%H:%M:%S")).unwrap(),
+            Value::ChronoTime(Some(v)) => write!(buffer, "'{}'", v.format("%H:%M:%S")).unwrap(),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTime(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S")).unwrap()
+                write!(buffer, "'{}'", v.format("%Y-%m-%d %H:%M:%S")).unwrap()
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeUtc(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
+                write!(buffer, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeLocal(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
+                write!(buffer, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
             #[cfg(feature = "with-chrono")]
             Value::ChronoDateTimeWithTimeZone(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
+                write!(buffer, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
             }
             #[cfg(feature = "with-time")]
             Value::TimeDate(Some(v)) => {
-                write!(s, "'{}'", v.format(time_format::FORMAT_DATE).unwrap()).unwrap()
+                write!(buffer, "'{}'", v.format(time_format::FORMAT_DATE).unwrap()).unwrap()
             }
             #[cfg(feature = "with-time")]
             Value::TimeTime(Some(v)) => {
-                write!(s, "'{}'", v.format(time_format::FORMAT_TIME).unwrap()).unwrap()
+                write!(buffer, "'{}'", v.format(time_format::FORMAT_TIME).unwrap()).unwrap()
             }
             #[cfg(feature = "with-time")]
-            Value::TimeDateTime(Some(v)) => {
-                write!(s, "'{}'", v.format(time_format::FORMAT_DATETIME).unwrap()).unwrap()
-            }
+            Value::TimeDateTime(Some(v)) => write!(
+                buffer,
+                "'{}'",
+                v.format(time_format::FORMAT_DATETIME).unwrap()
+            )
+            .unwrap(),
             #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(Some(v)) => write!(
-                s,
+                buffer,
                 "'{}'",
                 v.format(time_format::FORMAT_DATETIME_TZ).unwrap()
             )
@@ -1165,73 +1170,73 @@ pub trait QueryBuilder:
             // Jiff date and time dosen't need format string
             // The default behavior is what we want
             #[cfg(feature = "with-jiff")]
-            Value::JiffDate(Some(v)) => write!(s, "'{v}'").unwrap(),
+            Value::JiffDate(Some(v)) => write!(buffer, "'{v}'").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffTime(Some(v)) => write!(s, "'{v}'").unwrap(),
+            Value::JiffTime(Some(v)) => write!(buffer, "'{v}'").unwrap(),
             // Both JiffDateTime and JiffTimestamp map to timestamp
             #[cfg(feature = "with-jiff")]
             Value::JiffDateTime(Some(v)) => {
                 use crate::with_jiff::JIFF_DATE_TIME_FMT_STR;
-                write!(s, "'{}'", v.strftime(JIFF_DATE_TIME_FMT_STR)).unwrap()
+                write!(buffer, "'{}'", v.strftime(JIFF_DATE_TIME_FMT_STR)).unwrap()
             }
             #[cfg(feature = "with-jiff")]
             Value::JiffTimestamp(Some(v)) => {
                 use crate::with_jiff::JIFF_TIMESTAMP_FMT_STR;
-                write!(s, "'{}'", v.strftime(JIFF_TIMESTAMP_FMT_STR)).unwrap()
+                write!(buffer, "'{}'", v.strftime(JIFF_TIMESTAMP_FMT_STR)).unwrap()
             }
             #[cfg(feature = "with-jiff")]
             Value::JiffZoned(Some(v)) => {
                 // Zoned map to timestamp with timezone
 
                 use crate::with_jiff::JIFF_ZONE_FMT_STR;
-                write!(s, "'{}'", v.strftime(JIFF_ZONE_FMT_STR)).unwrap()
+                write!(buffer, "'{}'", v.strftime(JIFF_ZONE_FMT_STR)).unwrap()
             }
             #[cfg(feature = "with-rust_decimal")]
-            Value::Decimal(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::Decimal(Some(v)) => write!(buffer, "{v}").unwrap(),
             #[cfg(feature = "with-bigdecimal")]
-            Value::BigDecimal(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::BigDecimal(Some(v)) => write!(buffer, "{v}").unwrap(),
             #[cfg(feature = "with-uuid")]
-            Value::Uuid(Some(v)) => write!(s, "'{v}'").unwrap(),
+            Value::Uuid(Some(v)) => write!(buffer, "'{v}'").unwrap(),
             #[cfg(feature = "postgres-array")]
             Value::Array(_, Some(v)) => {
                 if v.is_empty() {
-                    write!(s, "'{{}}'").unwrap()
+                    write!(buffer, "'{{}}'").unwrap()
                 } else {
-                    write!(s, "ARRAY [").unwrap();
+                    write!(buffer, "ARRAY [").unwrap();
 
                     let mut viter = v.iter();
 
                     if let Some(element) = viter.next() {
-                        self.write_value(s, element);
+                        self.write_value(buffer, element);
                     }
 
                     for element in viter {
-                        write!(s, ", ").unwrap();
-                        self.write_value(s, element);
+                        write!(buffer, ", ").unwrap();
+                        self.write_value(buffer, element);
                     }
 
-                    write!(s, "]").unwrap();
+                    write!(buffer, "]").unwrap();
                 }
             }
             #[cfg(feature = "postgres-vector")]
             Value::Vector(Some(v)) => {
-                write!(s, "'[").unwrap();
+                write!(buffer, "'[").unwrap();
                 let mut viter = v.as_slice().iter();
 
                 if let Some(element) = viter.next() {
-                    write!(s, "{element}").unwrap();
+                    write!(buffer, "{element}").unwrap();
                 }
 
                 for element in viter {
-                    write!(s, ",").unwrap();
-                    write!(s, "{element}").unwrap();
+                    write!(buffer, ",").unwrap();
+                    write!(buffer, "{element}").unwrap();
                 }
-                write!(s, "]'").unwrap();
+                write!(buffer, "]'").unwrap();
             }
             #[cfg(feature = "with-ipnetwork")]
-            Value::IpNetwork(Some(v)) => write!(s, "'{v}'").unwrap(),
+            Value::IpNetwork(Some(v)) => write!(buffer, "'{v}'").unwrap(),
             #[cfg(feature = "with-mac_address")]
-            Value::MacAddress(Some(v)) => write!(s, "'{v}'").unwrap(),
+            Value::MacAddress(Some(v)) => write!(buffer, "'{v}'").unwrap(),
         };
     }
 
@@ -1543,8 +1548,23 @@ pub trait QueryBuilder:
     }
 
     #[doc(hidden)]
+    fn write_string_quoted_dyn(&self, string: &str, buffer: &mut dyn Write) {
+        write!(buffer, "'{}'", self.escape_string(string)).unwrap()
+    }
+
+    #[doc(hidden)]
     /// Write bytes enclosed with engine specific byte syntax
     fn write_bytes(&self, bytes: &[u8], buffer: &mut String) {
+        write!(buffer, "x'").unwrap();
+        for b in bytes {
+            write!(buffer, "{b:02X}").unwrap();
+        }
+        write!(buffer, "'").unwrap();
+    }
+
+    #[doc(hidden)]
+    /// Write bytes enclosed with engine specific byte syntax
+    fn write_bytes_dyn(&self, bytes: &[u8], buffer: &mut dyn Write) {
         write!(buffer, "x'").unwrap();
         for b in bytes {
             write!(buffer, "{b:02X}").unwrap();

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1114,13 +1114,13 @@ pub trait QueryBuilder:
             Value::BigUnsigned(Some(v)) => write!(buffer, "{v}")?,
             Value::Float(Some(v)) => write!(buffer, "{v}")?,
             Value::Double(Some(v)) => write!(buffer, "{v}")?,
-            Value::String(Some(v)) => self.write_string_quoted_dyn(v, buffer),
+            Value::String(Some(v)) => self.write_string_quoted(v, buffer),
             Value::Char(Some(v)) => {
-                self.write_string_quoted_dyn(std::str::from_utf8(&[*v as u8]).unwrap(), buffer)
+                self.write_string_quoted(std::str::from_utf8(&[*v as u8]).unwrap(), buffer)
             }
             Value::Bytes(Some(v)) => self.write_bytes_dyn(v, buffer),
             #[cfg(feature = "with-json")]
-            Value::Json(Some(v)) => self.write_string_quoted_dyn(&v.to_string(), buffer),
+            Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), buffer),
             #[cfg(feature = "with-chrono")]
             Value::ChronoDate(Some(v)) => write!(buffer, "'{}'", v.format("%Y-%m-%d"))?,
             #[cfg(feature = "with-chrono")]
@@ -1539,12 +1539,7 @@ pub trait QueryBuilder:
 
     #[doc(hidden)]
     /// Write a string surrounded by escaped quotes.
-    fn write_string_quoted(&self, string: &str, buffer: &mut String) {
-        write!(buffer, "'{}'", self.escape_string(string)).unwrap()
-    }
-
-    #[doc(hidden)]
-    fn write_string_quoted_dyn(&self, string: &str, buffer: &mut dyn Write) {
+    fn write_string_quoted(&self, string: &str, buffer: &mut dyn Write) {
         write!(buffer, "'{}'", self.escape_string(string)).unwrap()
     }
 

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1058,56 +1058,54 @@ pub trait QueryBuilder:
             | Value::Double(None)
             | Value::String(None)
             | Value::Char(None)
-            | Value::Bytes(None) => write!(buffer, "NULL").unwrap(),
+            | Value::Bytes(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-json")]
-            Value::Json(None) => write!(buffer, "NULL").unwrap(),
+            Value::Json(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDate(None) => write!(buffer, "NULL").unwrap(),
+            Value::ChronoDate(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoTime(None) => write!(buffer, "NULL").unwrap(),
+            Value::ChronoTime(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTime(None) => write!(buffer, "NULL").unwrap(),
+            Value::ChronoDateTime(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeUtc(None) => write!(buffer, "NULL").unwrap(),
+            Value::ChronoDateTimeUtc(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeLocal(None) => write!(buffer, "NULL").unwrap(),
+            Value::ChronoDateTimeLocal(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeWithTimeZone(None) => write!(buffer, "NULL").unwrap(),
+            Value::ChronoDateTimeWithTimeZone(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-time")]
-            Value::TimeDate(None) => write!(buffer, "NULL").unwrap(),
+            Value::TimeDate(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-time")]
-            Value::TimeTime(None) => write!(buffer, "NULL").unwrap(),
+            Value::TimeTime(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-time")]
-            Value::TimeDateTime(None) => write!(buffer, "NULL").unwrap(),
+            Value::TimeDateTime(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-time")]
-            Value::TimeDateTimeWithTimeZone(None) => write!(buffer, "NULL").unwrap(),
+            Value::TimeDateTimeWithTimeZone(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffDate(None) => write!(buffer, "NULL").unwrap(),
+            Value::JiffDate(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffTime(None) => write!(buffer, "NULL").unwrap(),
+            Value::JiffTime(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffDateTime(None) => write!(buffer, "NULL").unwrap(),
+            Value::JiffDateTime(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffTimestamp(None) => write!(buffer, "NULL").unwrap(),
+            Value::JiffTimestamp(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-jiff")]
-            Value::JiffZoned(None) => write!(buffer, "NULL").unwrap(),
+            Value::JiffZoned(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-rust_decimal")]
-            Value::Decimal(None) => write!(buffer, "NULL").unwrap(),
+            Value::Decimal(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-bigdecimal")]
-            Value::BigDecimal(None) => write!(buffer, "NULL").unwrap(),
+            Value::BigDecimal(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-uuid")]
-            Value::Uuid(None) => write!(buffer, "NULL").unwrap(),
+            Value::Uuid(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-ipnetwork")]
-            Value::IpNetwork(None) => write!(buffer, "NULL").unwrap(),
+            Value::IpNetwork(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "with-mac_address")]
-            Value::MacAddress(None) => write!(buffer, "NULL").unwrap(),
+            Value::MacAddress(None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "postgres-array")]
-            Value::Array(_, None) => write!(buffer, "NULL").unwrap(),
+            Value::Array(_, None) => buffer.write_str("NULL").unwrap(),
             #[cfg(feature = "postgres-vector")]
-            Value::Vector(None) => write!(buffer, "NULL").unwrap(),
-            Value::Bool(Some(b)) => {
-                write!(buffer, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap()
-            }
+            Value::Vector(None) => buffer.write_str("NULL").unwrap(),
+            Value::Bool(Some(b)) => buffer.write_str(if *b { "TRUE" } else { "FALSE" }).unwrap(),
             Value::TinyInt(Some(v)) => write!(buffer, "{v}").unwrap(),
             Value::SmallInt(Some(v)) => write!(buffer, "{v}").unwrap(),
             Value::Int(Some(v)) => write!(buffer, "{v}").unwrap(),
@@ -1200,9 +1198,9 @@ pub trait QueryBuilder:
             #[cfg(feature = "postgres-array")]
             Value::Array(_, Some(v)) => {
                 if v.is_empty() {
-                    write!(buffer, "'{{}}'").unwrap()
+                    buffer.write_str("{}").unwrap();
                 } else {
-                    write!(buffer, "ARRAY [").unwrap();
+                    buffer.write_str("ARRAY [").unwrap();
 
                     let mut viter = v.iter();
 
@@ -1211,11 +1209,10 @@ pub trait QueryBuilder:
                     }
 
                     for element in viter {
-                        write!(buffer, ", ").unwrap();
+                        buffer.write_str(", ").unwrap();
                         self.write_value(buffer, element);
                     }
-
-                    write!(buffer, "]").unwrap();
+                    buffer.write_str("]").unwrap();
                 }
             }
             #[cfg(feature = "postgres-vector")]
@@ -1228,10 +1225,11 @@ pub trait QueryBuilder:
                 }
 
                 for element in viter {
-                    write!(buffer, ",").unwrap();
+                    buffer.write_str(",").unwrap();
+
                     write!(buffer, "{element}").unwrap();
                 }
-                write!(buffer, "]'").unwrap();
+                buffer.write_str("]").unwrap();
             }
             #[cfg(feature = "with-ipnetwork")]
             Value::IpNetwork(Some(v)) => write!(buffer, "'{v}'").unwrap(),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1038,186 +1038,7 @@ pub trait QueryBuilder:
 
     fn value_to_string_common(&self, v: &Value) -> String {
         let mut s = String::new();
-        match v {
-            Value::Bool(None)
-            | Value::TinyInt(None)
-            | Value::SmallInt(None)
-            | Value::Int(None)
-            | Value::BigInt(None)
-            | Value::TinyUnsigned(None)
-            | Value::SmallUnsigned(None)
-            | Value::Unsigned(None)
-            | Value::BigUnsigned(None)
-            | Value::Float(None)
-            | Value::Double(None)
-            | Value::String(None)
-            | Value::Char(None)
-            | Value::Bytes(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-json")]
-            Value::Json(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDate(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeUtc(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeLocal(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
-            Value::TimeDate(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
-            Value::TimeTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
-            Value::TimeDateTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
-            Value::TimeDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffDate(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffDateTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffTimestamp(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffZoned(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-rust_decimal")]
-            Value::Decimal(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-bigdecimal")]
-            Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-uuid")]
-            Value::Uuid(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-ipnetwork")]
-            Value::IpNetwork(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-mac_address")]
-            Value::MacAddress(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "postgres-array")]
-            Value::Array(_, None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "postgres-vector")]
-            Value::Vector(None) => write!(s, "NULL").unwrap(),
-            Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
-            Value::TinyInt(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::SmallInt(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Int(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::BigInt(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::TinyUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::SmallUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Unsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::BigUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Float(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Double(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::String(Some(v)) => self.write_string_quoted(v, &mut s),
-            Value::Char(Some(v)) => {
-                self.write_string_quoted(std::str::from_utf8(&[*v as u8]).unwrap(), &mut s)
-            }
-            Value::Bytes(Some(v)) => self.write_bytes(v, &mut s),
-            #[cfg(feature = "with-json")]
-            Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), &mut s),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDate(Some(v)) => write!(s, "'{}'", v.format("%Y-%m-%d")).unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoTime(Some(v)) => write!(s, "'{}'", v.format("%H:%M:%S")).unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTime(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S")).unwrap()
-            }
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeUtc(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
-            }
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeLocal(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
-            }
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeWithTimeZone(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
-            }
-            #[cfg(feature = "with-time")]
-            Value::TimeDate(Some(v)) => {
-                write!(s, "'{}'", v.format(time_format::FORMAT_DATE).unwrap()).unwrap()
-            }
-            #[cfg(feature = "with-time")]
-            Value::TimeTime(Some(v)) => {
-                write!(s, "'{}'", v.format(time_format::FORMAT_TIME).unwrap()).unwrap()
-            }
-            #[cfg(feature = "with-time")]
-            Value::TimeDateTime(Some(v)) => {
-                write!(s, "'{}'", v.format(time_format::FORMAT_DATETIME).unwrap()).unwrap()
-            }
-            #[cfg(feature = "with-time")]
-            Value::TimeDateTimeWithTimeZone(Some(v)) => write!(
-                s,
-                "'{}'",
-                v.format(time_format::FORMAT_DATETIME_TZ).unwrap()
-            )
-            .unwrap(),
-            // Jiff date and time dosen't need format string
-            // The default behavior is what we want
-            #[cfg(feature = "with-jiff")]
-            Value::JiffDate(Some(v)) => write!(s, "'{v}'").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffTime(Some(v)) => write!(s, "'{v}'").unwrap(),
-            // Both JiffDateTime and JiffTimestamp map to timestamp
-            #[cfg(feature = "with-jiff")]
-            Value::JiffDateTime(Some(v)) => {
-                use crate::with_jiff::JIFF_DATE_TIME_FMT_STR;
-                write!(s, "'{}'", v.strftime(JIFF_DATE_TIME_FMT_STR)).unwrap()
-            }
-            #[cfg(feature = "with-jiff")]
-            Value::JiffTimestamp(Some(v)) => {
-                use crate::with_jiff::JIFF_TIMESTAMP_FMT_STR;
-                write!(s, "'{}'", v.strftime(JIFF_TIMESTAMP_FMT_STR)).unwrap()
-            }
-            #[cfg(feature = "with-jiff")]
-            Value::JiffZoned(Some(v)) => {
-                // Zoned map to timestamp with timezone
-
-                use crate::with_jiff::JIFF_ZONE_FMT_STR;
-                write!(s, "'{}'", v.strftime(JIFF_ZONE_FMT_STR)).unwrap()
-            }
-            #[cfg(feature = "with-rust_decimal")]
-            Value::Decimal(Some(v)) => write!(s, "{v}").unwrap(),
-            #[cfg(feature = "with-bigdecimal")]
-            Value::BigDecimal(Some(v)) => write!(s, "{v}").unwrap(),
-            #[cfg(feature = "with-uuid")]
-            Value::Uuid(Some(v)) => write!(s, "'{v}'").unwrap(),
-            #[cfg(feature = "postgres-array")]
-            Value::Array(_, Some(v)) => {
-                if v.is_empty() {
-                    write!(s, "'{{}}'").unwrap()
-                } else {
-                    write!(
-                        s,
-                        "ARRAY [{}]",
-                        v.iter()
-                            .map(|element| self.value_to_string(element))
-                            .collect::<Vec<String>>()
-                            .join(",")
-                    )
-                    .unwrap()
-                }
-            }
-            #[cfg(feature = "postgres-vector")]
-            Value::Vector(Some(v)) => {
-                write!(s, "'[").unwrap();
-                for (i, &element) in v.as_slice().iter().enumerate() {
-                    if i != 0 {
-                        write!(s, ",").unwrap();
-                    }
-                    write!(s, "{element}").unwrap();
-                }
-                write!(s, "]'").unwrap();
-            }
-            #[cfg(feature = "with-ipnetwork")]
-            Value::IpNetwork(Some(v)) => write!(s, "'{v}'").unwrap(),
-            #[cfg(feature = "with-mac_address")]
-            Value::MacAddress(Some(v)) => write!(s, "'{v}'").unwrap(),
-        };
+        self.write_value(&mut s, v);
         s
     }
 
@@ -1702,4 +1523,197 @@ pub(crate) fn common_well_known_left_associative(op: &BinOper) -> bool {
         op,
         BinOper::And | BinOper::Or | BinOper::Add | BinOper::Sub | BinOper::Mul | BinOper::Mod
     )
+}
+
+trait QueryBuilderInternal {
+    fn write_value(&self, s: &mut String, value: &Value);
+}
+
+impl<T> QueryBuilderInternal for T
+where
+    T: QueryBuilder + ?Sized,
+{
+    #[doc(hidden)]
+    fn write_value(&self, s: &mut String, value: &Value) {
+        match value {
+            Value::Bool(None)
+            | Value::TinyInt(None)
+            | Value::SmallInt(None)
+            | Value::Int(None)
+            | Value::BigInt(None)
+            | Value::TinyUnsigned(None)
+            | Value::SmallUnsigned(None)
+            | Value::Unsigned(None)
+            | Value::BigUnsigned(None)
+            | Value::Float(None)
+            | Value::Double(None)
+            | Value::String(None)
+            | Value::Char(None)
+            | Value::Bytes(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-json")]
+            Value::Json(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDate(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeUtc(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeLocal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-time")]
+            Value::TimeDate(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-time")]
+            Value::TimeTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-time")]
+            Value::TimeDateTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-time")]
+            Value::TimeDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffDate(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffDateTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffTimestamp(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffZoned(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-rust_decimal")]
+            Value::Decimal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-bigdecimal")]
+            Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-uuid")]
+            Value::Uuid(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-ipnetwork")]
+            Value::IpNetwork(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-mac_address")]
+            Value::MacAddress(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "postgres-array")]
+            Value::Array(_, None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "postgres-vector")]
+            Value::Vector(None) => write!(s, "NULL").unwrap(),
+            Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
+            Value::TinyInt(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::SmallInt(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::Int(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::BigInt(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::TinyUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::SmallUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::Unsigned(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::BigUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::Float(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::Double(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::String(Some(v)) => self.write_string_quoted(v, s),
+            Value::Char(Some(v)) => {
+                self.write_string_quoted(std::str::from_utf8(&[*v as u8]).unwrap(), s)
+            }
+            Value::Bytes(Some(v)) => self.write_bytes(v, s),
+            #[cfg(feature = "with-json")]
+            Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), s),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDate(Some(v)) => write!(s, "'{}'", v.format("%Y-%m-%d")).unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoTime(Some(v)) => write!(s, "'{}'", v.format("%H:%M:%S")).unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTime(Some(v)) => {
+                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S")).unwrap()
+            }
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeUtc(Some(v)) => {
+                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
+            }
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeLocal(Some(v)) => {
+                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
+            }
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeWithTimeZone(Some(v)) => {
+                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
+            }
+            #[cfg(feature = "with-time")]
+            Value::TimeDate(Some(v)) => {
+                write!(s, "'{}'", v.format(time_format::FORMAT_DATE).unwrap()).unwrap()
+            }
+            #[cfg(feature = "with-time")]
+            Value::TimeTime(Some(v)) => {
+                write!(s, "'{}'", v.format(time_format::FORMAT_TIME).unwrap()).unwrap()
+            }
+            #[cfg(feature = "with-time")]
+            Value::TimeDateTime(Some(v)) => {
+                write!(s, "'{}'", v.format(time_format::FORMAT_DATETIME).unwrap()).unwrap()
+            }
+            #[cfg(feature = "with-time")]
+            Value::TimeDateTimeWithTimeZone(Some(v)) => write!(
+                s,
+                "'{}'",
+                v.format(time_format::FORMAT_DATETIME_TZ).unwrap()
+            )
+            .unwrap(),
+            // Jiff date and time dosen't need format string
+            // The default behavior is what we want
+            #[cfg(feature = "with-jiff")]
+            Value::JiffDate(Some(v)) => write!(s, "'{v}'").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffTime(Some(v)) => write!(s, "'{v}'").unwrap(),
+            // Both JiffDateTime and JiffTimestamp map to timestamp
+            #[cfg(feature = "with-jiff")]
+            Value::JiffDateTime(Some(v)) => {
+                use crate::with_jiff::JIFF_DATE_TIME_FMT_STR;
+                write!(s, "'{}'", v.strftime(JIFF_DATE_TIME_FMT_STR)).unwrap()
+            }
+            #[cfg(feature = "with-jiff")]
+            Value::JiffTimestamp(Some(v)) => {
+                use crate::with_jiff::JIFF_TIMESTAMP_FMT_STR;
+                write!(s, "'{}'", v.strftime(JIFF_TIMESTAMP_FMT_STR)).unwrap()
+            }
+            #[cfg(feature = "with-jiff")]
+            Value::JiffZoned(Some(v)) => {
+                // Zoned map to timestamp with timezone
+
+                use crate::with_jiff::JIFF_ZONE_FMT_STR;
+                write!(s, "'{}'", v.strftime(JIFF_ZONE_FMT_STR)).unwrap()
+            }
+            #[cfg(feature = "with-rust_decimal")]
+            Value::Decimal(Some(v)) => write!(s, "{v}").unwrap(),
+            #[cfg(feature = "with-bigdecimal")]
+            Value::BigDecimal(Some(v)) => write!(s, "{v}").unwrap(),
+            #[cfg(feature = "with-uuid")]
+            Value::Uuid(Some(v)) => write!(s, "'{v}'").unwrap(),
+            #[cfg(feature = "postgres-array")]
+            Value::Array(_, Some(v)) => {
+                if v.is_empty() {
+                    write!(s, "'{{}}'").unwrap()
+                } else {
+                    write!(
+                        s,
+                        "ARRAY [{}]",
+                        v.iter()
+                            .map(|element| self.value_to_string(element))
+                            .collect::<Vec<String>>()
+                            .join(",")
+                    )
+                    .unwrap()
+                }
+            }
+            #[cfg(feature = "postgres-vector")]
+            Value::Vector(Some(v)) => {
+                write!(s, "'[").unwrap();
+                for (i, &element) in v.as_slice().iter().enumerate() {
+                    if i != 0 {
+                        write!(s, ",").unwrap();
+                    }
+                    write!(s, "{element}").unwrap();
+                }
+                write!(s, "]'").unwrap();
+            }
+            #[cfg(feature = "with-ipnetwork")]
+            Value::IpNetwork(Some(v)) => write!(s, "'{v}'").unwrap(),
+            #[cfg(feature = "with-mac_address")]
+            Value::MacAddress(Some(v)) => write!(s, "'{v}'").unwrap(),
+        };
+    }
 }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1043,6 +1043,199 @@ pub trait QueryBuilder:
     }
 
     #[doc(hidden)]
+    fn write_value(&self, s: &mut String, value: &Value) {
+        match value {
+            Value::Bool(None)
+            | Value::TinyInt(None)
+            | Value::SmallInt(None)
+            | Value::Int(None)
+            | Value::BigInt(None)
+            | Value::TinyUnsigned(None)
+            | Value::SmallUnsigned(None)
+            | Value::Unsigned(None)
+            | Value::BigUnsigned(None)
+            | Value::Float(None)
+            | Value::Double(None)
+            | Value::String(None)
+            | Value::Char(None)
+            | Value::Bytes(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-json")]
+            Value::Json(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDate(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeUtc(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeLocal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-time")]
+            Value::TimeDate(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-time")]
+            Value::TimeTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-time")]
+            Value::TimeDateTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-time")]
+            Value::TimeDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffDate(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffDateTime(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffTimestamp(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffZoned(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-rust_decimal")]
+            Value::Decimal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-bigdecimal")]
+            Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-uuid")]
+            Value::Uuid(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-ipnetwork")]
+            Value::IpNetwork(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "with-mac_address")]
+            Value::MacAddress(None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "postgres-array")]
+            Value::Array(_, None) => write!(s, "NULL").unwrap(),
+            #[cfg(feature = "postgres-vector")]
+            Value::Vector(None) => write!(s, "NULL").unwrap(),
+            Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
+            Value::TinyInt(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::SmallInt(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::Int(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::BigInt(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::TinyUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::SmallUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::Unsigned(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::BigUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::Float(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::Double(Some(v)) => write!(s, "{v}").unwrap(),
+            Value::String(Some(v)) => self.write_string_quoted(v, s),
+            Value::Char(Some(v)) => {
+                self.write_string_quoted(std::str::from_utf8(&[*v as u8]).unwrap(), s)
+            }
+            Value::Bytes(Some(v)) => self.write_bytes(v, s),
+            #[cfg(feature = "with-json")]
+            Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), s),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDate(Some(v)) => write!(s, "'{}'", v.format("%Y-%m-%d")).unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoTime(Some(v)) => write!(s, "'{}'", v.format("%H:%M:%S")).unwrap(),
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTime(Some(v)) => {
+                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S")).unwrap()
+            }
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeUtc(Some(v)) => {
+                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
+            }
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeLocal(Some(v)) => {
+                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
+            }
+            #[cfg(feature = "with-chrono")]
+            Value::ChronoDateTimeWithTimeZone(Some(v)) => {
+                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
+            }
+            #[cfg(feature = "with-time")]
+            Value::TimeDate(Some(v)) => {
+                write!(s, "'{}'", v.format(time_format::FORMAT_DATE).unwrap()).unwrap()
+            }
+            #[cfg(feature = "with-time")]
+            Value::TimeTime(Some(v)) => {
+                write!(s, "'{}'", v.format(time_format::FORMAT_TIME).unwrap()).unwrap()
+            }
+            #[cfg(feature = "with-time")]
+            Value::TimeDateTime(Some(v)) => {
+                write!(s, "'{}'", v.format(time_format::FORMAT_DATETIME).unwrap()).unwrap()
+            }
+            #[cfg(feature = "with-time")]
+            Value::TimeDateTimeWithTimeZone(Some(v)) => write!(
+                s,
+                "'{}'",
+                v.format(time_format::FORMAT_DATETIME_TZ).unwrap()
+            )
+            .unwrap(),
+            // Jiff date and time dosen't need format string
+            // The default behavior is what we want
+            #[cfg(feature = "with-jiff")]
+            Value::JiffDate(Some(v)) => write!(s, "'{v}'").unwrap(),
+            #[cfg(feature = "with-jiff")]
+            Value::JiffTime(Some(v)) => write!(s, "'{v}'").unwrap(),
+            // Both JiffDateTime and JiffTimestamp map to timestamp
+            #[cfg(feature = "with-jiff")]
+            Value::JiffDateTime(Some(v)) => {
+                use crate::with_jiff::JIFF_DATE_TIME_FMT_STR;
+                write!(s, "'{}'", v.strftime(JIFF_DATE_TIME_FMT_STR)).unwrap()
+            }
+            #[cfg(feature = "with-jiff")]
+            Value::JiffTimestamp(Some(v)) => {
+                use crate::with_jiff::JIFF_TIMESTAMP_FMT_STR;
+                write!(s, "'{}'", v.strftime(JIFF_TIMESTAMP_FMT_STR)).unwrap()
+            }
+            #[cfg(feature = "with-jiff")]
+            Value::JiffZoned(Some(v)) => {
+                // Zoned map to timestamp with timezone
+
+                use crate::with_jiff::JIFF_ZONE_FMT_STR;
+                write!(s, "'{}'", v.strftime(JIFF_ZONE_FMT_STR)).unwrap()
+            }
+            #[cfg(feature = "with-rust_decimal")]
+            Value::Decimal(Some(v)) => write!(s, "{v}").unwrap(),
+            #[cfg(feature = "with-bigdecimal")]
+            Value::BigDecimal(Some(v)) => write!(s, "{v}").unwrap(),
+            #[cfg(feature = "with-uuid")]
+            Value::Uuid(Some(v)) => write!(s, "'{v}'").unwrap(),
+            #[cfg(feature = "postgres-array")]
+            Value::Array(_, Some(v)) => {
+                if v.is_empty() {
+                    write!(s, "'{{}}'").unwrap()
+                } else {
+                    write!(s, "ARRAY [").unwrap();
+
+                    let mut viter = v.iter();
+
+                    if let Some(element) = viter.next() {
+                        self.write_value(s, element);
+                    }
+
+                    for element in viter {
+                        write!(s, ", ").unwrap();
+                        self.write_value(s, element);
+                    }
+
+                    write!(s, "]").unwrap();
+                }
+            }
+            #[cfg(feature = "postgres-vector")]
+            Value::Vector(Some(v)) => {
+                write!(s, "'[").unwrap();
+                let mut viter = v.as_slice().iter();
+
+                if let Some(element) = viter.next() {
+                    write!(s, "{element}").unwrap();
+                }
+
+                for element in viter {
+                    write!(s, ",").unwrap();
+                    write!(s, "{element}").unwrap();
+                }
+                write!(s, "]'").unwrap();
+            }
+            #[cfg(feature = "with-ipnetwork")]
+            Value::IpNetwork(Some(v)) => write!(s, "'{v}'").unwrap(),
+            #[cfg(feature = "with-mac_address")]
+            Value::MacAddress(Some(v)) => write!(s, "'{v}'").unwrap(),
+        };
+    }
+
+    #[doc(hidden)]
     /// Write ON CONFLICT expression
     fn prepare_on_conflict(&self, on_conflict: &Option<OnConflict>, sql: &mut dyn SqlWriter) {
         if let Some(on_conflict) = on_conflict {
@@ -1523,206 +1716,4 @@ pub(crate) fn common_well_known_left_associative(op: &BinOper) -> bool {
         op,
         BinOper::And | BinOper::Or | BinOper::Add | BinOper::Sub | BinOper::Mul | BinOper::Mod
     )
-}
-
-trait QueryBuilderInternal {
-    fn write_value(&self, s: &mut String, value: &Value);
-}
-
-impl<T> QueryBuilderInternal for T
-where
-    T: QueryBuilder + ?Sized,
-{
-    #[doc(hidden)]
-    fn write_value(&self, s: &mut String, value: &Value) {
-        match value {
-            Value::Bool(None)
-            | Value::TinyInt(None)
-            | Value::SmallInt(None)
-            | Value::Int(None)
-            | Value::BigInt(None)
-            | Value::TinyUnsigned(None)
-            | Value::SmallUnsigned(None)
-            | Value::Unsigned(None)
-            | Value::BigUnsigned(None)
-            | Value::Float(None)
-            | Value::Double(None)
-            | Value::String(None)
-            | Value::Char(None)
-            | Value::Bytes(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-json")]
-            Value::Json(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDate(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeUtc(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeLocal(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
-            Value::TimeDate(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
-            Value::TimeTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
-            Value::TimeDateTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-time")]
-            Value::TimeDateTimeWithTimeZone(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffDate(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffDateTime(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffTimestamp(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffZoned(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-rust_decimal")]
-            Value::Decimal(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-bigdecimal")]
-            Value::BigDecimal(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-uuid")]
-            Value::Uuid(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-ipnetwork")]
-            Value::IpNetwork(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "with-mac_address")]
-            Value::MacAddress(None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "postgres-array")]
-            Value::Array(_, None) => write!(s, "NULL").unwrap(),
-            #[cfg(feature = "postgres-vector")]
-            Value::Vector(None) => write!(s, "NULL").unwrap(),
-            Value::Bool(Some(b)) => write!(s, "{}", if *b { "TRUE" } else { "FALSE" }).unwrap(),
-            Value::TinyInt(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::SmallInt(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Int(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::BigInt(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::TinyUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::SmallUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Unsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::BigUnsigned(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Float(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::Double(Some(v)) => write!(s, "{v}").unwrap(),
-            Value::String(Some(v)) => self.write_string_quoted(v, s),
-            Value::Char(Some(v)) => {
-                self.write_string_quoted(std::str::from_utf8(&[*v as u8]).unwrap(), s)
-            }
-            Value::Bytes(Some(v)) => self.write_bytes(v, s),
-            #[cfg(feature = "with-json")]
-            Value::Json(Some(v)) => self.write_string_quoted(&v.to_string(), s),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDate(Some(v)) => write!(s, "'{}'", v.format("%Y-%m-%d")).unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoTime(Some(v)) => write!(s, "'{}'", v.format("%H:%M:%S")).unwrap(),
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTime(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S")).unwrap()
-            }
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeUtc(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
-            }
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeLocal(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
-            }
-            #[cfg(feature = "with-chrono")]
-            Value::ChronoDateTimeWithTimeZone(Some(v)) => {
-                write!(s, "'{}'", v.format("%Y-%m-%d %H:%M:%S %:z")).unwrap()
-            }
-            #[cfg(feature = "with-time")]
-            Value::TimeDate(Some(v)) => {
-                write!(s, "'{}'", v.format(time_format::FORMAT_DATE).unwrap()).unwrap()
-            }
-            #[cfg(feature = "with-time")]
-            Value::TimeTime(Some(v)) => {
-                write!(s, "'{}'", v.format(time_format::FORMAT_TIME).unwrap()).unwrap()
-            }
-            #[cfg(feature = "with-time")]
-            Value::TimeDateTime(Some(v)) => {
-                write!(s, "'{}'", v.format(time_format::FORMAT_DATETIME).unwrap()).unwrap()
-            }
-            #[cfg(feature = "with-time")]
-            Value::TimeDateTimeWithTimeZone(Some(v)) => write!(
-                s,
-                "'{}'",
-                v.format(time_format::FORMAT_DATETIME_TZ).unwrap()
-            )
-            .unwrap(),
-            // Jiff date and time dosen't need format string
-            // The default behavior is what we want
-            #[cfg(feature = "with-jiff")]
-            Value::JiffDate(Some(v)) => write!(s, "'{v}'").unwrap(),
-            #[cfg(feature = "with-jiff")]
-            Value::JiffTime(Some(v)) => write!(s, "'{v}'").unwrap(),
-            // Both JiffDateTime and JiffTimestamp map to timestamp
-            #[cfg(feature = "with-jiff")]
-            Value::JiffDateTime(Some(v)) => {
-                use crate::with_jiff::JIFF_DATE_TIME_FMT_STR;
-                write!(s, "'{}'", v.strftime(JIFF_DATE_TIME_FMT_STR)).unwrap()
-            }
-            #[cfg(feature = "with-jiff")]
-            Value::JiffTimestamp(Some(v)) => {
-                use crate::with_jiff::JIFF_TIMESTAMP_FMT_STR;
-                write!(s, "'{}'", v.strftime(JIFF_TIMESTAMP_FMT_STR)).unwrap()
-            }
-            #[cfg(feature = "with-jiff")]
-            Value::JiffZoned(Some(v)) => {
-                // Zoned map to timestamp with timezone
-
-                use crate::with_jiff::JIFF_ZONE_FMT_STR;
-                write!(s, "'{}'", v.strftime(JIFF_ZONE_FMT_STR)).unwrap()
-            }
-            #[cfg(feature = "with-rust_decimal")]
-            Value::Decimal(Some(v)) => write!(s, "{v}").unwrap(),
-            #[cfg(feature = "with-bigdecimal")]
-            Value::BigDecimal(Some(v)) => write!(s, "{v}").unwrap(),
-            #[cfg(feature = "with-uuid")]
-            Value::Uuid(Some(v)) => write!(s, "'{v}'").unwrap(),
-            #[cfg(feature = "postgres-array")]
-            Value::Array(_, Some(v)) => {
-                if v.is_empty() {
-                    write!(s, "'{{}}'").unwrap()
-                } else {
-                    write!(s, "ARRAY [").unwrap();
-
-                    let mut viter = v.iter();
-
-                    if let Some(element) = viter.next() {
-                        self.write_value(s, element);
-                    }
-
-                    for element in viter {
-                        write!(s, ", ").unwrap();
-                        self.write_value(s, element);
-                    }
-
-                    write!(s, "]").unwrap();
-                }
-            }
-            #[cfg(feature = "postgres-vector")]
-            Value::Vector(Some(v)) => {
-                write!(s, "'[").unwrap();
-                let mut viter = v.as_slice().iter();
-
-                if let Some(element) = viter.next() {
-                    write!(s, "{element}").unwrap();
-                }
-
-                for element in viter {
-                    write!(s, ",").unwrap();
-                    write!(s, "{element}").unwrap();
-                }
-                write!(s, "]'").unwrap();
-            }
-            #[cfg(feature = "with-ipnetwork")]
-            Value::IpNetwork(Some(v)) => write!(s, "'{v}'").unwrap(),
-            #[cfg(feature = "with-mac_address")]
-            Value::MacAddress(Some(v)) => write!(s, "'{v}'").unwrap(),
-        };
-    }
 }

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1194,7 +1194,7 @@ pub trait QueryBuilder:
             #[cfg(feature = "postgres-array")]
             Value::Array(_, Some(v)) => {
                 if v.is_empty() {
-                    buffer.write_str("{}")?;
+                    buffer.write_str("'{}'")?;
                 } else {
                     buffer.write_str("ARRAY [")?;
 
@@ -1205,7 +1205,7 @@ pub trait QueryBuilder:
                     }
 
                     for element in viter {
-                        buffer.write_str(", ")?;
+                        buffer.write_str(",")?;
                         self.write_value(buffer, element)?;
                     }
                     buffer.write_str("]")?;
@@ -1225,7 +1225,7 @@ pub trait QueryBuilder:
 
                     write!(buffer, "{element}")?;
                 }
-                buffer.write_str("]")?;
+                buffer.write_str("]'")?;
             }
             #[cfg(feature = "with-ipnetwork")]
             Value::IpNetwork(Some(v)) => write!(buffer, "'{v}'")?,

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -194,12 +194,6 @@ mod tests_postgres {
 
     #[test]
     fn inject_parameters_7() {
-        let mut buf1 = String::new();
-        let mut buf2 = String::new();
-        assert_eq!(
-            PostgresQueryBuilder.write_string_quoted("B'C", &mut buf1),
-            PostgresQueryBuilder.write_string_quoted("B'C", &mut buf2)
-        );
         assert_eq!(
             inject_parameters("WHERE A = $1", [Value::from("B'C")], &PostgresQueryBuilder),
             "WHERE A = E'B\\'C'"

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -194,8 +194,14 @@ mod tests_postgres {
 
     #[test]
     fn inject_parameters_7() {
+        let mut buf1 = String::new();
+        let mut buf2 = String::new();
         assert_eq!(
-            inject_parameters("WHERE A = $1", ["B'C".into()], &PostgresQueryBuilder),
+            PostgresQueryBuilder.write_string_quoted("B'C", &mut buf1),
+            PostgresQueryBuilder.write_string_quoted("B'C", &mut buf2)
+        );
+        assert_eq!(
+            inject_parameters("WHERE A = $1", [Value::from("B'C")], &PostgresQueryBuilder),
             "WHERE A = E'B\\'C'"
         );
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -647,7 +647,7 @@ impl IntoIterator for Values {
 
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", CommonSqlQueryBuilder.value_to_string(self))
+        CommonSqlQueryBuilder.write_value(f, self)
     }
 }
 


### PR DESCRIPTION
## PR Info

Remove unneeded allocations.
Benchmark results show a significant performance improvement in query.to_string.

```
value/select_and_to_string::mysql                                                                             
  time:   [4.5816 µs 4.6076 µs 4.6429 µs]
  change: [-26.313% -25.676% -25.047%] (p = 0.00 < 0.05)
  Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
value/select_and_to_string::pg                                                                             
  time:   [5.3180 µs 5.3518 µs 5.4032 µs]
  change: [-40.190% -39.428% -38.762%] (p = 0.00 < 0.05)
  Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
value/select_and_to_string::sqlite                                                                             
  time:   [4.7982 µs 4.8595 µs 4.9348 µs]
  change: [-7.0087% -5.6796% -4.2794%] (p = 0.00 < 0.05)
  Performance has improved.
```

## Changes

- Remove unneeded allocations in 
  - `MysqlQueryBuilder::prepare_column_type`
  - `inject_parameters`
  - `PostgresqlQueryBuilder::write_string_quoted`
  - `<String as SqlWriter>::push_param`
  - `Value::display`
  - `QuotedBuilder::prepare_iden` 
- Add helper method `QueryBuilder::write_value`
- Replace `write!` macro with `Write::write_str`
- Add `EscapeBuilder::write_escaped`
- Replace `EscapeBuilder::escape_string` with `EscapeBuilder::write_escaped`

## Breaking Change
- Change parameter type of `QueryBuilder::write_string_quoted`， `QueryBuilder::write_bytes` from `&mut String` to `&mut dyn Write`