### PR TITLE
feat(indexes): Support for index column operator class 

### DIFF
--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -162,6 +162,9 @@ impl IndexBuilder for PostgresQueryBuilder {
                     }
                 }
             }
+            if let Some(operator_class) = col.operator_class() {
+                write!(sql, " {}", operator_class.to_string()).unwrap();
+            }
             false
         });
         write!(sql, ")").unwrap();

--- a/tests/postgres/index.rs
+++ b/tests/postgres/index.rs
@@ -72,6 +72,19 @@ fn create_5() {
 fn create_6() {
     assert_eq!(
         Index::create()
+            .if_not_exists()
+            .name("idx-glyph-image")
+            .table(Glyph::Table)
+            .col(Glyph::Image.into_index_column().with_operator_class("text_pattern_ops"))
+            .to_string(PostgresQueryBuilder),
+        r#"CREATE INDEX IF NOT EXISTS "idx-glyph-image" ON "glyph" ("image" text_pattern_ops)"#
+    );
+}
+
+#[test]
+fn create_7() {
+    assert_eq!(
+        Index::create()
             .unique()
             .nulls_not_distinct()
             .name("idx-glyph-aspect-image")
@@ -84,7 +97,7 @@ fn create_6() {
 }
 
 #[test]
-fn create_7() {
+fn create_8() {
     assert_eq!(
         Index::create()
             .unique()
@@ -99,7 +112,7 @@ fn create_7() {
 }
 
 #[test]
-fn create_8() {
+fn create_9() {
     assert_eq!(
         Index::create()
             .name("idx-font-name-include-id-language")
@@ -115,7 +128,7 @@ fn create_8() {
 }
 
 #[test]
-fn create_9() {
+fn create_10() {
     assert_eq!(
         Index::create()
             .name("idx-character-area")
@@ -127,7 +140,7 @@ fn create_9() {
 }
 
 #[test]
-fn create_10() {
+fn create_11() {
     assert_eq!(
         Index::create()
             .name("idx-character-character-area-desc-created_at")


### PR DESCRIPTION
## New Features
- Adds support for specifying operator classes with index columns (closes #907)

Postgres only.
