### PR TITLE
feat: add SelectExprTrait for ergonomic alias and window chaining

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -244,6 +244,18 @@ impl SelectInto {
     }
 }
 
+impl From<WindowStatement> for WindowSelectType {
+    fn from(stmt: WindowStatement) -> Self {
+        Self::Query(stmt)
+    }
+}
+
+impl<T: IntoIden> From<T> for WindowSelectType {
+    fn from(iden: T) -> Self {
+        Self::Name(iden.into_iden())
+    }
+}
+
 /// Extension methods for building a [`SelectExpr`] from an expression.
 ///
 /// This makes it ergonomic to attach select-specific modifiers (like `AS` and `OVER`) and pass the
@@ -259,7 +271,7 @@ impl SelectInto {
 ///     .expr(
 ///         Expr::col(Char::Character)
 ///             .max()
-///             .window(WindowStatement::partition_by(Char::FontSize))
+///             .over(WindowStatement::partition_by(Char::FontSize))
 ///             .alias("C"),
 ///     )
 ///     .to_owned();
@@ -274,11 +286,7 @@ pub trait SelectExprTrait: Sized {
     where
         A: IntoIden;
 
-    fn window(self, window: WindowStatement) -> SelectExpr;
-
-    fn window_name<W>(self, window: W) -> SelectExpr
-    where
-        W: IntoIden;
+    fn over(self, over_expr: impl Into<WindowSelectType>) -> SelectExpr;
 }
 
 impl SelectExprTrait for SelectExpr {
@@ -290,16 +298,8 @@ impl SelectExprTrait for SelectExpr {
         self
     }
 
-    fn window(mut self, window: WindowStatement) -> SelectExpr {
-        self.window = Some(WindowSelectType::Query(window));
-        self
-    }
-
-    fn window_name<W>(mut self, window: W) -> SelectExpr
-    where
-        W: IntoIden,
-    {
-        self.window = Some(WindowSelectType::Name(window.into_iden()));
+    fn over(mut self, over_expr: impl Into<WindowSelectType>) -> SelectExpr {
+        self.window = Some(over_expr.into());
         self
     }
 }
@@ -315,15 +315,8 @@ where
         SelectExpr::from(self).alias(alias)
     }
 
-    fn window(self, window: WindowStatement) -> SelectExpr {
-        SelectExpr::from(self).window(window)
-    }
-
-    fn window_name<W>(self, window: W) -> SelectExpr
-    where
-        W: IntoIden,
-    {
-        SelectExpr::from(self).window_name(window)
+    fn over(self, over_expr: impl Into<WindowSelectType>) -> SelectExpr {
+        SelectExpr::from(self).over(over_expr)
     }
 }
 impl SelectStatement {
@@ -840,7 +833,7 @@ impl SelectStatement {
     where
         T: Into<Expr>,
     {
-        self.expr(expr.window(window));
+        self.expr(expr.over(window));
         self
     }
 
@@ -878,7 +871,7 @@ impl SelectStatement {
         T: Into<Expr>,
         A: IntoIden,
     {
-        self.expr(expr.window(window).alias(alias));
+        self.expr(expr.over(window).alias(alias));
         self
     }
 
@@ -913,7 +906,7 @@ impl SelectStatement {
         T: Into<Expr>,
         W: IntoIden,
     {
-        self.expr(expr.window_name(window));
+        self.expr(expr.over(window));
         self
     }
 
@@ -949,7 +942,7 @@ impl SelectStatement {
         A: IntoIden,
         W: IntoIden,
     {
-        self.expr(expr.window_name(window).alias(alias));
+        self.expr(expr.over(window).alias(alias));
         self
     }
 

--- a/tests/mysql/query.rs
+++ b/tests/mysql/query.rs
@@ -1055,13 +1055,13 @@ fn select_61() {
 fn select_62() {
     assert_eq!(
         Query::select()
+            .from(Char::Table)
             .expr(
                 Expr::col(Char::Character)
                     .max()
-                    .window(WindowStatement::partition_by(Char::FontSize))
+                    .over(WindowStatement::partition_by(Char::FontSize))
                     .alias("C"),
             )
-            .from(Char::Table)
             .to_string(MysqlQueryBuilder),
         r#"SELECT MAX(`character`) OVER ( PARTITION BY `font_size` ) AS `C` FROM `character`"#
     );
@@ -1071,8 +1071,8 @@ fn select_62() {
 fn select_63() {
     assert_eq!(
         Query::select()
-            .expr(Expr::col(Char::Character).max().window_name("w"))
             .from(Char::Table)
+            .expr(Expr::col(Char::Character).max().over("w"))
             .window("w", WindowStatement::partition_by(Char::FontSize))
             .to_string(MysqlQueryBuilder),
         r#"SELECT MAX(`character`) OVER `w` FROM `character` WINDOW `w` AS (PARTITION BY `font_size`)"#

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1290,13 +1290,13 @@ fn select_65() {
 fn select_66() {
     assert_eq!(
         Query::select()
+            .from(Char::Table)
             .expr(
                 Expr::col(Char::Character)
                     .max()
-                    .window(WindowStatement::partition_by(Char::FontSize))
+                    .over(WindowStatement::partition_by(Char::FontSize))
                     .alias("C"),
             )
-            .from(Char::Table)
             .to_string(PostgresQueryBuilder),
         r#"SELECT MAX("character") OVER ( PARTITION BY "font_size" ) AS "C" FROM "character""#
     );
@@ -1306,8 +1306,8 @@ fn select_66() {
 fn select_67() {
     assert_eq!(
         Query::select()
-            .expr(Expr::col(Char::Character).max().window_name("w"))
             .from(Char::Table)
+            .expr(Expr::col(Char::Character).max().over("w"))
             .window("w", WindowStatement::partition_by(Char::FontSize))
             .to_string(PostgresQueryBuilder),
         r#"SELECT MAX("character") OVER "w" FROM "character" WINDOW "w" AS (PARTITION BY "font_size")"#

--- a/tests/sqlite/query.rs
+++ b/tests/sqlite/query.rs
@@ -1028,13 +1028,13 @@ fn select_58() {
 fn select_59() {
     assert_eq!(
         Query::select()
+            .from(Char::Table)
             .expr(
                 Expr::col(Char::Character)
                     .max()
-                    .window(WindowStatement::partition_by(Char::FontSize))
+                    .over(WindowStatement::partition_by(Char::FontSize))
                     .alias("C"),
             )
-            .from(Char::Table)
             .to_string(SqliteQueryBuilder),
         r#"SELECT MAX("character") OVER ( PARTITION BY "font_size" ) AS "C" FROM "character""#
     );
@@ -1044,8 +1044,8 @@ fn select_59() {
 fn select_60() {
     assert_eq!(
         Query::select()
-            .expr(Expr::col(Char::Character).max().window_name("w"))
             .from(Char::Table)
+            .expr(Expr::col(Char::Character).max().over("w"))
             .window("w", WindowStatement::partition_by(Char::FontSize))
             .to_string(SqliteQueryBuilder),
         r#"SELECT MAX("character") OVER "w" FROM "character" WINDOW "w" AS (PARTITION BY "font_size")"#


### PR DESCRIPTION
## PR Info

- Closes #344

## Changes

### SelectExprTrait

Add SelectExprTrait providing alias and over methods. Implemented for both SelectExpr and `T: Into<Expr>`, enabling.

```rust
Expr::col(...).alias(...)
Expr::col(...).over(...)
```

`over` accepts `impl Into<WindowSelectType>`, with impls for

```rust
impl From<WindowStatement> for WindowSelectType;
impl<T: IntoIden> From<T> for WindowSelectType;
```

### Compatibility and refactor

Existing helpers are kept, and their implementation now routes through SelectExprTrait.

- SelectStatement::expr_as
- SelectStatement::expr_window
- SelectStatement::expr_window_as
- SelectStatement::expr_window_name
- SelectStatement::expr_window_name_as

### Doctest fixes

Fix window-related doctests to generate executable SQL (apply the window clause to a window function, e.g. MAX(col) OVER (...), instead of a bare column).

## Examples

```rust
Query::select()
    .from(Char::Table)
    .expr(Expr::col(Char::Character).alias("C"));

Query::select()
    .from(Char::Table)
    .expr(
        Expr::col(Char::Character)
            .max()
            .over(WindowStatement::partition_by(Char::FontSize))
            .alias("C"),
    );

Query::select()
    .from(Char::Table)
    .expr(Expr::col(Char::Character).max().over("w"))
    .window("w", WindowStatement::partition_by(Char::FontSize));
```

## Design notes & feedback requested

I'd appreciate maintainer input on whether this design aligns with the project's long-term direction.

1. Expr → SelectExpr transition
    - Option A: Explicit method like Expr::into_select() — more explicit, avoids method-name collisions
    - Option B: Extension trait allowing Expr::col(...).alias(...) directly — more ergonomic (this PR)

2. SelectExpr construction responsibility
    - Option A: Chaining methods on SelectExpr (this PR) — simple, but moves SelectExpr toward a builder-like role
    - Option B: Separate SelectExprBuilder — keeps SelectExpr as pure data, but adds a new public type
