### PR TITLE
Add support for Postgres range type

### DIFF
--- a/src/expr/enum.rs
+++ b/src/expr/enum.rs
@@ -594,6 +594,35 @@ impl Expr {
         Func::sum(self).into()
     }
 
+    /// Express a `AVG` (average) function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .expr(Expr::col((Char::Table, Char::SizeW)).avg())
+    ///     .from(Char::Table)
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT AVG(`character`.`size_w`) FROM `character`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT AVG("character"."size_w") FROM "character""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT AVG("character"."size_w") FROM "character""#
+    /// );
+    /// ```
+    pub fn avg(self) -> Self {
+        Func::avg(self).into()
+    }
+
     /// Express a `COUNT` function.
     ///
     /// # Examples

--- a/src/func.rs
+++ b/src/func.rs
@@ -172,7 +172,7 @@ impl Func {
         FunctionCall::new(Func::Sum).arg(expr)
     }
 
-    /// Call `AVG` function.
+    /// Call `AVG` function for average.
     ///
     /// # Examples
     ///

--- a/src/value.rs
+++ b/src/value.rs
@@ -42,6 +42,9 @@ mod tests;
 #[cfg(feature = "hashable-value")]
 mod hashable_value;
 
+mod value_class;
+pub use value_class::*;
+
 mod value_tuple;
 pub use value_tuple::*;
 

--- a/src/value/value_class.rs
+++ b/src/value/value_class.rs
@@ -1,0 +1,18 @@
+pub trait NumericValue: Sized {}
+
+pub trait DateLikeValue: Sized {}
+
+pub trait TimeLikeValue: Sized {}
+
+pub trait DateTimeLikeValue: Sized {}
+
+impl NumericValue for i8 {}
+impl NumericValue for i16 {}
+impl NumericValue for i32 {}
+impl NumericValue for i64 {}
+impl NumericValue for u8 {}
+impl NumericValue for u16 {}
+impl NumericValue for u32 {}
+impl NumericValue for u64 {}
+impl NumericValue for f32 {}
+impl NumericValue for f64 {}

--- a/src/value/with_bigdecimal.rs
+++ b/src/value/with_bigdecimal.rs
@@ -2,6 +2,8 @@ use super::*;
 
 type_to_box_value!(BigDecimal, BigDecimal, Decimal(None));
 
+impl NumericValue for BigDecimal;
+
 impl Value {
     pub fn is_big_decimal(&self) -> bool {
         matches!(self, Self::BigDecimal(_))

--- a/src/value/with_chrono.rs
+++ b/src/value/with_chrono.rs
@@ -5,6 +5,13 @@ type_to_value!(NaiveDate, ChronoDate, Date);
 type_to_value!(NaiveTime, ChronoTime, Time);
 type_to_value!(NaiveDateTime, ChronoDateTime, DateTime);
 
+impl DateLikeValue for NaiveDate;
+impl TimeLikeValue for NaiveTime;
+impl DateTimeLikeValue for NaiveDateTime;
+impl DateTimeLikeValue for DateTime<Utc>;
+impl DateTimeLikeValue for DateTime<Local>;
+impl DateTimeLikeValue for DateTime<FixedOffset>;
+
 impl From<DateTime<Utc>> for Value {
     fn from(v: DateTime<Utc>) -> Value {
         Value::ChronoDateTimeUtc(Some(v))

--- a/src/value/with_jiff.rs
+++ b/src/value/with_jiff.rs
@@ -7,6 +7,12 @@ type_to_box_value!(civil::DateTime, JiffDateTime, DateTime);
 type_to_box_value!(Timestamp, JiffTimestamp, Timestamp);
 type_to_box_value!(Zoned, JiffZoned, TimestampWithTimeZone);
 
+impl DateLikeValue for civil::Date {}
+impl TimeLikeValue for civil::Time {}
+impl DateTimeLikeValue for civil::DateTime {}
+impl DateTimeLikeValue for Timestamp {}
+impl DateTimeLikeValue for Zoned {}
+
 impl Value {
     #[inline]
     pub fn jiff_date<T: Into<Option<civil::Date>>>(v: T) -> Value {

--- a/src/value/with_rust_decimal.rs
+++ b/src/value/with_rust_decimal.rs
@@ -2,6 +2,8 @@ use super::*;
 
 type_to_value!(Decimal, Decimal, Decimal(None));
 
+impl NumericValue for Decimal;
+
 impl Value {
     pub fn is_decimal(&self) -> bool {
         matches!(self, Self::Decimal(_))

--- a/src/value/with_time.rs
+++ b/src/value/with_time.rs
@@ -4,6 +4,11 @@ type_to_value!(time::Date, TimeDate, Date);
 type_to_value!(time::Time, TimeTime, Time);
 type_to_value!(PrimitiveDateTime, TimeDateTime, DateTime);
 
+impl DateLikeValue for time::Date {}
+impl TimeLikeValue for time::Time {}
+impl DateTimeLikeValue for time::PrimitiveDateTime {}
+impl DateTimeLikeValue for time::OffsetDateTime {}
+
 impl From<OffsetDateTime> for Value {
     fn from(v: OffsetDateTime) -> Value {
         Value::TimeDateTimeWithTimeZone(Some(v))


### PR DESCRIPTION
## PR Info

- Closes https://github.com/SeaQL/sea-query/issues/69

## New Features

- [ ] Provide a new type `RangeType` to implement Postgres range type
- [ ] Provide range type as an element type of Postgres Array

## Doubts

- [ ] Not sure where to implement `hashable-value` features. I put that in the `with_range.rs`
- [ ] It implements time ranges with Chrono and Time I left out Jiff now
- [ ] Not sure how it plays together with `with-json`
- [ ] How to make RangeType from std Rust types (tuple, std range, how to describe exclusive and inclusive bounds?)