### PR TITLE
Refactor CI

### DIFF
--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -25,41 +25,53 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  RUSTFLAGS: "-C debuginfo=0"
 
 jobs:
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example: [diesel_sqlite, diesel_postgres, diesel_mysql]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: rustfmt
-      - run: cargo fmt --manifest-path examples/diesel_sqlite/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/diesel_postgres/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/diesel_mysql/Cargo.toml --all -- --check
+      - run: cargo fmt --manifest-path examples/${{ matrix.example }}/Cargo.toml --all -- --check
+      - run: cargo fmt --manifest-path examples/${{ matrix.example }}/Cargo.toml --all -- --check
+      - run: cargo fmt --manifest-path examples/${{ matrix.example }}/Cargo.toml --all -- --check
 
   diesel-build:
     name: Build `sea-query-diesel`
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - "postgres,sqlite,mysql --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector"
+          - "postgres,sqlite,mysql --features=with-chrono"
+          - "postgres,sqlite,mysql --features=with-json"
+          - "postgres,sqlite,mysql --features=with-rust_decimal"
+          - "postgres --features=with-rust_decimal-postgres"
+          - "mysql --features=with-rust_decimal-mysql"
+          - "postgres,sqlite,mysql --features=with-bigdecimal"
+          - "postgres,sqlite,mysql --features=postgres-vector"
+          - "postgres,sqlite,mysql --features=postgres-array"
+          - "postgres,sqlite,mysql --features=with-mac_address"
+          - "postgres,sqlite,mysql --features=with-ipnetwork"
+          - "postgres,sqlite,mysql --features=with-time"
+          - "postgres,sqlite,mysql --features=with-uuid"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo update --manifest-path sea-query-diesel/Cargo.toml -p ipnetwork@0.21.1 --precise=0.20.0
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-chrono
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-json
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-rust_decimal
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres --features=with-rust_decimal-postgres
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features mysql --features=with-rust_decimal-mysql
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-bigdecimal
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-uuid
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-time
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-ipnetwork
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-mac_address
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=postgres-array
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=postgres-vector
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features ${{ matrix.features }}
 
   sqlite:
     name: SQLite
@@ -71,6 +83,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
       - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml
 
@@ -101,6 +115,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
       - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml
 
@@ -131,6 +147,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
       - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml
 
@@ -160,6 +178,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo update --manifest-path examples/${{ matrix.example }}/Cargo.toml -p ipnetwork@0.21.1 --precise=0.20.0
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
       - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml

--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -57,9 +57,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-diesel/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo update --manifest-path sea-query-diesel/Cargo.toml -p ipnetwork@0.21.1 --precise=0.20.0
@@ -100,9 +97,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ steps.cache-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -148,9 +142,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ steps.cache-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -196,9 +187,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ steps.cache-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -243,9 +231,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ steps.cache-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo update --manifest-path examples/${{ matrix.example }}/Cargo.toml -p ipnetwork@0.21.1 --precise=0.20.0

--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -28,6 +28,7 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   RUSTFLAGS: "-C debuginfo=0"
+  CARGO_INCREMENTAL: 0
 
 jobs:
   rustfmt:

--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -34,16 +34,15 @@ jobs:
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        example: [diesel_sqlite, diesel_postgres, diesel_mysql]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: rustfmt
-      - run: cargo fmt --manifest-path examples/${{ matrix.example }}/Cargo.toml --all -- --check
+      - run: cargo fmt --manifest-path examples/diesel_sqlite/Cargo.toml --all -- --check
+      - run: cargo fmt --manifest-path examples/diesel_postgres/Cargo.toml --all -- --check
+      - run: cargo fmt --manifest-path examples/diesel_mysql/Cargo.toml --all -- --check
 
   diesel-build:
     name: Build `sea-query-diesel`

--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -36,20 +36,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
           components: rustfmt
