### PR TITLE
implemented drop column if exists for postgres

### DIFF
--- a/src/backend/mysql/table.rs
+++ b/src/backend/mysql/table.rs
@@ -190,8 +190,11 @@ impl TableBuilder for MysqlQueryBuilder {
                         sql.write_str(" TO ").unwrap();
                         self.prepare_iden(to_name, sql);
                     }
-                    TableAlterOption::DropColumn(column_name) => {
+                    TableAlterOption::DropColumn(DropColumnOption { column_name, if_exists }) => {
                         sql.write_str("DROP COLUMN ").unwrap();
+                        if *if_exists{
+                             panic!("MySQL does not support drop column if exists");
+                        }
                         self.prepare_iden(column_name, sql);
                     }
                     TableAlterOption::DropForeignKey(name) => {

--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -170,8 +170,14 @@ impl TableBuilder for PostgresQueryBuilder {
                         sql.write_str(" TO ").unwrap();
                         self.prepare_iden(to_name, sql);
                     }
-                    TableAlterOption::DropColumn(column_name) => {
+                    TableAlterOption::DropColumn(DropColumnOption{
+                        column_name,
+                        if_exists
+                    }) => {
                         sql.write_str("DROP COLUMN ").unwrap();
+                         if *if_exists {
+                            sql.write_str("IF EXISTS ").unwrap();
+                        }
                         self.prepare_iden(column_name, sql);
                     }
                     TableAlterOption::DropForeignKey(name) => {

--- a/src/backend/sqlite/table.rs
+++ b/src/backend/sqlite/table.rs
@@ -62,9 +62,15 @@ impl TableBuilder for SqliteQueryBuilder {
                 sql.write_str(" TO ").unwrap();
                 self.prepare_iden(to_name, sql);
             }
-            TableAlterOption::DropColumn(col_name) => {
+            TableAlterOption::DropColumn(DropColumnOption {
+                column_name,
+                if_exists,
+            }) => {
                 sql.write_str("DROP COLUMN ").unwrap();
-                self.prepare_iden(col_name, sql);
+                if *if_exists {
+                    panic!("Sqlite does not support drop column if exists");
+                }
+                self.prepare_iden(column_name, sql);
             }
             TableAlterOption::DropForeignKey(_) => {
                 panic!(


### PR DESCRIPTION
## PR Info

<!-- mention the related issue -->
Closes https://github.com/SeaQL/sea-query/issues/995

## New Features

This pull request implements DROP COLUMN IF EXISTS for Postgres which is not supported by sea-query currently.