### PR TITLE
Wrap part of on_conflict_target in parentheses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -989,6 +989,7 @@ pub mod sqlx;
 pub mod table;
 pub mod token;
 pub mod types;
+mod utils;
 pub mod value;
 
 #[doc(hidden)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,44 @@
+use std::fmt;
+
+// A helper to make write separator easier and faster
+pub(crate) struct JoinWrite<'a, T, I, B, F1, F2, F3, F4>
+where
+    I: IntoIterator<Item = T>,
+    B: fmt::Write,
+    F1: FnMut(&mut B) -> fmt::Result,
+    F2: FnMut(&mut B, T) -> fmt::Result,
+    F3: FnMut(&mut B) -> fmt::Result,
+    F4: FnMut(&mut B) -> fmt::Result,
+{
+    pub buf: &'a mut B,
+    pub items: I,
+    pub at_first: F1,
+    pub r#do: F2,
+    pub join: F3,
+    pub at_last: F4,
+}
+
+impl<T, I, B, F1, F2, F3, F4> JoinWrite<'_, T, I, B, F1, F2, F3, F4>
+where
+    I: IntoIterator<Item = T>,
+    B: fmt::Write,
+    F1: FnMut(&mut B) -> fmt::Result,
+    F2: FnMut(&mut B, T) -> fmt::Result,
+    F3: FnMut(&mut B) -> fmt::Result,
+    F4: FnMut(&mut B) -> fmt::Result,
+{
+    pub fn exec(mut self) -> fmt::Result {
+        let mut iter = self.items.into_iter();
+        if let Some(first) = iter.next() {
+            (self.at_first)(self.buf)?;
+            (self.r#do)(self.buf, first)?;
+            for item in iter {
+                (self.join)(self.buf)?;
+                (self.r#do)(self.buf, item)?;
+            }
+            (self.at_last)(self.buf)?
+        }
+
+        Ok(())
+    }
+}

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1837,7 +1837,7 @@ fn insert_on_conflict_11() {
         [
             r#"INSERT INTO "font" ("id", "name")"#,
             r#"VALUES (20, 'Monospaced terminal')"#,
-            r#"ON CONFLICT ("name", "variant" IS NULL) DO NOTHING"#,
+            r#"ON CONFLICT ("name", ("variant" IS NULL)) DO NOTHING"#,
         ]
         .join(" ")
     );


### PR DESCRIPTION
@tisonkun mentioned to me that in PostgreSQL, some statements used as the `index_expression` in a `conflict_target` need to be wrapped in parentheses.

https://www.postgresql.org/docs/current/sql-insert.html
```
where conflict_target can be one of:

    ( { index_column_name | ( index_expression ) } [ COLLATE collation ] [ opclass ] [, ...] ) [ WHERE index_predicate ]
    ON CONSTRAINT constraint_name
```