### PR TITLE
Add support for `time::UtcDateTime`

### DIFF
--- a/sea-query-sqlx/src/sqlx_any.rs
+++ b/sea-query-sqlx/src/sqlx_any.rs
@@ -88,6 +88,10 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::any::Any> for SqlxValues {
                     let _ = args.add(Value::TimeDateTime(t).time_as_naive_utc_in_string());
                 }
                 #[cfg(feature = "with-time")]
+                Value::TimeDateTimeUtc(t) => {
+                    let _ = args.add(Value::TimeDateTimeUtc(t).time_as_naive_utc_in_string());
+                }
+                #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => {
                     let _ =
                         args.add(Value::TimeDateTimeWithTimeZone(t).time_as_naive_utc_in_string());

--- a/sea-query-sqlx/src/sqlx_mysql.rs
+++ b/sea-query-sqlx/src/sqlx_mysql.rs
@@ -87,6 +87,10 @@ impl sqlx::IntoArguments<'_, sqlx::mysql::MySql> for SqlxValues {
                     let _ = args.add(t);
                 }
                 #[cfg(feature = "with-time")]
+                Value::TimeDateTimeUtc(t) => {
+                    let _ = args.add(t.map(sqlx::types::time::OffsetDateTime::from));
+                }
+                #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => {
                     let _ = args.add(t);
                 }

--- a/sea-query-sqlx/src/sqlx_postgres.rs
+++ b/sea-query-sqlx/src/sqlx_postgres.rs
@@ -104,6 +104,10 @@ impl sqlx::IntoArguments<'_, sqlx::postgres::Postgres> for SqlxValues {
                     let _ = args.add(t);
                 }
                 #[cfg(feature = "with-time")]
+                Value::TimeDateTimeUtc(t) => {
+                    let _ = args.add(t.map(sqlx::types::time::OffsetDateTime::from));
+                }
+                #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => {
                     let _ = args.add(t);
                 }
@@ -270,6 +274,15 @@ impl sqlx::IntoArguments<'_, sqlx::postgres::Postgres> for SqlxValues {
                     ArrayType::TimeDateTime => {
                         let value: Option<Vec<time::PrimitiveDateTime>> = Value::Array(ty, v)
                             .expect("This Value::Array should consist of Value::TimeDateTime");
+                        let _ = args.add(value);
+                    }
+                    #[cfg(feature = "with-time")]
+                    ArrayType::TimeDateTimeUtc => {
+                        let value: Option<Vec<time::UtcDateTime>> = Value::Array(ty, v)
+                            .expect("This Value::Array should consist of Value::TimeDateTimeUtc");
+                        // temprorary, until sqlx supports UtcDateTime
+                        let value: Option<Vec<time::OffsetDateTime>> = value
+                            .map(|vec| vec.into_iter().map(time::OffsetDateTime::from).collect());
                         let _ = args.add(value);
                     }
                     #[cfg(feature = "with-time")]

--- a/sea-query-sqlx/src/sqlx_sqlite.rs
+++ b/sea-query-sqlx/src/sqlx_sqlite.rs
@@ -87,6 +87,10 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                     let _ = args.add(t);
                 }
                 #[cfg(feature = "with-time")]
+                Value::TimeDateTimeUtc(t) => {
+                    let _ = args.add(t.map(sqlx::types::time::OffsetDateTime::from));
+                }
+                #[cfg(feature = "with-time")]
                 Value::TimeDateTimeWithTimeZone(t) => {
                     let _ = args.add(t);
                 }
@@ -100,7 +104,6 @@ impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
                 }
                 #[cfg(feature = "with-bigdecimal")]
                 Value::BigDecimal(big_decimal) => {
-                    use sea_query::prelude::bigdecimal::ToPrimitive;
                     let _ = args.add(big_decimal.map(|d| d.to_string()));
                 }
                 #[cfg(feature = "with-json")]

--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1199,6 +1199,8 @@ pub trait QueryBuilder:
             #[cfg(feature = "with-time")]
             Value::TimeDateTime(None) => buf.write_str("NULL")?,
             #[cfg(feature = "with-time")]
+            Value::TimeDateTimeUtc(None) => buf.write_str("NULL")?,
+            #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(None) => buf.write_str("NULL")?,
             #[cfg(feature = "with-jiff")]
             Value::JiffDate(None) => buf.write_str("NULL")?,
