### PR TITLE
Tweak pg json functions

### DIFF
--- a/src/extension/postgres/func/json_exists.rs
+++ b/src/extension/postgres/func/json_exists.rs
@@ -7,10 +7,10 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct Builder {
-    pub(crate) context_item: Expr,
-    pub(crate) path_expression: Cow<'static, str>,
-    pub(crate) passing: Vec<(Value, Cow<'static, str>)>,
-    pub(crate) on_error: Option<OnClause>,
+    context_item: Expr,
+    path_expression: Cow<'static, str>,
+    passing: Vec<(Value, Cow<'static, str>)>,
+    on_error: Option<OnClause>,
 }
 
 impl From<Builder> for FunctionCall {
@@ -26,7 +26,7 @@ impl From<Builder> for Expr {
 }
 
 #[derive(Debug, Clone)]
-pub enum OnClause {
+pub(super) enum OnClause {
     True,
     False,
     Unknown,
@@ -64,29 +64,6 @@ impl Builder {
         for (value, alias) in passing {
             self.passing.push((value.into(), alias.into()));
         }
-        self
-    }
-
-    /// Replace current PASSING parameters
-    pub fn set_passing<V, A, I>(mut self, passing: I) -> Self
-    where
-        V: Into<Value>,
-        A: Into<Cow<'static, str>>,
-        I: IntoIterator<Item = (V, A)>,
-    {
-        self.passing = passing
-            .into_iter()
-            .map(|(v, a)| (v.into(), a.into()))
-            .collect();
-        self
-    }
-
-    /// Set ON ERROR clause
-    pub fn on_error<E>(mut self, on_error: E) -> Self
-    where
-        E: Into<OnClause>,
-    {
-        self.on_error = Some(on_error.into());
         self
     }
 
@@ -143,9 +120,6 @@ impl Builder {
 
 impl PgFunc {
     /// Create a `JSON_EXISTS` function builder. Postgres only.
-    ///
-    /// The `JSON_EXISTS` function tests whether a JSON path expression returns any items for the specified JSON value.
-    /// It returns a boolean value: `true` if the path expression returns one or more items, `false` otherwise.
     ///
     /// # Examples
     ///

--- a/src/extension/postgres/func/json_fn.rs
+++ b/src/extension/postgres/func/json_fn.rs
@@ -5,12 +5,12 @@ use crate::{PostgresQueryBuilder, QueryBuilder, Value, join_io};
 
 #[derive(Debug, Clone)]
 pub struct QuotesClause {
-    pub(crate) kind: QuotesKind,
-    pub(crate) on_scalar_string: bool,
+    pub(super) kind: QuotesKind,
+    pub(super) on_scalar_string: bool,
 }
 
 impl QuotesClause {
-    pub(crate) fn write_to(&self, buf: &mut String) -> fmt::Result {
+    pub(super) fn write_to(&self, buf: &mut String) -> fmt::Result {
         match self.kind {
             QuotesKind::Keep => buf.write_str(" KEEP QUOTES")?,
             QuotesKind::Omit => buf.write_str(" OMIT QUOTES")?,
@@ -53,7 +53,7 @@ pub struct WrapperClause {
 }
 
 impl WrapperClause {
-    pub(crate) fn write_to(&self, buf: &mut String) -> fmt::Result {
+    pub(super) fn write_to(&self, buf: &mut String) -> fmt::Result {
         match self.kind {
             WrapperKind::Without => buf.write_str(" WITHOUT")?,
             WrapperKind::WithConditional => buf.write_str(" WITH CONDITIONAL")?,

--- a/src/extension/postgres/func/json_query.rs
+++ b/src/extension/postgres/func/json_query.rs
@@ -11,14 +11,14 @@ use crate::{
 /// Builder for JSON_QUERY function
 #[derive(Debug, Clone)]
 pub struct Builder {
-    pub(crate) context_item: Expr,
-    pub(crate) path_expression: Cow<'static, str>,
-    pub(crate) passing: Vec<(Value, Cow<'static, str>)>,
-    pub(crate) returning: Option<crate::TypeRef>,
-    pub(crate) wrapper: Option<WrapperClause>,
-    pub(crate) quotes: Option<QuotesClause>,
-    pub(crate) on_empty: Option<OnClause>,
-    pub(crate) on_error: Option<OnClause>,
+    context_item: Expr,
+    path_expression: Cow<'static, str>,
+    passing: Vec<(Value, Cow<'static, str>)>,
+    returning: Option<crate::TypeRef>,
+    wrapper: Option<WrapperClause>,
+    quotes: Option<QuotesClause>,
+    on_empty: Option<OnClause>,
+    on_error: Option<OnClause>,
 }
 
 impl From<Builder> for FunctionCall {
@@ -83,15 +83,59 @@ impl Builder {
         self
     }
 
-    /// Set ON EMPTY clause
-    pub fn on_empty(mut self, on_empty: OnClause) -> Self {
-        self.on_empty = Some(on_empty);
+    pub fn error_on_empty(mut self) -> Self {
+        self.on_empty = Some(OnClause::Error);
         self
     }
 
-    /// Set ON ERROR clause
-    pub fn on_error(mut self, on_error: OnClause) -> Self {
-        self.on_error = Some(on_error);
+    pub fn null_on_empty(mut self) -> Self {
+        self.on_empty = Some(OnClause::Null);
+        self
+    }
+
+    pub fn empty_array_on_empty(mut self) -> Self {
+        self.on_empty = Some(OnClause::EmptyArray);
+        self
+    }
+
+    pub fn empty_object_on_empty(mut self) -> Self {
+        self.on_empty = Some(OnClause::EmptyObject);
+        self
+    }
+
+    pub fn default_on_empty<T>(mut self, expr: T) -> Self
+    where
+        T: Into<Expr>,
+    {
+        self.on_empty = Some(OnClause::Default(expr.into()));
+        self
+    }
+
+    pub fn error_on_error(mut self) -> Self {
+        self.on_error = Some(OnClause::Error);
+        self
+    }
+
+    pub fn null_on_error(mut self) -> Self {
+        self.on_error = Some(OnClause::Null);
+        self
+    }
+
+    pub fn empty_array_on_error(mut self) -> Self {
+        self.on_error = Some(OnClause::EmptyArray);
+        self
+    }
+
+    pub fn empty_object_on_error(mut self) -> Self {
+        self.on_error = Some(OnClause::EmptyObject);
+        self
+    }
+
+    pub fn default_on_error<T>(mut self, expr: T) -> Self
+    where
+        T: Into<Expr>,
+    {
+        self.on_error = Some(OnClause::Default(expr.into()));
         self
     }
 

--- a/src/extension/postgres/func/json_table/builder.rs
+++ b/src/extension/postgres/func/json_table/builder.rs
@@ -15,12 +15,12 @@ use super::types::*;
 /// Builder for JSON_TABLE function
 #[derive(Debug, Clone)]
 pub struct Builder {
-    pub(crate) context_item: Expr,
-    pub(crate) path_expression: Cow<'static, str>,
-    pub(crate) as_json_path_name: Option<Cow<'static, str>>,
-    pub(crate) passing: Vec<(Value, Cow<'static, str>)>,
-    pub(crate) columns: Vec<JsonTableColumn>,
-    pub(crate) on_error: Option<OnErrorClause>,
+    pub(super) context_item: Expr,
+    pub(super) path_expression: Cow<'static, str>,
+    pub(super) as_json_path_name: Option<Cow<'static, str>>,
+    pub(super) passing: Vec<(Value, Cow<'static, str>)>,
+    pub(super) columns: Vec<JsonTableColumn>,
+    pub(super) on_error: Option<OnErrorClause>,
 }
 
 impl From<Builder> for FunctionCall {
@@ -127,15 +127,15 @@ impl Builder {
         }
     }
 
-    /// Set ON ERROR clause for the entire JSON_TABLE
-    pub fn on_error(mut self, on_error: OnErrorClause) -> Self {
-        self.on_error = Some(on_error);
-        self
-    }
-
     /// Convenience method for `ERROR ON ERROR`
     pub fn error_on_error(mut self) -> Self {
         self.on_error = Some(OnErrorClause::Error);
+        self
+    }
+
+    /// Convenience method for `EMPTY ON ERROR`
+    pub fn empty_on_error(mut self) -> Self {
+        self.on_error = Some(OnErrorClause::Empty);
         self
     }
 

--- a/src/extension/postgres/func/json_table/column.rs
+++ b/src/extension/postgres/func/json_table/column.rs
@@ -7,18 +7,18 @@ use super::builder::Builder;
 use super::types::*;
 
 /// Builder for regular columns in JSON_TABLE
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ColumnBuilder<T> {
-    pub(crate) builder: T,
-    pub(crate) name: Cow<'static, str>,
-    pub(crate) column_type: TypeRef,
-    pub(crate) format_json: bool,
-    pub(crate) encoding_utf8: bool,
-    pub(crate) path: Option<Cow<'static, str>>,
-    pub(crate) wrapper: Option<WrapperClause>,
-    pub(crate) quotes: Option<QuotesClause>,
-    pub(crate) on_empty: Option<OnClause>,
-    pub(crate) on_error: Option<OnClause>,
+    pub(super) builder: T,
+    pub(super) name: Cow<'static, str>,
+    pub(super) column_type: TypeRef,
+    pub(super) format_json: bool,
+    pub(super) encoding_utf8: bool,
+    pub(super) path: Option<Cow<'static, str>>,
+    pub(super) wrapper: Option<WrapperClause>,
+    pub(super) quotes: Option<QuotesClause>,
+    pub(super) on_empty: Option<OnClause>,
+    pub(super) on_error: Option<OnClause>,
 }
 
 impl<T> ColumnBuilder<T> {
@@ -58,18 +58,6 @@ impl<T> ColumnBuilder<T> {
         Q: Into<QuotesClause>,
     {
         self.quotes = Some(quotes.into());
-        self
-    }
-
-    /// Set ON EMPTY clause
-    pub fn on_empty(mut self, on_empty: OnClause) -> Self {
-        self.on_empty = Some(on_empty);
-        self
-    }
-
-    /// Set ON ERROR clause
-    pub fn on_error(mut self, on_error: OnClause) -> Self {
-        self.on_error = Some(on_error);
         self
     }
 

--- a/src/extension/postgres/func/json_table/exists_column.rs
+++ b/src/extension/postgres/func/json_table/exists_column.rs
@@ -6,13 +6,13 @@ use crate::{
 };
 
 /// Builder for EXISTS columns in JSON_TABLE
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExistsColumnBuilder<T> {
-    pub(crate) builder: T,
-    pub(crate) name: Cow<'static, str>,
-    pub(crate) column_type: TypeRef,
-    pub(crate) path: Option<Cow<'static, str>>,
-    pub(crate) on_error: Option<ExistsOnErrorClause>,
+    pub(super) builder: T,
+    pub(super) name: Cow<'static, str>,
+    pub(super) column_type: TypeRef,
+    pub(super) path: Option<Cow<'static, str>>,
+    pub(super) on_error: Option<ExistsOnErrorClause>,
 }
 
 impl<T> ExistsColumnBuilder<T> {
@@ -22,12 +22,6 @@ impl<T> ExistsColumnBuilder<T> {
         P: Into<Cow<'static, str>>,
     {
         self.path = Some(path.into());
-        self
-    }
-
-    /// Set ON ERROR clause
-    pub fn on_error(mut self, on_error: ExistsOnErrorClause) -> Self {
-        self.on_error = Some(on_error);
         self
     }
 

--- a/src/extension/postgres/func/json_table/mod.rs
+++ b/src/extension/postgres/func/json_table/mod.rs
@@ -1,17 +1,16 @@
-pub use builder::Builder;
-pub use column::ColumnBuilder;
-pub use exists_column::ExistsColumnBuilder;
-pub use nested::NestedPathBuilder;
-pub use types::*;
-
 use crate::*;
 use std::borrow::Cow;
 
-pub mod builder;
-pub mod column;
-pub mod exists_column;
-pub mod nested;
-pub mod types;
+mod builder;
+pub use builder::Builder;
+mod column;
+pub use column::ColumnBuilder;
+mod exists_column;
+pub use exists_column::ExistsColumnBuilder;
+mod nested;
+pub use nested::NestedPathBuilder;
+pub(super) mod types;
+pub use types::*;
 
 impl PgFunc {
     /// Create a `JSON_TABLE` function builder. Postgres only.

--- a/src/extension/postgres/func/json_table/nested.rs
+++ b/src/extension/postgres/func/json_table/nested.rs
@@ -7,13 +7,13 @@ use super::builder::Builder;
 use super::types::*;
 
 /// Builder for NESTED PATH columns in JSON_TABLE
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NestedPathBuilder {
-    pub(crate) builder: Builder,
-    pub(crate) explicit: bool,
-    pub(crate) path: Cow<'static, str>,
-    pub(crate) json_path_name: Option<Cow<'static, str>>,
-    pub(crate) columns: Vec<JsonTableColumn>,
+    pub(super) builder: Builder,
+    pub(super) explicit: bool,
+    pub(super) path: Cow<'static, str>,
+    pub(super) json_path_name: Option<Cow<'static, str>>,
+    pub(super) columns: Vec<JsonTableColumn>,
 }
 
 impl NestedPathBuilder {

--- a/src/extension/postgres/func/json_table/types.rs
+++ b/src/extension/postgres/func/json_table/types.rs
@@ -9,7 +9,7 @@ pub use crate::extension::postgres::json_fn::QuotesKind;
 
 /// Represents a column definition in JSON_TABLE
 #[derive(Debug, Clone)]
-pub enum JsonTableColumn {
+pub(super) enum JsonTableColumn {
     /// FOR ORDINALITY column
     Ordinality { name: Cow<'static, str> },
     /// Regular column with type and optional clauses
@@ -42,7 +42,7 @@ pub enum JsonTableColumn {
 
 /// ON EMPTY/ON ERROR clause for regular columns
 #[derive(Debug, Clone)]
-pub enum OnClause {
+pub(in super::super) enum OnClause {
     Error,
     Null,
     EmptyArray,
@@ -68,7 +68,7 @@ impl OnClause {
 
 /// ON ERROR clause for EXISTS columns
 #[derive(Debug, Clone)]
-pub enum ExistsOnErrorClause {
+pub(super) enum ExistsOnErrorClause {
     Error,
     True,
     False,
@@ -88,7 +88,7 @@ impl ExistsOnErrorClause {
 }
 
 #[derive(Debug, Clone)]
-pub enum OnErrorClause {
+pub(super) enum OnErrorClause {
     Error,
     Empty,
     EmptyArray,

--- a/src/extension/postgres/func/json_value.rs
+++ b/src/extension/postgres/func/json_value.rs
@@ -7,16 +7,16 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct Builder {
-    pub(crate) context_item: Expr,
-    pub(crate) path_expression: Cow<'static, str>,
-    pub(crate) passing: Vec<(Value, Cow<'static, str>)>,
-    pub(crate) returning: Option<crate::TypeRef>,
-    pub(crate) on_empty: Option<OnClause>,
-    pub(crate) on_error: Option<OnClause>,
+    context_item: Expr,
+    path_expression: Cow<'static, str>,
+    passing: Vec<(Value, Cow<'static, str>)>,
+    returning: Option<crate::TypeRef>,
+    on_empty: Option<OnClause>,
+    on_error: Option<OnClause>,
 }
 
 #[derive(Debug, Clone)]
-pub enum OnClause {
+enum OnClause {
     Error,
     Null,
     Default(Expr),
@@ -45,32 +45,12 @@ impl Builder {
         self
     }
 
-    /// Replace current PASSING parameters
-    pub fn set_passing<V, A, I>(mut self, passing: I) -> Self
-    where
-        V: Into<Value>,
-        A: Into<Cow<'static, str>>,
-        I: IntoIterator<Item = (V, A)>,
-    {
-        self.passing = passing
-            .into_iter()
-            .map(|(a, b)| (a.into(), b.into()))
-            .collect();
-        self
-    }
-
     /// Set RETURNING clause
     pub fn returning<T>(mut self, returning: T) -> Self
     where
         T: Into<TypeRef>,
     {
         self.returning = Some(returning.into());
-        self
-    }
-
-    /// Set ON EMPTY clause
-    pub fn on_empty(mut self, on_empty: OnClause) -> Self {
-        self.on_empty = Some(on_empty);
         self
     }
 
@@ -92,12 +72,6 @@ impl Builder {
         T: Into<Expr>,
     {
         self.on_empty = Some(OnClause::Default(expr.into()));
-        self
-    }
-
-    /// Set ON ERROR clause
-    pub fn on_error(mut self, on_error: OnClause) -> Self {
-        self.on_error = Some(on_error);
         self
     }
 
@@ -184,10 +158,6 @@ impl From<Builder> for Expr {
 impl PgFunc {
     /// Create a `JSON_VALUE` function builder. Postgres only.
     ///
-    /// Returns the result of applying the SQL/JSON path_expression to the context_item.
-    /// Only use JSON_VALUE() if the extracted value is expected to be a single SQL/JSON scalar item.
-    /// Supports RETURNING, ON EMPTY, and ON ERROR clauses.
-    ///
     /// # Examples
     ///
     /// Basic usage with RETURNING:
@@ -236,7 +206,7 @@ impl PgFunc {
     /// let query = Query::select()
     ///     .expr(
     ///         PgFunc::json_value(Expr::val(r#"[1,2]"#), "strict $[*]")
-    ///             .on_error(json_value::OnClause::Default(Expr::val(9))),
+    ///             .default_on_error(Expr::val(9)),
     ///     )
     ///     .to_owned();
     ///


### PR DESCRIPTION
- Minimize the exported surface and improve visibility.
- Remove all `on_*` methods, as they were verbose anyway.
- Remove the `set_passing` method; can add them back if needed, but I think the current methods are sufficient.