### PR TITLE
clarify default behaviour on StringLen

### DIFF
--- a/src/table/column.rs
+++ b/src/table/column.rs
@@ -119,7 +119,7 @@ pub enum ColumnType {
     LTree,
 }
 
-/// Length for var-char/binary; default to 255
+/// Length for var-char/binary; default to 255 in MySQL if length is not specified
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum StringLen {
     /// String size


### PR DESCRIPTION
## PR Info
Clarified default length for var-char/binary in MySQL.
<!-- mention the related issue -->
- Closes https://github.com/SeaQL/sea-query/issues/1049