### PR TITLE
feat(index): Support for `CONCURRENTLY` modifying indexes

### DIFF
--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -42,6 +42,10 @@ impl IndexBuilder for PostgresQueryBuilder {
         self.prepare_index_prefix(create, sql);
         write!(sql, "INDEX ").unwrap();
 
+        if create.concurrently {
+            write!(sql, "CONCURRENTLY ").unwrap();
+        }
+
         if create.if_not_exists {
             write!(sql, "IF NOT EXISTS ").unwrap();
         }
@@ -88,6 +92,10 @@ impl IndexBuilder for PostgresQueryBuilder {
 
     fn prepare_index_drop_statement(&self, drop: &IndexDropStatement, sql: &mut dyn SqlWriter) {
         write!(sql, "DROP INDEX ").unwrap();
+
+        if drop.concurrently {
+            write!(sql, "CONCURRENTLY ").unwrap();
+        }
 
         if drop.if_exists {
             write!(sql, "IF EXISTS ").unwrap();

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -213,6 +213,7 @@ pub struct IndexCreateStatement {
     pub(crate) index: TableIndex,
     pub(crate) primary: bool,
     pub(crate) unique: bool,
+    pub(crate) concurrently: bool,
     pub(crate) nulls_not_distinct: bool,
     pub(crate) index_type: Option<IndexType>,
     pub(crate) if_not_exists: bool,
@@ -238,6 +239,7 @@ impl IndexCreateStatement {
             index: Default::default(),
             primary: false,
             unique: false,
+            concurrently: false,
             nulls_not_distinct: false,
             index_type: None,
             if_not_exists: false,
@@ -291,6 +293,12 @@ impl IndexCreateStatement {
         self
     }
 
+    /// Set index to be created concurrently. Only available on Postgres.
+    pub fn concurrently(&mut self) -> &mut Self {
+        self.concurrently = true;
+        self
+    }
+
     /// Set nulls to not be treated as distinct values. Only available on Postgres.
     pub fn nulls_not_distinct(&mut self) -> &mut Self {
         self.nulls_not_distinct = true;
@@ -340,6 +348,7 @@ impl IndexCreateStatement {
             index: self.index.take(),
             primary: self.primary,
             unique: self.unique,
+            concurrently: self.concurrently,
             nulls_not_distinct: self.nulls_not_distinct,
             index_type: self.index_type.take(),
             if_not_exists: self.if_not_exists,

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -32,6 +32,7 @@ pub struct IndexDropStatement {
     pub(crate) table: Option<TableRef>,
     pub(crate) index: TableIndex,
     pub(crate) if_exists: bool,
+    pub(crate) concurrently: bool,
 }
 
 impl IndexDropStatement {
@@ -60,6 +61,12 @@ impl IndexDropStatement {
 
     pub fn if_exists(&mut self) -> &mut Self {
         self.if_exists = true;
+        self
+    }
+
+    /// Set index to be dropped concurrently. Only available on Postgres.
+    pub fn concurrently(&mut self) -> &mut Self {
+        self.concurrently = true;
         self
     }
 }

--- a/tests/postgres/index.rs
+++ b/tests/postgres/index.rs
@@ -44,6 +44,20 @@ fn create_3() {
 fn create_4() {
     assert_eq!(
         Index::create()
+            .full_text()
+            .name("idx-glyph-image")
+            .concurrently()
+            .table(Glyph::Table)
+            .col(Glyph::Image)
+            .to_string(PostgresQueryBuilder),
+        r#"CREATE INDEX CONCURRENTLY "idx-glyph-image" ON "glyph" USING GIN ("image")"#
+    );
+}
+
+#[test]
+fn create_5() {
+    assert_eq!(
+        Index::create()
             .if_not_exists()
             .full_text()
             .name("idx-glyph-image")
@@ -55,7 +69,7 @@ fn create_4() {
 }
 
 #[test]
-fn create_5() {
+fn create_6() {
     assert_eq!(
         Index::create()
             .unique()
@@ -69,7 +83,7 @@ fn create_5() {
 }
 
 #[test]
-fn create_6() {
+fn create_7() {
     assert_eq!(
         Index::create()
             .unique()
@@ -84,7 +98,7 @@ fn create_6() {
 }
 
 #[test]
-fn create_7() {
+fn create_8() {
     assert_eq!(
         Index::create()
             .unique()
@@ -99,7 +113,7 @@ fn create_7() {
 }
 
 #[test]
-fn create_8() {
+fn create_9() {
     assert_eq!(
         Index::create()
             .name("idx-font-name-include-id-language")
@@ -115,7 +129,7 @@ fn create_8() {
 }
 
 #[test]
-fn create_9() {
+fn create_10() {
     assert_eq!(
         Index::create()
             .name("idx-character-area")
@@ -127,7 +141,7 @@ fn create_9() {
 }
 
 #[test]
-fn create_10() {
+fn create_11() {
     assert_eq!(
         Index::create()
             .name("idx-character-character-area-desc-created_at")
@@ -158,6 +172,17 @@ fn drop_2() {
     assert_eq!(
         Index::drop()
             .name("idx-glyph-aspect")
+            .concurrently()
+            .to_string(PostgresQueryBuilder),
+        r#"DROP INDEX CONCURRENTLY "idx-glyph-aspect""#
+    );
+}
+
+#[test]
+fn drop_3() {
+    assert_eq!(
+        Index::drop()
+            .name("idx-glyph-aspect")
             .table(("schema", Glyph::Table))
             .to_string(PostgresQueryBuilder),
         r#"DROP INDEX "schema"."idx-glyph-aspect""#
@@ -165,7 +190,7 @@ fn drop_2() {
 }
 
 #[test]
-fn drop_3() {
+fn drop_4() {
     assert_eq!(
         Index::drop()
             .name("idx-glyph-aspect")
@@ -177,7 +202,7 @@ fn drop_3() {
 
 #[test]
 #[should_panic(expected = "Not supported")]
-fn drop_4() {
+fn drop_5() {
     Index::drop()
         .name("idx-glyph-aspect")
         .table(("database", "schema", Glyph::Table))


### PR DESCRIPTION
## New Features
- Adds support for creating and dropping indexes concurrently
https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY

Postgres only.