-      - run: cargo fmt --manifest-path examples/diesel_sqlite/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/diesel_postgres/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/diesel_mysql/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path examples/diesel_sqlite/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path examples/diesel_postgres/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path examples/diesel_mysql/Cargo.toml --all -- --check
 
   diesel-build:
     name: Build `sea-query-diesel`
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - uses: actions/cache@v4
         with:
           path: |
@@ -83,7 +82,7 @@ jobs:
         example: [diesel_sqlite]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Generate cache key
         id: cache-key
         run: |
@@ -128,7 +127,7 @@ jobs:
           --health-retries=3
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Generate cache key
         id: cache-key
         run: |
@@ -173,7 +172,7 @@ jobs:
           --health-retries=3
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Generate cache key
         id: cache-key
         run: |
@@ -217,7 +216,7 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Generate cache key
         id: cache-key
         run: |

--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -48,29 +48,25 @@ jobs:
   diesel-build:
     name: Build `sea-query-diesel`
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        features:
-          - "postgres,sqlite,mysql --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector"
-          - "postgres,sqlite,mysql --features=with-chrono"
-          - "postgres,sqlite,mysql --features=with-json"
-          - "postgres,sqlite,mysql --features=with-rust_decimal"
-          - "postgres --features=with-rust_decimal-postgres"
-          - "mysql --features=with-rust_decimal-mysql"
-          - "postgres,sqlite,mysql --features=with-bigdecimal"
-          - "postgres,sqlite,mysql --features=postgres-vector"
-          - "postgres,sqlite,mysql --features=postgres-array"
-          - "postgres,sqlite,mysql --features=with-mac_address"
-          - "postgres,sqlite,mysql --features=with-ipnetwork"
-          - "postgres,sqlite,mysql --features=with-time"
-          - "postgres,sqlite,mysql --features=with-uuid"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo update --manifest-path sea-query-diesel/Cargo.toml -p ipnetwork@0.21.1 --precise=0.20.0
-      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features ${{ matrix.features }}
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-chrono
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-json
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-rust_decimal
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres --features=with-rust_decimal-postgres
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features mysql --features=with-rust_decimal-mysql
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-bigdecimal
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-uuid
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-time
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-ipnetwork
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=with-mac_address
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=postgres-array
+      - run: cargo build --manifest-path sea-query-diesel/Cargo.toml --workspace --features postgres,sqlite,mysql --features=postgres-vector
 
   sqlite:
     name: SQLite

--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -50,6 +50,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-diesel/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo update --manifest-path sea-query-diesel/Cargo.toml -p ipnetwork@0.21.1 --precise=0.20.0
@@ -77,6 +86,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Generate cache key
+        id: cache-key
+        run: |
+          cargo_hash=$(shasum Cargo.toml examples/${{ matrix.example }}/Cargo.toml | shasum | cut -d' ' -f1)
+          echo "key=${{ runner.os }}-cargo-${cargo_hash}" >> $GITHUB_OUTPUT
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ steps.cache-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -109,6 +133,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Generate cache key
+        id: cache-key
+        run: |
+          cargo_hash=$(shasum Cargo.toml examples/${{ matrix.example }}/Cargo.toml | shasum | cut -d' ' -f1)
+          echo "key=${{ runner.os }}-cargo-${cargo_hash}" >> $GITHUB_OUTPUT
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ steps.cache-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -141,6 +180,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Generate cache key
+        id: cache-key
+        run: |
+          cargo_hash=$(shasum Cargo.toml examples/${{ matrix.example }}/Cargo.toml | shasum | cut -d' ' -f1)
+          echo "key=${{ runner.os }}-cargo-${cargo_hash}" >> $GITHUB_OUTPUT
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ steps.cache-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -172,6 +226,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Generate cache key
+        id: cache-key
+        run: |
+          cargo_hash=$(shasum Cargo.toml examples/${{ matrix.example }}/Cargo.toml | shasum | cut -d' ' -f1)
+          echo "key=${{ runner.os }}-cargo-${cargo_hash}" >> $GITHUB_OUTPUT
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ steps.cache-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo update --manifest-path examples/${{ matrix.example }}/Cargo.toml -p ipnetwork@0.21.1 --precise=0.20.0

