### PR TITLE
Fix Missing `IntoCondition` Import Breaking Loco.rs Migration to SeaORM 2.0

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -3,8 +3,8 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 use crate::{
-    FunctionCall, QueryStatement, QueryStatementBuilder, QueryStatementWriter, SubQueryStatement,
-    WindowStatement, WithClause, WithQuery,
+    FunctionCall, IntoCondition, QueryStatement, QueryStatementBuilder, QueryStatementWriter,
+    SubQueryStatement, WindowStatement, WithClause, WithQuery,
     backend::QueryBuilder,
     expr::*,
     prepare::*,

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use inherent::inherent;
 
 use crate::{
-    QueryStatement, QueryStatementBuilder, QueryStatementWriter, ReturningClause,
+    IntoCondition, QueryStatement, QueryStatementBuilder, QueryStatementWriter, ReturningClause,
     SubQueryStatement, WithClause, WithQuery,
     backend::QueryBuilder,
     expr::*,


### PR DESCRIPTION
## Description

This PR fixes a critical issue that was breaking Loco.rs framework migration to SeaORM 2.0. The problem was that the `IntoCondition` trait import was missing in the `UpdateStatement` and `SelectStatement` implementations, preventing proper compilation and usage of conditional queries.

## Problem

When upgrading to SeaORM 2.0, Loco.rs users encountered compilation errors in query building due to missing `IntoCondition` trait implementations. The `cond_where` method in `ConditionalStatement` trait implementations required `IntoCondition` but the necessary imports and trait bounds were incomplete.

## Changes Made

### 1. Added Missing Import
```rust
use crate::IntoCondition;
```

## Impact

- ✅ Fixes Loco.rs migration to SeaORM 2.0

## Testing

The fix has been verified with:
- Loco.rs test suite
- SeaQuery integration tests

## Related Issues

Fixes migration issues reported in Loco.rs framework when upgrading to SeaORM 2.0.

## Notes

This is a minimal, targeted fix that addresses the immediate compilation issue while maintaining all existing functionality and API compatibility.