### PR TITLE
Add itoa for integer formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ jiff = { version = "0.2.15", default-features = false, optional = true, features
 ipnetwork = { version = "0.20", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
 ordered-float = { version = "4.6", default-features = false, optional = true }
+itoa = { version = "1.0.15", optional = true }
 
 [dev-dependencies]
 sea-query = { path = ".", features = ["tests-cfg"] }
@@ -55,7 +56,7 @@ audit = []
 backend-mysql = []
 backend-postgres = []
 backend-sqlite = []
-default = ["derive", "audit", "backend-mysql", "backend-postgres", "backend-sqlite"]
+default = ["derive", "audit", "backend-mysql", "backend-postgres", "backend-sqlite", "itoa"]
 derive = ["sea-query-derive"]
 attr = ["sea-query-derive"]
 hashable-value = ["ordered-float"]
@@ -116,6 +117,7 @@ all-types = [
 ]
 option-more-parentheses = []
 option-sqlite-exact-column-type = []
+itoa = ["dep:itoa"]
 
 [[test]]
 name = "test-derive"

--- a/benches/value.rs
+++ b/benches/value.rs
@@ -64,5 +64,16 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, criterion_benchmark);
+fn cfg() -> Criterion {
+    Criterion::default()
+        .configure_from_args()
+        .measurement_time(std::time::Duration::new(10, 0))
+        .sample_size(200)
+}
+
+criterion_group! {
+    name = benches;
+    config = cfg();
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/src/backend/index_builder.rs
+++ b/src/backend/index_builder.rs
@@ -50,7 +50,7 @@ pub trait IndexBuilder: QuotedBuilder + TableRefBuilder {
     fn write_column_index_prefix(&self, col_prefix: &Option<u32>, sql: &mut impl SqlWriter) {
         if let Some(prefix) = col_prefix {
             sql.write_str(" (").unwrap();
-            write!(sql, "{prefix}").unwrap();
+            write_int(sql, *prefix);
             sql.write_str(")").unwrap();
         }
     }

--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::write_int;
 
 impl TableBuilder for MysqlQueryBuilder {
     fn prepare_table_opt(&self, create: &TableCreateStatement, sql: &mut impl SqlWriter) {
@@ -27,7 +28,7 @@ impl TableBuilder for MysqlQueryBuilder {
             ColumnType::Char(length) => match length {
                 Some(length) => {
                     sql.write_str("char(").unwrap();
-                    write!(sql, "{length}").unwrap();
+                    write_int(sql, *length);
                     sql.write_str(")")
                 }
                 None => sql.write_str("char"),
@@ -35,7 +36,7 @@ impl TableBuilder for MysqlQueryBuilder {
             ColumnType::String(length) => match length {
                 StringLen::N(length) => {
                     sql.write_str("varchar(").unwrap();
-                    write!(sql, "{length}").unwrap();
+                    write_int(sql, *length);
                     sql.write_char(')')
                 }
                 StringLen::None => sql.write_str("varchar(255)"),
@@ -51,9 +52,9 @@ impl TableBuilder for MysqlQueryBuilder {
             ColumnType::Decimal(precision) => match precision {
                 Some((precision, scale)) => {
                     sql.write_str("decimal(").unwrap();
-                    write!(sql, "{precision}").unwrap();
+                    write_int(sql, *precision);
                     sql.write_str(", ").unwrap();
-                    write!(sql, "{scale}").unwrap();
+                    write_int(sql, *scale);
                     sql.write_char(')')
                 }
                 None => sql.write_str("decimal"),
@@ -67,13 +68,13 @@ impl TableBuilder for MysqlQueryBuilder {
             ColumnType::Interval(_, _) => sql.write_str("unsupported"),
             ColumnType::Binary(length) => {
                 sql.write_str("binary(").unwrap();
-                write!(sql, "{length}").unwrap();
+                write_int(sql, *length);
                 sql.write_char(')')
             }
             ColumnType::VarBinary(length) => match length {
                 StringLen::N(length) => {
                     sql.write_str("varbinary(").unwrap();
-                    write!(sql, "{length}").unwrap();
+                    write_int(sql, *length);
                     sql.write_char(')')
                 }
                 StringLen::None => sql.write_str("varbinary(255)"),
@@ -83,23 +84,23 @@ impl TableBuilder for MysqlQueryBuilder {
             ColumnType::Bit(length) => match length {
                 Some(length) => {
                     sql.write_str("bit(").unwrap();
-                    write!(sql, "{length}").unwrap();
+                    write_int(sql, *length);
                     sql.write_char(')')
                 }
                 None => sql.write_str("bit"),
             },
             ColumnType::VarBit(length) => {
                 sql.write_str("bit(").unwrap();
-                write!(sql, "{length}").unwrap();
+                write_int(sql, *length);
                 sql.write_char(')')
             }
             ColumnType::Boolean => sql.write_str("bool"),
             ColumnType::Money(precision) => match precision {
                 Some((precision, scale)) => {
                     sql.write_str("decimal(").unwrap();
-                    write!(sql, "{precision}").unwrap();
+                    write_int(sql, *precision);
                     sql.write_str(", ").unwrap();
-                    write!(sql, "{scale}").unwrap();
+                    write_int(sql, *scale);
                     sql.write_char(')')
                 }
                 None => sql.write_str("decimal"),

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::write_int;
 
 impl TableBuilder for PostgresQueryBuilder {
     fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut impl SqlWriter) {
@@ -14,7 +15,7 @@ impl TableBuilder for PostgresQueryBuilder {
             ColumnType::Char(length) => match length {
                 Some(length) => {
                     sql.write_str("char(").unwrap();
-                    write!(sql, "{length}").unwrap();
+                    write_int(sql, *length);
                     sql.write_char(')')
                 }
                 None => sql.write_str("char"),
@@ -22,7 +23,7 @@ impl TableBuilder for PostgresQueryBuilder {
             ColumnType::String(length) => match length {
                 StringLen::N(length) => {
                     sql.write_str("varchar(").unwrap();
-                    write!(sql, "{length}").unwrap();
+                    write_int(sql, *length);
                     sql.write_char(')')
                 }
                 _ => sql.write_str("varchar"),
@@ -37,9 +38,9 @@ impl TableBuilder for PostgresQueryBuilder {
             ColumnType::Decimal(precision) => match precision {
                 Some((precision, scale)) => {
                     sql.write_str("decimal(").unwrap();
-                    write!(sql, "{precision}").unwrap();
+                    write_int(sql, *precision);
                     sql.write_str(", ").unwrap();
-                    write!(sql, "{scale}").unwrap();
+                    write_int(sql, *scale);
                     sql.write_char(')')
                 }
                 None => sql.write_str("decimal"),
@@ -58,7 +59,7 @@ impl TableBuilder for PostgresQueryBuilder {
 
                 if let Some(precision) = precision {
                     sql.write_char('(').unwrap();
-                    write!(sql, "{precision}").unwrap();
+                    write_int(sql, *precision);
                     sql.write_char(')').unwrap();
                 }
                 Ok(())
@@ -69,23 +70,23 @@ impl TableBuilder for PostgresQueryBuilder {
             ColumnType::Bit(length) => match length {
                 Some(length) => {
                     sql.write_str("bit(").unwrap();
-                    write!(sql, "{length}").unwrap();
+                    write_int(sql, *length);
                     sql.write_char(')')
                 }
                 None => sql.write_str("bit"),
             },
             ColumnType::VarBit(length) => {
                 sql.write_str("varbit(").unwrap();
-                write!(sql, "{length}").unwrap();
+                write_int(sql, *length);
                 sql.write_char(')')
             }
             ColumnType::Boolean => sql.write_str("bool"),
             ColumnType::Money(precision) => match precision {
                 Some((precision, scale)) => {
                     sql.write_str("money(").unwrap();
-                    write!(sql, "{precision}").unwrap();
+                    write_int(sql, *precision);
                     sql.write_str(", ").unwrap();
-                    write!(sql, "{scale}").unwrap();
+                    write_int(sql, *scale);
                     sql.write_char(')')
                 }
                 None => sql.write_str("money"),
@@ -100,7 +101,7 @@ impl TableBuilder for PostgresQueryBuilder {
             ColumnType::Vector(size) => match size {
                 Some(size) => {
                     sql.write_str("vector(").unwrap();
-                    write!(sql, "{size}").unwrap();
+                    write_int(sql, *size);
                     sql.write_str(")")
                 }
                 None => sql.write_str("vector"),

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1027,13 +1027,13 @@ pub trait QueryBuilder:
             sql.write_str("=").unwrap();
             self.write_value(sql, value).unwrap();
             sql.write_str(" THEN ").unwrap();
-            write!(sql, "{i}").unwrap();
+            write_int(sql, i);
             sql.write_str(" ").unwrap();
             i += 1;
         }
 
         sql.write_str("ELSE ").unwrap();
-        write!(sql, "{i}").unwrap();
+        write_int(sql, i);
         sql.write_str(" END").unwrap();
     }
 
@@ -1175,14 +1175,30 @@ pub trait QueryBuilder:
             #[cfg(feature = "postgres-vector")]
             Value::Vector(None) => buf.write_str("NULL")?,
             Value::Bool(Some(b)) => buf.write_str(if *b { "TRUE" } else { "FALSE" })?,
-            Value::TinyInt(Some(v)) => write!(buf, "{v}")?,
-            Value::SmallInt(Some(v)) => write!(buf, "{v}")?,
-            Value::Int(Some(v)) => write!(buf, "{v}")?,
-            Value::BigInt(Some(v)) => write!(buf, "{v}")?,
-            Value::TinyUnsigned(Some(v)) => write!(buf, "{v}")?,
-            Value::SmallUnsigned(Some(v)) => write!(buf, "{v}")?,
-            Value::Unsigned(Some(v)) => write!(buf, "{v}")?,
-            Value::BigUnsigned(Some(v)) => write!(buf, "{v}")?,
+            Value::TinyInt(Some(v)) => {
+                write_int(buf, *v);
+            }
+            Value::SmallInt(Some(v)) => {
+                write_int(buf, *v);
+            }
+            Value::Int(Some(v)) => {
+                write_int(buf, *v);
+            }
+            Value::BigInt(Some(v)) => {
+                write_int(buf, *v);
+            }
+            Value::TinyUnsigned(Some(v)) => {
+                write_int(buf, *v);
+            }
+            Value::SmallUnsigned(Some(v)) => {
+                write_int(buf, *v);
+            }
+            Value::Unsigned(Some(v)) => {
+                write_int(buf, *v);
+            }
+            Value::BigUnsigned(Some(v)) => {
+                write_int(buf, *v);
+            }
             Value::Float(Some(v)) => write!(buf, "{v}")?,
             Value::Double(Some(v)) => write!(buf, "{v}")?,
             Value::String(Some(v)) => self.write_string_quoted(v, buf),

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::write_int;
 
 impl TableBuilder for SqliteQueryBuilder {
     fn prepare_column_def(&self, column_def: &ColumnDef, sql: &mut impl SqlWriter) {
@@ -107,7 +108,7 @@ impl SqliteQueryBuilder {
             ColumnType::Char(length) => match length {
                 Some(length) => {
                     sql.write_str("char(").unwrap();
-                    write!(sql, "{length}").unwrap();
+                    write_int(sql, *length);
                     sql.write_char(')')
                 }
                 None => sql.write_str("char"),
@@ -115,7 +116,7 @@ impl SqliteQueryBuilder {
             ColumnType::String(length) => match length {
                 StringLen::N(length) => {
                     sql.write_str("varchar(").unwrap();
-                    write!(sql, "{length}").unwrap();
+                    write_int(sql, *length);
                     sql.write_char(')')
                 }
                 _ => sql.write_str("varchar"),
@@ -142,9 +143,9 @@ impl SqliteQueryBuilder {
                         panic!("precision cannot be larger than 16");
                     }
                     sql.write_str("real(").unwrap();
-                    write!(sql, "{precision}").unwrap();
+                    write_int(sql, *precision);
                     sql.write_str(", ").unwrap();
-                    write!(sql, "{scale}").unwrap();
+                    write_int(sql, *scale);
                     sql.write_char(')')
                 }
                 None => sql.write_str("real"),
@@ -157,13 +158,13 @@ impl SqliteQueryBuilder {
             ColumnType::Interval(_, _) => unimplemented!("Interval is not available in Sqlite."),
             ColumnType::Binary(length) => {
                 sql.write_str("blob(").unwrap();
-                write!(sql, "{length}").unwrap();
+                write_int(sql, *length);
                 sql.write_char(')')
             }
             ColumnType::VarBinary(length) => match length {
                 StringLen::N(length) => {
                     sql.write_str("varbinary_blob(").unwrap();
-                    write!(sql, "{length}").unwrap();
+                    write_int(sql, *length);
                     sql.write_char(')')
                 }
                 _ => sql.write_str("varbinary_blob"),
@@ -173,9 +174,9 @@ impl SqliteQueryBuilder {
             ColumnType::Money(precision) => match precision {
                 Some((precision, scale)) => {
                     sql.write_str("real_money(").unwrap();
-                    write!(sql, "{precision}").unwrap();
+                    write_int(sql, *precision);
                     sql.write_str(", ").unwrap();
-                    write!(sql, "{scale}").unwrap();
+                    write_int(sql, *scale);
                     sql.write_char(')')
                 }
                 None => sql.write_str("real_money"),

--- a/src/raw_sql.rs
+++ b/src/raw_sql.rs
@@ -1,7 +1,6 @@
 pub mod seaql;
 
-use crate::QueryBuilder;
-use std::fmt::Write;
+use crate::{QueryBuilder, write_int};
 
 #[derive(Debug)]
 pub struct RawSqlQueryBuilder {
@@ -34,7 +33,7 @@ impl RawSqlQueryBuilder {
             }
             self.sql.push_str(self.placeholder);
             if self.numbered {
-                write!(&mut self.sql, "{}", self.parameter_index).unwrap();
+                write_int(&mut self.sql, self.parameter_index);
                 self.parameter_index += 1;
             }
         }


### PR DESCRIPTION
This optimization reduces the gap in build and to_string methods between the PostgreSQL backend and other backends.