### PR TITLE
Rename `prepare_simple_expr` to `prepare_expr`

### DIFF
--- a/src/backend/mysql/index.rs
+++ b/src/backend/mysql/index.rs
@@ -113,7 +113,7 @@ impl IndexBuilder for MysqlQueryBuilder {
                     }
                     IndexColumn::Expr(column) => {
                         sql.write_str("(").unwrap();
-                        self.prepare_simple_expr(&column.expr, sql);
+                        self.prepare_expr(&column.expr, sql);
                         sql.write_str(")").unwrap();
                         if let Some(order) = &column.order {
                             match order {

--- a/src/backend/mysql/query.rs
+++ b/src/backend/mysql/query.rs
@@ -135,16 +135,16 @@ impl QueryBuilder for MysqlQueryBuilder {
         match order_expr.nulls {
             None => (),
             Some(NullOrdering::Last) => {
-                self.prepare_simple_expr(&order_expr.expr, sql);
+                self.prepare_expr(&order_expr.expr, sql);
                 sql.write_str(" IS NULL ASC, ").unwrap()
             }
             Some(NullOrdering::First) => {
-                self.prepare_simple_expr(&order_expr.expr, sql);
+                self.prepare_expr(&order_expr.expr, sql);
                 sql.write_str(" IS NULL DESC, ").unwrap()
             }
         }
         if !matches!(order_expr.order, Order::Field(_)) {
-            self.prepare_simple_expr(&order_expr.expr, sql);
+            self.prepare_expr(&order_expr.expr, sql);
         }
         self.prepare_order(order_expr, sql);
     }

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -157,7 +157,7 @@ impl IndexBuilder for PostgresQueryBuilder {
                     }
                     IndexColumn::Expr(column) => {
                         sql.write_str("(").unwrap();
-                        self.prepare_simple_expr(&column.expr, sql);
+                        self.prepare_expr(&column.expr, sql);
                         sql.write_str(")").unwrap();
                         if let Some(order) = &column.order {
                             match order {

--- a/src/backend/postgres/query.rs
+++ b/src/backend/postgres/query.rs
@@ -34,11 +34,11 @@ impl QueryBuilder for PostgresQueryBuilder {
         ("$", true)
     }
 
-    fn prepare_simple_expr(&self, simple_expr: &Expr, sql: &mut dyn SqlWriter) {
+    fn prepare_expr(&self, simple_expr: &Expr, sql: &mut dyn SqlWriter) {
         match simple_expr {
             Expr::AsEnum(type_name, expr) => {
                 sql.write_str("CAST(").unwrap();
-                self.prepare_simple_expr_common(expr, sql);
+                self.prepare_expr_common(expr, sql);
                 let q = self.quote();
                 let type_name = &type_name.0;
                 let (ty, sfx) = if let Some(base) = type_name.strip_suffix("[]") {
@@ -53,7 +53,7 @@ impl QueryBuilder for PostgresQueryBuilder {
                 sql.write_str(sfx).unwrap();
                 sql.write_char(')').unwrap();
             }
-            _ => QueryBuilder::prepare_simple_expr_common(self, simple_expr, sql),
+            _ => QueryBuilder::prepare_expr_common(self, simple_expr, sql),
         }
     }
 
@@ -169,7 +169,7 @@ impl QueryBuilder for PostgresQueryBuilder {
 
     fn prepare_order_expr(&self, order_expr: &OrderExpr, sql: &mut dyn SqlWriter) {
         if !matches!(order_expr.order, Order::Field(_)) {
-            self.prepare_simple_expr(&order_expr.expr, sql);
+            self.prepare_expr(&order_expr.expr, sql);
         }
         self.prepare_order(order_expr, sql);
         match order_expr.nulls {

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -298,7 +298,7 @@ impl PostgresQueryBuilder {
             write!(sql, "ALTER COLUMN ").unwrap();
             self.prepare_iden(&column_def.name, sql);
             write!(sql, " SET DEFAULT ").unwrap();
-            QueryBuilder::prepare_simple_expr(self, default, sql);
+            QueryBuilder::prepare_expr(self, default, sql);
         }
         if column_def.spec.unique {
             write_comma_if_not_first!();
@@ -327,7 +327,7 @@ impl PostgresQueryBuilder {
 
         if let Some(expr) = &column_def.spec.using {
             write!(sql, " USING ").unwrap();
-            QueryBuilder::prepare_simple_expr(self, expr, sql);
+            QueryBuilder::prepare_expr(self, expr, sql);
         }
 
         if let Some(extra) = &column_def.spec.extra {

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -79,7 +79,7 @@ pub trait QueryBuilder:
                                         sql.write_str(", ").unwrap();
                                     },
                                     do {
-                                        self.prepare_simple_expr(col, sql);
+                                        self.prepare_expr(col, sql);
                                     }
                                 );
 
@@ -177,7 +177,7 @@ pub trait QueryBuilder:
                 sql.write_str(", ").unwrap();
             },
             do {
-                self.prepare_simple_expr(expr, sql);
+                self.prepare_expr(expr, sql);
             }
         );
 
@@ -260,7 +260,7 @@ pub trait QueryBuilder:
                 let (col, v) = row;
                 self.prepare_update_column(&update.table, &update.from, col, sql);
                 sql.write_str(" = ").unwrap();
-                self.prepare_simple_expr(v, sql);
+                self.prepare_expr(v, sql);
             }
         );
 
@@ -394,11 +394,11 @@ pub trait QueryBuilder:
     }
 
     /// Translate [`Expr`] into SQL statement.
-    fn prepare_simple_expr(&self, simple_expr: &Expr, sql: &mut dyn SqlWriter) {
-        self.prepare_simple_expr_common(simple_expr, sql);
+    fn prepare_expr(&self, simple_expr: &Expr, sql: &mut dyn SqlWriter) {
+        self.prepare_expr_common(simple_expr, sql);
     }
 
-    fn prepare_simple_expr_common(&self, simple_expr: &Expr, sql: &mut dyn SqlWriter) {
+    fn prepare_expr_common(&self, simple_expr: &Expr, sql: &mut dyn SqlWriter) {
         match simple_expr {
             Expr::Column(column_ref) => {
                 self.prepare_column_ref(column_ref, sql);
@@ -414,7 +414,7 @@ pub trait QueryBuilder:
                 if !drop_expr_paren {
                     sql.write_str("(").unwrap();
                 }
-                self.prepare_simple_expr(expr, sql);
+                self.prepare_expr(expr, sql);
                 if !drop_expr_paren {
                     sql.write_str(")").unwrap();
                 }
@@ -474,12 +474,12 @@ pub trait QueryBuilder:
                             }
                             Some(Token::Unquoted(tok)) if numbered => {
                                 if let Ok(num) = tok.parse::<usize>() {
-                                    self.prepare_simple_expr(&values[num - 1], sql);
+                                    self.prepare_expr(&values[num - 1], sql);
                                 }
                                 tokenizer.next();
                             }
                             _ => {
-                                self.prepare_simple_expr(&values[count], sql);
+                                self.prepare_expr(&values[count], sql);
                                 count += 1;
                             }
                         },
@@ -491,7 +491,7 @@ pub trait QueryBuilder:
                 self.prepare_keyword(keyword, sql);
             }
             Expr::AsEnum(_, expr) => {
-                self.prepare_simple_expr(expr, sql);
+                self.prepare_expr(expr, sql);
             }
             Expr::Case(case_stmt) => {
                 self.prepare_case_statement(case_stmt, sql);
@@ -516,11 +516,11 @@ pub trait QueryBuilder:
             self.prepare_condition_where(&case.condition, sql);
             sql.write_str(") THEN ").unwrap();
 
-            self.prepare_simple_expr(&case.result, sql);
+            self.prepare_expr(&case.result, sql);
         }
         if let Some(r#else) = r#else {
             sql.write_str(" ELSE ").unwrap();
-            self.prepare_simple_expr(r#else, sql);
+            self.prepare_expr(r#else, sql);
         }
 
         sql.write_str(" END)").unwrap();
@@ -576,7 +576,7 @@ pub trait QueryBuilder:
 
     /// Translate [`SelectExpr`] into SQL statement.
     fn prepare_select_expr(&self, select_expr: &SelectExpr, sql: &mut dyn SqlWriter) {
-        self.prepare_simple_expr(&select_expr.expr, sql);
+        self.prepare_expr(&select_expr.expr, sql);
         match &select_expr.window {
             Some(WindowSelectType::Name(name)) => {
                 sql.write_str(" OVER ").unwrap();
@@ -747,7 +747,7 @@ pub trait QueryBuilder:
         if need_parentheses {
             sql.write_str("(").unwrap();
         }
-        self.prepare_simple_expr(simple_expr, sql);
+        self.prepare_expr(simple_expr, sql);
         if need_parentheses {
             sql.write_str(")").unwrap();
         }
@@ -794,7 +794,7 @@ pub trait QueryBuilder:
             if modifier.distinct {
                 sql.write_str("DISTINCT ").unwrap();
             }
-            self.prepare_simple_expr(arg, sql);
+            self.prepare_expr(arg, sql);
         }
 
         for (arg, modifier) in args {
@@ -802,7 +802,7 @@ pub trait QueryBuilder:
             if modifier.distinct {
                 sql.write_str("DISTINCT ").unwrap();
             }
-            self.prepare_simple_expr(arg, sql);
+            self.prepare_expr(arg, sql);
         }
 
         sql.write_str(")").unwrap();
@@ -839,7 +839,7 @@ pub trait QueryBuilder:
                 .unwrap();
                 sql.write_str(" FIRST BY ").unwrap();
 
-                self.prepare_simple_expr(&search.expr.as_ref().unwrap().expr, sql);
+                self.prepare_expr(&search.expr.as_ref().unwrap().expr, sql);
 
                 sql.write_str(" SET ").unwrap();
 
@@ -849,7 +849,7 @@ pub trait QueryBuilder:
             if let Some(cycle) = &with_clause.cycle {
                 sql.write_str("CYCLE ").unwrap();
 
-                self.prepare_simple_expr(cycle.expr.as_ref().unwrap(), sql);
+                self.prepare_expr(cycle.expr.as_ref().unwrap(), sql);
 
                 sql.write_str(" SET ").unwrap();
 
@@ -980,7 +980,7 @@ pub trait QueryBuilder:
     /// Translate [`OrderExpr`] into SQL statement.
     fn prepare_order_expr(&self, order_expr: &OrderExpr, sql: &mut dyn SqlWriter) {
         if !matches!(order_expr.order, Order::Field(_)) {
-            self.prepare_simple_expr(&order_expr.expr, sql);
+            self.prepare_expr(&order_expr.expr, sql);
         }
         self.prepare_order(order_expr, sql);
     }
@@ -1013,7 +1013,7 @@ pub trait QueryBuilder:
         let mut i = 0;
         for value in &values.0 {
             sql.write_str("WHEN ").unwrap();
-            self.prepare_simple_expr(&order_expr.expr, sql);
+            self.prepare_expr(&order_expr.expr, sql);
             sql.write_str("=").unwrap();
             self.write_value(sql.as_writer(), value).unwrap();
             sql.write_str(" THEN ").unwrap();
@@ -1073,7 +1073,7 @@ pub trait QueryBuilder:
             if i != 0 {
                 sql.write_str(", ").unwrap();
             }
-            self.prepare_simple_expr(expr, sql);
+            self.prepare_expr(expr, sql);
         }
         sql.write_str(")").unwrap();
     }
@@ -1376,7 +1376,7 @@ pub trait QueryBuilder:
                         self.prepare_iden(col, sql);
                     }
                     OnConflictTarget::ConflictExpr(expr) => {
-                        self.prepare_simple_expr(expr, sql);
+                        self.prepare_expr(expr, sql);
                     }
                 }
             },
@@ -1425,7 +1425,7 @@ pub trait QueryBuilder:
                                 OnConflictUpdate::Expr(col, expr) => {
                                     self.prepare_iden(col, sql);
                                     sql.write_str(" = ").unwrap();
-                                    self.prepare_simple_expr(expr, sql);
+                                    self.prepare_expr(expr, sql);
                                 }
                             }
                         }
@@ -1500,7 +1500,7 @@ pub trait QueryBuilder:
                             sql.write_str(", ").unwrap();
                         },
                         do {
-                            self.prepare_simple_expr(expr, sql);
+                            self.prepare_expr(expr, sql);
                         }
                     );
                 }
@@ -1539,7 +1539,7 @@ pub trait QueryBuilder:
     /// Translate part of a condition to part of a "WHERE" clause.
     fn prepare_condition_where(&self, condition: &Condition, sql: &mut dyn SqlWriter) {
         let simple_expr = condition.clone().into();
-        self.prepare_simple_expr(&simple_expr, sql);
+        self.prepare_expr(&simple_expr, sql);
     }
 
     #[doc(hidden)]
@@ -1574,7 +1574,7 @@ pub trait QueryBuilder:
                 sql.write_str(", ").unwrap();
             },
             do {
-                self.prepare_simple_expr(expr, sql);
+                self.prepare_expr(expr, sql);
             }
         );
 
@@ -1625,7 +1625,7 @@ pub trait QueryBuilder:
         if left_paren {
             sql.write_str("(").unwrap();
         }
-        self.prepare_simple_expr(left, sql);
+        self.prepare_expr(left, sql);
         if left_paren {
             sql.write_str(")").unwrap();
         }
@@ -1659,7 +1659,7 @@ pub trait QueryBuilder:
         if right_paren {
             sql.write_str("(").unwrap();
         }
-        self.prepare_simple_expr(right, sql);
+        self.prepare_expr(right, sql);
         if right_paren {
             sql.write_str(")").unwrap();
         }

--- a/src/backend/sqlite/query.rs
+++ b/src/backend/sqlite/query.rs
@@ -55,7 +55,7 @@ impl QueryBuilder for SqliteQueryBuilder {
 
     fn prepare_order_expr(&self, order_expr: &OrderExpr, sql: &mut dyn SqlWriter) {
         if !matches!(order_expr.order, Order::Field(_)) {
-            self.prepare_simple_expr(&order_expr.expr, sql);
+            self.prepare_expr(&order_expr.expr, sql);
         }
         self.prepare_order(order_expr, sql);
         match order_expr.nulls {

--- a/src/backend/table_builder.rs
+++ b/src/backend/table_builder.rs
@@ -113,7 +113,7 @@ pub trait TableBuilder:
 
         if let Some(default) = default {
             write!(sql, " DEFAULT ").unwrap();
-            QueryBuilder::prepare_simple_expr(self, default, sql);
+            QueryBuilder::prepare_expr(self, default, sql);
         }
 
         if let Some(generated) = generated {
@@ -239,14 +239,14 @@ pub trait TableBuilder:
         }
 
         sql.write_str("CHECK (").unwrap();
-        QueryBuilder::prepare_simple_expr(self, &check.expr, sql);
+        QueryBuilder::prepare_expr(self, &check.expr, sql);
         sql.write_str(")").unwrap();
     }
 
     /// Translate the generated column into SQL statement
     fn prepare_generated_column(&self, r#gen: &Expr, stored: bool, sql: &mut dyn SqlWriter) {
         sql.write_str("GENERATED ALWAYS AS (").unwrap();
-        QueryBuilder::prepare_simple_expr(self, r#gen, sql);
+        QueryBuilder::prepare_expr(self, r#gen, sql);
         sql.write_str(")").unwrap();
         if stored {
             sql.write_str(" STORED").unwrap();

--- a/src/extension/postgres/func/json_exists.rs
+++ b/src/extension/postgres/func/json_exists.rs
@@ -98,7 +98,7 @@ impl Builder {
     fn build_internal(self) -> Result<FunctionCall, core::fmt::Error> {
         let mut buf = String::with_capacity(20);
 
-        PostgresQueryBuilder.prepare_simple_expr(&self.context_item, &mut buf);
+        PostgresQueryBuilder.prepare_expr(&self.context_item, &mut buf);
         buf.write_str(" ")?;
         write_json_path_expr(&mut buf, &self.path_expression)?;
 

--- a/src/extension/postgres/func/json_query.rs
+++ b/src/extension/postgres/func/json_query.rs
@@ -146,7 +146,7 @@ impl Builder {
     fn build_internal(self) -> Result<FunctionCall, core::fmt::Error> {
         let mut buf = String::with_capacity(50);
 
-        PostgresQueryBuilder.prepare_simple_expr(&self.context_item, &mut buf);
+        PostgresQueryBuilder.prepare_expr(&self.context_item, &mut buf);
         buf.write_str(" ")?;
         write_json_path_expr(&mut buf, &self.path_expression)?;
 

--- a/src/extension/postgres/func/json_table/builder.rs
+++ b/src/extension/postgres/func/json_table/builder.rs
@@ -152,7 +152,7 @@ impl Builder {
     fn build_internal(self) -> Result<FunctionCall, core::fmt::Error> {
         let mut buf = String::with_capacity(200);
 
-        PostgresQueryBuilder.prepare_simple_expr(&self.context_item, &mut buf);
+        PostgresQueryBuilder.prepare_expr(&self.context_item, &mut buf);
         buf.write_str(", ")?;
         write_json_path_expr(&mut buf, &self.path_expression)?;
 

--- a/src/extension/postgres/func/json_table/types.rs
+++ b/src/extension/postgres/func/json_table/types.rs
@@ -59,7 +59,7 @@ impl OnClause {
             OnClause::EmptyObject => buf.write_str("EMPTY OBJECT")?,
             OnClause::Default(expr) => {
                 buf.write_str("DEFAULT ")?;
-                PostgresQueryBuilder.prepare_simple_expr(expr, buf);
+                PostgresQueryBuilder.prepare_expr(expr, buf);
             }
         };
         Ok(())

--- a/src/extension/postgres/func/json_value.rs
+++ b/src/extension/postgres/func/json_value.rs
@@ -103,7 +103,7 @@ impl Builder {
     fn build_internal(self) -> Result<FunctionCall, core::fmt::Error> {
         let mut buf = String::with_capacity(50);
 
-        PostgresQueryBuilder.prepare_simple_expr(&self.context_item, &mut buf);
+        PostgresQueryBuilder.prepare_expr(&self.context_item, &mut buf);
         buf.write_str(" ")?;
         write_json_path_expr(&mut buf, &self.path_expression)?;
 
@@ -121,7 +121,7 @@ impl Builder {
                 OnClause::Null => buf.write_str(" NULL")?,
                 OnClause::Default(expr) => {
                     buf.write_str(" DEFAULT ")?;
-                    PostgresQueryBuilder.prepare_simple_expr(&expr, &mut buf);
+                    PostgresQueryBuilder.prepare_expr(&expr, &mut buf);
                 }
             }
             buf.write_str(" ON EMPTY")?;
@@ -133,7 +133,7 @@ impl Builder {
                 OnClause::Null => buf.write_str(" NULL")?,
                 OnClause::Default(expr) => {
                     buf.write_str(" DEFAULT ")?;
-                    PostgresQueryBuilder.prepare_simple_expr(&expr, &mut buf);
+                    PostgresQueryBuilder.prepare_expr(&expr, &mut buf);
                 }
             };
             buf.write_str(" ON ERROR")?;


### PR DESCRIPTION
Since we have renamed SimpleExpr, I renamed the related methods for consistency.
This is basically just a personal preference.