--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -59,6 +59,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-diesel/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo update --manifest-path sea-query-diesel/Cargo.toml -p ipnetwork@0.21.1 --precise=0.20.0
@@ -101,6 +102,7 @@ jobs:
           key: ${{ steps.cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -148,6 +150,7 @@ jobs:
           key: ${{ steps.cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -195,6 +198,7 @@ jobs:
           key: ${{ steps.cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -241,6 +245,7 @@ jobs:
           key: ${{ steps.cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-cargo--${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo update --manifest-path examples/${{ matrix.example }}/Cargo.toml -p ipnetwork@0.21.1 --precise=0.20.0

--- a/.github/workflows/diesel.yml
+++ b/.github/workflows/diesel.yml
@@ -43,8 +43,6 @@ jobs:
           toolchain: nightly
           components: rustfmt
       - run: cargo fmt --manifest-path examples/${{ matrix.example }}/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/${{ matrix.example }}/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/${{ matrix.example }}/Cargo.toml --all -- --check
 
   diesel-build:
     name: Build `sea-query-diesel`

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,7 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   RUSTFLAGS: "-C debuginfo=0"
+  CARGO_INCREMENTAL: 0
 
 jobs:
   rustfmt:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,20 +69,6 @@ jobs:
   build:
     name: Build `sea-query`
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        feature: [
-          "with-chrono",
-          "with-json",
-          "with-rust_decimal",
-          "with-bigdecimal",
-          "with-uuid",
-          "with-time",
-          "with-ipnetwork",
-          "with-mac_address",
-          "postgres-array",
-          "postgres-vector"
-        ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -90,7 +76,17 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --workspace --no-default-features
       - run: cargo build --workspace --all-features
-      - run: cargo build --workspace --features=${{ matrix.feature }}
+      - run: cargo build --workspace --features=with-chrono
+      - run: cargo build --workspace --features=with-json
+      - run: cargo build --workspace --features=with-rust_decimal
+      - run: cargo build --workspace --features=with-bigdecimal
+      - run: cargo build --workspace --features=with-uuid
+      - run: cargo build --workspace --features=with-time
+      - run: cargo build --workspace --features=with-ipnetwork
+      - run: cargo build --workspace --features=with-mac_address
+      - run: cargo build --workspace --features=postgres-array
+      - run: cargo build --workspace --features=postgres-vector
+      - run: cargo build --workspace --features=thread-safe
 
   binder-build:
     name: Build `sea-query-sqlx`
@@ -120,52 +116,42 @@ jobs:
   rusqlite-build:
     name: Build `sea-query-rusqlite`
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        feature: [
-          "with-chrono",
-          "with-json",
-          "with-rust_decimal",
-          "with-bigdecimal",
-          "with-uuid",
-          "with-time",
-          "with-ipnetwork",
-          "with-mac_address",
-          "postgres-array",
-          "postgres-vector"
-        ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace --features=${{ matrix.feature }}
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-chrono
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-json
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-rust_decimal
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-bigdecimal
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-uuid
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-time
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-ipnetwork
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-mac_address
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=postgres-array
+      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=postgres-vector
 
   postgres-build:
     name: Build `sea-query-postgres`
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        feature: [
-          "with-chrono",
-          "with-json",
-          "with-rust_decimal",
-          "with-bigdecimal",
-          "with-uuid",
-          "with-time",
-          "with-ipnetwork",
-          "with-mac_address",
-          "postgres-array",
-          "postgres-vector"
-        ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace --features=${{ matrix.feature }}
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-chrono
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-json
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-rust_decimal
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-bigdecimal
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-uuid
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-time
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-ipnetwork
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-mac_address
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=postgres-array
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=postgres-vector
 
   test:
     name: Unit Test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,30 +34,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
           components: rustfmt
-      - run: cargo fmt --manifest-path Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path sea-query-sqlx/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path sea-query-derive/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path sea-query-postgres/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path sea-query-rusqlite/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/sqlx_sqlite/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/sqlx_any/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/rusqlite/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/sqlx_postgres/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/postgres/Cargo.toml --all -- --check
-      - run: cargo fmt --manifest-path examples/sqlx_mysql/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path sea-query-sqlx/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path sea-query-derive/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path sea-query-postgres/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path sea-query-rusqlite/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path examples/sqlx_sqlite/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path examples/sqlx_any/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path examples/rusqlite/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path examples/sqlx_postgres/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path examples/postgres/Cargo.toml --all -- --check
+      - run: cargo +nightly fmt --manifest-path examples/sqlx_mysql/Cargo.toml --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@1.85
         with:
-          toolchain: stable
           components: clippy
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -79,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -114,7 +112,7 @@ jobs:
         tls: [rustls]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -142,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -170,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -199,7 +197,7 @@ jobs:
     needs: ["build"]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -220,7 +218,7 @@ jobs:
     needs: ["build"]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -243,7 +241,7 @@ jobs:
         example: [rusqlite, sqlx_sqlite]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -283,7 +281,7 @@ jobs:
           --health-retries=3
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -323,7 +321,7 @@ jobs:
           --health-retries=3
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -362,7 +360,7 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -382,7 +380,7 @@ jobs:
     needs: ["test", "derive-test", "binder-build"]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,9 +66,10 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-diesel/Cargo.toml', 'sea-query-postgres/Cargo.toml', 'sea-query-rusqlite/Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-postgres/Cargo.toml', 'sea-query-rusqlite/Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo clippy --features=all-features --workspace -- -D warnings
@@ -92,6 +93,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --workspace --no-default-features
@@ -129,6 +131,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-sqlx/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
@@ -159,6 +162,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-rusqlite/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
@@ -189,6 +193,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-postgres/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
@@ -241,6 +246,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --package sea-query-derive
@@ -266,6 +272,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml', 'sea-query-rusqlite/Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -308,6 +315,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -350,6 +358,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -391,6 +400,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-diesel/Cargo.toml', 'sea-query-postgres/Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -413,6 +423,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/sqlx_any/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,10 +66,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-postgres/Cargo.toml', 'sea-query-rusqlite/Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo clippy --features=all-features --workspace -- -D warnings
@@ -91,9 +88,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --workspace --no-default-features
@@ -129,9 +123,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-sqlx/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
@@ -160,9 +151,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-rusqlite/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
@@ -191,9 +179,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-postgres/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
@@ -244,9 +229,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --package sea-query-derive
@@ -270,9 +252,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml', 'sea-query-rusqlite/Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -313,9 +292,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -356,9 +332,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -398,9 +371,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-diesel/Cargo.toml', 'sea-query-postgres/Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -421,9 +391,6 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/sqlx_any/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -226,10 +226,10 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-derive-test-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
-      - run: cargo build --package sea-query-derive
+      - run: cargo test --package sea-query-derive --no-run
       - run: cargo test --package sea-query-derive
 
   sqlite:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,16 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-diesel/Cargo.toml', 'sea-query-postgres/Cargo.toml', 'sea-query-rusqlite/Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo clippy --features=all-features --workspace -- -D warnings
@@ -72,6 +82,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --workspace --no-default-features
@@ -99,6 +119,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-sqlx/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
@@ -119,6 +149,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-rusqlite/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
@@ -139,6 +179,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-postgres/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
@@ -160,6 +210,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo test
@@ -173,6 +231,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --package sea-query-derive
@@ -188,6 +256,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml', 'sea-query-rusqlite/Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -220,6 +298,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -252,6 +340,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -283,6 +381,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-diesel/Cargo.toml', 'sea-query-postgres/Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
@@ -295,6 +403,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml', 'sea-query-sqlx/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/sqlx_any/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  RUSTFLAGS: "-C debuginfo=0"
 
 jobs:
   rustfmt:
@@ -55,6 +58,8 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo clippy --features=all-features --workspace -- -D warnings
       - run: cargo clippy --manifest-path sea-query-sqlx/Cargo.toml --workspace --features runtime-async-std-rustls --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector -- -D warnings
       - run: cargo clippy --manifest-path sea-query-rusqlite/Cargo.toml --all-features --workspace -- -D warnings
@@ -63,22 +68,28 @@ jobs:
   build:
     name: Build `sea-query`
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature: [
+          "with-chrono",
+          "with-json",
+          "with-rust_decimal",
+          "with-bigdecimal",
+          "with-uuid",
+          "with-time",
+          "with-ipnetwork",
+          "with-mac_address",
+          "postgres-array",
+          "postgres-vector"
+        ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --workspace --no-default-features
       - run: cargo build --workspace --all-features
-      - run: cargo build --workspace --features=with-chrono
-      - run: cargo build --workspace --features=with-json
-      - run: cargo build --workspace --features=with-rust_decimal
-      - run: cargo build --workspace --features=with-bigdecimal
-      - run: cargo build --workspace --features=with-uuid
-      - run: cargo build --workspace --features=with-time
-      - run: cargo build --workspace --features=with-ipnetwork
-      - run: cargo build --workspace --features=with-mac_address
-      - run: cargo build --workspace --features=postgres-array
-      - run: cargo build --workspace --features=postgres-vector
-      - run: cargo build --workspace --features=thread-safe
+      - run: cargo build --workspace --features=${{ matrix.feature }}
 
   binder-build:
     name: Build `sea-query-sqlx`
@@ -91,6 +102,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-sqlx/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
       - run: cargo build --manifest-path sea-query-sqlx/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-chrono
       - run: cargo build --manifest-path sea-query-sqlx/Cargo.toml --workspace  --features sqlx-postgres,sqlx-sqlite,sqlx-any,sqlx-mysql --features=runtime-${{ matrix.runtime }}-${{ matrix.tls }} --features=with-json
@@ -106,38 +119,52 @@ jobs:
   rusqlite-build:
     name: Build `sea-query-rusqlite`
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature: [
+          "with-chrono",
+          "with-json",
+          "with-rust_decimal",
+          "with-bigdecimal",
+          "with-uuid",
+          "with-time",
+          "with-ipnetwork",
+          "with-mac_address",
+          "postgres-array",
+          "postgres-vector"
+        ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
-      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-chrono
-      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-json
-      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-rust_decimal
-      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-bigdecimal
-      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-uuid
-      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-time
-      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-ipnetwork
-      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=with-mac_address
-      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=postgres-array
-      - run: cargo build --manifest-path sea-query-rusqlite/Cargo.toml --workspace  --features=postgres-vector
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace --features=${{ matrix.feature }}
 
   postgres-build:
     name: Build `sea-query-postgres`
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature: [
+          "with-chrono",
+          "with-json",
+          "with-rust_decimal",
+          "with-bigdecimal",
+          "with-uuid",
+          "with-time",
+          "with-ipnetwork",
+          "with-mac_address",
+          "postgres-array",
+          "postgres-vector"
+        ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-chrono,with-json,with-rust_decimal,with-bigdecimal,with-uuid,with-time,with-ipnetwork,with-mac_address,postgres-array,postgres-vector
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-chrono
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-json
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-rust_decimal
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-bigdecimal
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-uuid
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-time
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-ipnetwork
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=with-mac_address
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=postgres-array
-      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=postgres-vector
+      - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace --features=${{ matrix.feature }}
 
   test:
     name: Unit Test
@@ -146,6 +173,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo test
       - run: cargo test --features=all-features
       - run: cargo test --test option-more-parentheses --features=tests-cfg,option-more-parentheses
@@ -157,6 +186,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --package sea-query-derive
       - run: cargo test --package sea-query-derive
 
@@ -170,6 +201,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
       - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml
 
@@ -200,6 +233,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
       - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml
 
@@ -230,6 +265,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
       - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml
 
@@ -259,6 +296,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/${{ matrix.example }}/Cargo.toml
       - run: cargo run --manifest-path examples/${{ matrix.example }}/Cargo.toml
 
@@ -269,4 +308,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - run: cargo build --manifest-path examples/sqlx_any/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,7 @@ jobs:
       - run: cargo clippy --manifest-path sea-query-postgres/Cargo.toml --all-features --workspace -- -D warnings
 
   build:
-    name: Build `sea-query`
+    name: Workspace
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -101,6 +101,15 @@ jobs:
       - run: cargo build --workspace --features=postgres-array
       - run: cargo build --workspace --features=postgres-vector
       - run: cargo build --workspace --features=thread-safe
+      - run: cargo test --no-run
+      - run: cargo test
+      - run: cargo test --features=all-features --no-run
+      - run: cargo test --features=all-features
+      - run: cargo test --test option-more-parentheses --features=tests-cfg,option-more-parentheses --no-run
+      - run: cargo test --test option-more-parentheses --features=tests-cfg,option-more-parentheses
+      - run: cargo test --package sea-query-derive --no-run
+      - run: cargo test --package sea-query-derive
+
 
   binder-build:
     name: Build `sea-query-sqlx`
@@ -191,51 +200,10 @@ jobs:
       - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=postgres-array
       - run: cargo build --manifest-path sea-query-postgres/Cargo.toml --workspace  --features=postgres-vector
 
-  test:
-    name: Unit Test
-    runs-on: ubuntu-latest
-    needs: ["build"]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.85
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-      - run: cargo test
-      - run: cargo test --features=all-features
-      - run: cargo test --test option-more-parentheses --features=tests-cfg,option-more-parentheses
-
-  derive-test:
-    name: Derive Tests
-    runs-on: ubuntu-latest
-    needs: ["build"]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.85
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-derive-test-${{ hashFiles('Cargo.toml', 'sea-query-derive/Cargo.toml') }}
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-      - run: cargo test --package sea-query-derive --no-run
-      - run: cargo test --package sea-query-derive
-
   sqlite:
     name: SQLite
     runs-on: ubuntu-latest
-    needs: ["test", "derive-test", "rusqlite-build", "binder-build"]
+    needs: ["build", "rusqlite-build", "binder-build"]
     strategy:
       matrix:
         example: [rusqlite, sqlx_sqlite]
@@ -258,7 +226,7 @@ jobs:
   mysql:
     name: MySQL
     runs-on: ubuntu-latest
-    needs: ["test", "derive-test", "binder-build"]
+    needs: ["build", "binder-build"]
     strategy:
       matrix:
         version: [8.0, 5.7]
@@ -298,7 +266,7 @@ jobs:
   mariadb:
     name: MariaDB
     runs-on: ubuntu-latest
-    needs: ["test", "derive-test", "binder-build"]
+    needs: ["build", "binder-build"]
     strategy:
       matrix:
         version: [10.6]
@@ -338,7 +306,7 @@ jobs:
   postgres:
     name: PostgreSQL
     runs-on: ubuntu-latest
-    needs: ["test", "derive-test", "binder-build", "postgres-build"]
+    needs: ["build", "binder-build", "postgres-build"]
     strategy:
       matrix:
         version: [14.4, 13.7, 12.11]
@@ -377,7 +345,7 @@ jobs:
   any:
     name: Any
     runs-on: ubuntu-latest
-    needs: ["test", "derive-test", "binder-build"]
+    needs: ["build", "binder-build"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
+# This will affect the CI, so you’ll need to update the workflows too.
 channel = "1.85"
 components = [
 	"rustfmt",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # This will affect the CI, so you’ll need to update the workflows too.
-channel = "1.85"
+channel = "1.85.1"
 components = [
 	"rustfmt",
 	"clippy",


### PR DESCRIPTION
- Add sccache to cache compilation results
- Cache cargo registry
- Disable debuginfo
- Disable incremental compilation
- Merge workspace tests because there are duplicate compilations between them.