@@ -1312,6 +1314,12 @@ pub trait QueryBuilder:
             Value::TimeDateTime(Some(v)) => {
                 buf.write_str("'")?;
                 buf.write_str(&v.format(time_format::FORMAT_DATETIME).unwrap())?;
+                buf.write_str("'")?;
+            }
+            #[cfg(feature = "with-time")]
+            Value::TimeDateTimeUtc(Some(v)) => {
+                buf.write_str("'")?;
+                buf.write_str(&v.format(time_format::FORMAT_DATETIME_TZ).unwrap())?;
                 buf.write_str("'")?;
             }
             #[cfg(feature = "with-time")]

--- a/src/value.rs
+++ b/src/value.rs
@@ -136,6 +136,10 @@ pub enum ArrayType {
 
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+    TimeDateTimeUtc,
+
+    #[cfg(feature = "with-time")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeDateTimeWithTimeZone,
 
     #[cfg(feature = "with-jiff")]
@@ -245,6 +249,10 @@ pub enum Value {
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
     TimeDateTime(Option<PrimitiveDateTime>),
+
+    #[cfg(feature = "with-time")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+    TimeDateTimeUtc(Option<time::UtcDateTime>),
 
     #[cfg(feature = "with-time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
@@ -411,6 +419,10 @@ impl Value {
 
             #[cfg(feature = "with-time")]
             #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+            Self::TimeDateTimeUtc(_) => Self::TimeDateTimeUtc(None),
+
+            #[cfg(feature = "with-time")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
             Self::TimeDateTimeWithTimeZone(_) => Self::TimeDateTimeWithTimeZone(None),
 
             #[cfg(feature = "with-jiff")]
@@ -534,6 +546,10 @@ impl Value {
             #[cfg(feature = "with-time")]
             #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
             Self::TimeDateTime(_) => Self::TimeDateTime(Some(PrimitiveDateTime::MIN)),
+
+            #[cfg(feature = "with-time")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]
+            Self::TimeDateTimeUtc(_) => Self::TimeDateTimeUtc(Some(time::UtcDateTime::MIN)),
 
             #[cfg(feature = "with-time")]
             #[cfg_attr(docsrs, doc(cfg(feature = "with-time")))]

--- a/src/value/hashable_value.rs
+++ b/src/value/hashable_value.rs
@@ -131,6 +131,8 @@ impl Hash for Value {
             #[cfg(feature = "with-time")]
             Value::TimeDateTime(primitive_date_time) => primitive_date_time.hash(state),
             #[cfg(feature = "with-time")]
+            Value::TimeDateTimeUtc(utc_date_time) => utc_date_time.hash(state),
+            #[cfg(feature = "with-time")]
             Value::TimeDateTimeWithTimeZone(offset_date_time) => offset_date_time.hash(state),
 
             #[cfg(feature = "with-jiff")]

--- a/src/value/prelude.rs
+++ b/src/value/prelude.rs
@@ -5,7 +5,7 @@ pub use serde_json::{self, Value as Json};
 pub use chrono::{self, DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 
 #[cfg(feature = "with-time")]
-pub use time::{self, OffsetDateTime, PrimitiveDateTime};
+pub use time::{self, OffsetDateTime, PrimitiveDateTime, UtcDateTime};
 
 #[cfg(feature = "with-jiff")]
 pub use jiff::{self, Timestamp, Zoned};

--- a/src/value/with_array.rs
+++ b/src/value/with_array.rs
@@ -49,6 +49,9 @@ impl NotU8 for PrimitiveDateTime {}
 #[cfg(feature = "with-time")]
 impl NotU8 for OffsetDateTime {}
 
+#[cfg(feature = "with-time")]
+impl NotU8 for UtcDateTime {}
+
 #[cfg(feature = "with-rust_decimal")]
 impl NotU8 for Decimal {}
 

--- a/src/value/with_json.rs
+++ b/src/value/with_json.rs
@@ -84,6 +84,8 @@ pub fn sea_value_to_json_value(value: &Value) -> Json {
         #[cfg(feature = "with-time")]
         Value::TimeDateTime(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-time")]
+        Value::TimeDateTimeUtc(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
+        #[cfg(feature = "with-time")]
         Value::TimeDateTimeWithTimeZone(_) => CommonSqlQueryBuilder.value_to_string(value).into(),
         #[cfg(feature = "with-jiff")]
         Value::JiffDate(_) => CommonSqlQueryBuilder.value_to_string(value).into(),


### PR DESCRIPTION
- Introduced `TimeDateTimeUtc` variant in `Value` and `ArrayType` enums.
- Updated `sqlx` integration files (MySQL, Postgres, SQLite) to handle `TimeDateTimeUtc`.
- Enhanced serialization and deserialization for `TimeDateTimeUtc`.
- Added necessary trait implementations for `UtcDateTime`.
- Updated query builder and JSON conversion functions to accommodate new type.

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - <!-- PR link -->

## New Features

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] <!-- any other non-breaking changes to the codebase -->
