### PR TITLE
Remove `inherent`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ name = "sea_query"
 path = "src/lib.rs"
 
 [dependencies]
-inherent = "1.0"
 sea-query-derive = { version = "1.0.0-rc.12", path = "sea-query-derive", optional = true }
 sea-query-postgres-types = { version = "0.1.0", path = "sea-query-postgres-types", optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["std", "derive", "rc"] }

--- a/src/foreign_key/create.rs
+++ b/src/foreign_key/create.rs
@@ -1,5 +1,3 @@
-use inherent::inherent;
-
 use crate::{
     ForeignKeyAction, SchemaStatementBuilder, TableForeignKey, backend::SchemaBuilder, types::*,
 };
@@ -177,15 +175,20 @@ impl ForeignKeyCreateStatement {
     }
 }
 
-#[inherent]
 impl SchemaStatementBuilder for ForeignKeyCreateStatement {
-    pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = String::with_capacity(256);
         schema_builder.prepare_foreign_key_create_statement(self, &mut sql);
         sql
     }
+}
 
-    pub fn to_string<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder;
+impl ForeignKeyCreateStatement {
+    pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::build(self, schema_builder)
+    }
+
+    pub fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::to_string(self, schema_builder)
+    }
 }

--- a/src/foreign_key/drop.rs
+++ b/src/foreign_key/drop.rs
@@ -1,5 +1,3 @@
-use inherent::inherent;
-
 use crate::{SchemaStatementBuilder, TableForeignKey, backend::SchemaBuilder, types::*};
 
 /// Drop a foreign key constraint for an existing table
@@ -55,9 +53,8 @@ impl ForeignKeyDropStatement {
     }
 }
 
-#[inherent]
 impl SchemaStatementBuilder for ForeignKeyDropStatement {
-    pub fn build<T>(&self, schema_builder: T) -> String
+    fn build<T>(&self, schema_builder: T) -> String
     where
         T: SchemaBuilder,
     {
@@ -65,8 +62,14 @@ impl SchemaStatementBuilder for ForeignKeyDropStatement {
         schema_builder.prepare_foreign_key_drop_statement(self, &mut sql);
         sql
     }
+}
 
-    pub fn to_string<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder;
+impl ForeignKeyDropStatement {
+    pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::build(self, schema_builder)
+    }
+
+    pub fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::to_string(self, schema_builder)
+    }
 }

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -1,5 +1,3 @@
-use inherent::inherent;
-
 use crate::{ConditionHolder, ConditionalStatement, IntoCondition};
 use crate::{SchemaStatementBuilder, backend::SchemaBuilder, types::*};
 
@@ -358,9 +356,8 @@ impl IndexCreateStatement {
     }
 }
 
-#[inherent]
 impl SchemaStatementBuilder for IndexCreateStatement {
-    pub fn build<T>(&self, schema_builder: T) -> String
+    fn build<T>(&self, schema_builder: T) -> String
     where
         T: SchemaBuilder,
     {
@@ -368,10 +365,16 @@ impl SchemaStatementBuilder for IndexCreateStatement {
         schema_builder.prepare_index_create_statement(self, &mut sql);
         sql
     }
+}
 
-    pub fn to_string<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder;
+impl IndexCreateStatement {
+    pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::build(self, schema_builder)
+    }
+
+    pub fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::to_string(self, schema_builder)
+    }
 }
 
 impl ConditionalStatement for IndexCreateStatement {

--- a/src/index/drop.rs
+++ b/src/index/drop.rs
@@ -1,5 +1,3 @@
-use inherent::inherent;
-
 use crate::{SchemaStatementBuilder, TableIndex, backend::SchemaBuilder, types::*};
 
 /// Drop an index for an existing table
@@ -71,18 +69,20 @@ impl IndexDropStatement {
     }
 }
 
-#[inherent]
 impl SchemaStatementBuilder for IndexDropStatement {
-    pub fn build<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder,
-    {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = String::with_capacity(256);
         schema_builder.prepare_index_drop_statement(self, &mut sql);
         sql
     }
+}
 
-    pub fn to_string<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder;
+impl IndexDropStatement {
+    pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::build(self, schema_builder)
+    }
+
+    pub fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::to_string(self, schema_builder)
+    }
 }

--- a/src/query/delete.rs
+++ b/src/query/delete.rs
@@ -1,4 +1,3 @@
-use inherent::inherent;
 use std::borrow::Cow;
 
 use crate::{
@@ -311,22 +310,32 @@ impl DeleteStatement {
     }
 }
 
-#[inherent]
 impl QueryStatementBuilder for DeleteStatement {
+    fn build_collect_any_into(&self, query_builder: &impl QueryBuilder, sql: &mut impl SqlWriter) {
+        query_builder.prepare_delete_statement(self, sql);
+    }
+}
+
+impl DeleteStatement {
+    pub fn build_any(&self, query_builder: &impl QueryBuilder) -> (String, Values) {
+        <Self as QueryStatementBuilder>::build_any(self, query_builder)
+    }
+
+    pub fn build_collect_any(
+        &self,
+        query_builder: &impl QueryBuilder,
+        sql: &mut impl SqlWriter,
+    ) -> String {
+        <Self as QueryStatementBuilder>::build_collect_any(self, query_builder, sql)
+    }
+
     pub fn build_collect_any_into(
         &self,
         query_builder: &impl QueryBuilder,
         sql: &mut impl SqlWriter,
     ) {
-        query_builder.prepare_delete_statement(self, sql);
+        <Self as QueryStatementBuilder>::build_collect_any_into(self, query_builder, sql)
     }
-
-    pub fn build_any(&self, query_builder: &impl QueryBuilder) -> (String, Values);
-    pub fn build_collect_any(
-        &self,
-        query_builder: &impl QueryBuilder,
-        sql: &mut impl SqlWriter,
-    ) -> String;
 }
 
 impl From<DeleteStatement> for QueryStatement {
@@ -341,85 +350,143 @@ impl From<DeleteStatement> for SubQueryStatement {
     }
 }
 
-#[inherent]
 impl QueryStatementWriter for DeleteStatement {
-    pub fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
         query_builder.prepare_delete_statement(self, sql);
+    }
+}
+
+impl DeleteStatement {
+    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
+        <Self as QueryStatementWriter>::to_string(self, query_builder)
+    }
+
+    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
+        <Self as QueryStatementWriter>::build(self, query_builder)
     }
 
     pub fn build_collect<T: QueryBuilder>(
         &self,
         query_builder: T,
         sql: &mut impl SqlWriter,
-    ) -> String;
-    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values);
-    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String;
+    ) -> String {
+        <Self as QueryStatementWriter>::build_collect(self, query_builder, sql)
+    }
+
+    pub fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
+        <Self as QueryStatementWriter>::build_collect_into(self, query_builder, sql);
+    }
 }
 
-#[inherent]
 impl OrderedStatement for DeleteStatement {
-    pub fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
+    fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
         self.orders.push(order);
         self
     }
 
-    pub fn clear_order_by(&mut self) -> &mut Self {
+    fn clear_order_by(&mut self) -> &mut Self {
         self.orders = Vec::new();
         self
     }
+}
 
-    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self
-    where
-        T: IntoColumnRef;
+impl DeleteStatement {
+    pub fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
+        <Self as OrderedStatement>::add_order_by(self, order)
+    }
 
-    pub fn order_by_expr(&mut self, expr: Expr, order: Order) -> &mut Self;
+    pub fn clear_order_by(&mut self) -> &mut Self {
+        <Self as OrderedStatement>::clear_order_by(self)
+    }
+
+    pub fn order_by<T: IntoColumnRef>(&mut self, col: T, order: Order) -> &mut Self {
+        <Self as OrderedStatement>::order_by(self, col, order)
+    }
+
+    pub fn order_by_expr(&mut self, expr: Expr, order: Order) -> &mut Self {
+        <Self as OrderedStatement>::order_by_expr(self, expr, order)
+    }
+
     pub fn order_by_customs<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: Into<Cow<'static, str>>,
-        I: IntoIterator<Item = (T, Order)>;
+        I: IntoIterator<Item = (T, Order)>,
+    {
+        <Self as OrderedStatement>::order_by_customs(self, cols)
+    }
+
     pub fn order_by_columns<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
-        I: IntoIterator<Item = (T, Order)>;
-    pub fn order_by_with_nulls<T>(
+        I: IntoIterator<Item = (T, Order)>,
+    {
+        <Self as OrderedStatement>::order_by_columns(self, cols)
+    }
+
+    pub fn order_by_with_nulls<T: IntoColumnRef>(
         &mut self,
         col: T,
         order: Order,
         nulls: NullOrdering,
-    ) -> &mut Self
-    where
-        T: IntoColumnRef;
+    ) -> &mut Self {
+        <Self as OrderedStatement>::order_by_with_nulls(self, col, order, nulls)
+    }
+
     pub fn order_by_expr_with_nulls(
         &mut self,
         expr: Expr,
         order: Order,
         nulls: NullOrdering,
-    ) -> &mut Self;
+    ) -> &mut Self {
+        <Self as OrderedStatement>::order_by_expr_with_nulls(self, expr, order, nulls)
+    }
+
     pub fn order_by_customs_with_nulls<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: Into<Cow<'static, str>>,
-        I: IntoIterator<Item = (T, Order, NullOrdering)>;
+        I: IntoIterator<Item = (T, Order, NullOrdering)>,
+    {
+        <Self as OrderedStatement>::order_by_customs_with_nulls(self, cols)
+    }
+
     pub fn order_by_columns_with_nulls<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
-        I: IntoIterator<Item = (T, Order, NullOrdering)>;
+        I: IntoIterator<Item = (T, Order, NullOrdering)>,
+    {
+        <Self as OrderedStatement>::order_by_columns_with_nulls(self, cols)
+    }
 }
 
-#[inherent]
 impl ConditionalStatement for DeleteStatement {
-    pub fn and_or_where(&mut self, condition: LogicalChainOper) -> &mut Self {
+    fn and_or_where(&mut self, condition: LogicalChainOper) -> &mut Self {
         self.r#where.add_and_or(condition);
         self
     }
 
-    pub fn cond_where<C>(&mut self, condition: C) -> &mut Self
+    fn cond_where<C>(&mut self, condition: C) -> &mut Self
     where
         C: IntoCondition,
     {
         self.r#where.add_condition(condition.into_condition());
         self
     }
+}
 
-    pub fn and_where_option(&mut self, other: Option<Expr>) -> &mut Self;
-    pub fn and_where(&mut self, other: Expr) -> &mut Self;
+impl DeleteStatement {
+    pub fn and_where(&mut self, other: Expr) -> &mut Self {
+        <Self as ConditionalStatement>::and_where(self, other)
+    }
+
+    pub fn and_where_option(&mut self, other: Option<Expr>) -> &mut Self {
+        <Self as ConditionalStatement>::and_where_option(self, other)
+    }
+
+    pub fn and_or_where(&mut self, condition: LogicalChainOper) -> &mut Self {
+        <Self as ConditionalStatement>::and_or_where(self, condition)
+    }
+
+    pub fn cond_where<C: IntoCondition>(&mut self, condition: C) -> &mut Self {
+        <Self as ConditionalStatement>::cond_where(self, condition)
+    }
 }

--- a/src/query/insert.rs
+++ b/src/query/insert.rs
@@ -1,5 +1,3 @@
-use inherent::inherent;
-
 use crate::{
     DynIden, Expr, IntoColumnRef, IntoIden, IntoTableRef, OnConflict, QueryBuilder, QueryStatement,
     QueryStatementBuilder, QueryStatementWriter, ReturningClause, SelectStatement, SqlWriter,
@@ -759,22 +757,32 @@ impl InsertStatement {
     }
 }
 
-#[inherent]
 impl QueryStatementBuilder for InsertStatement {
+    fn build_collect_any_into(&self, query_builder: &impl QueryBuilder, sql: &mut impl SqlWriter) {
+        query_builder.prepare_insert_statement(self, sql);
+    }
+}
+
+impl InsertStatement {
+    pub fn build_any(&self, query_builder: &impl QueryBuilder) -> (String, Values) {
+        <Self as QueryStatementBuilder>::build_any(self, query_builder)
+    }
+
+    pub fn build_collect_any(
+        &self,
+        query_builder: &impl QueryBuilder,
+        sql: &mut impl SqlWriter,
+    ) -> String {
+        <Self as QueryStatementBuilder>::build_collect_any(self, query_builder, sql)
+    }
+
     pub fn build_collect_any_into(
         &self,
         query_builder: &impl QueryBuilder,
         sql: &mut impl SqlWriter,
     ) {
-        query_builder.prepare_insert_statement(self, sql);
+        <Self as QueryStatementBuilder>::build_collect_any_into(self, query_builder, sql)
     }
-
-    pub fn build_any(&self, query_builder: &impl QueryBuilder) -> (String, Values);
-    pub fn build_collect_any(
-        &self,
-        query_builder: &impl QueryBuilder,
-        sql: &mut impl SqlWriter,
-    ) -> String;
 }
 
 impl From<InsertStatement> for QueryStatement {
@@ -789,17 +797,30 @@ impl From<InsertStatement> for SubQueryStatement {
     }
 }
 
-#[inherent]
 impl QueryStatementWriter for InsertStatement {
-    pub fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
         query_builder.prepare_insert_statement(self, sql);
+    }
+}
+
+impl InsertStatement {
+    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
+        <Self as QueryStatementWriter>::to_string(self, query_builder)
+    }
+
+    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
+        <Self as QueryStatementWriter>::build(self, query_builder)
     }
 
     pub fn build_collect<T: QueryBuilder>(
         &self,
         query_builder: T,
         sql: &mut impl SqlWriter,
-    ) -> String;
-    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values);
-    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String;
+    ) -> String {
+        <Self as QueryStatementWriter>::build_collect(self, query_builder, sql)
+    }
+
+    pub fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
+        <Self as QueryStatementWriter>::build_collect_into(self, query_builder, sql);
+    }
 }

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -1,4 +1,3 @@
-use inherent::inherent;
 use std::{borrow::Cow, fmt::Display};
 
 use crate::{
@@ -2707,22 +2706,32 @@ impl SelectStatement {
     }
 }
 
-#[inherent]
 impl QueryStatementBuilder for SelectStatement {
+    fn build_collect_any_into(&self, query_builder: &impl QueryBuilder, sql: &mut impl SqlWriter) {
+        query_builder.prepare_select_statement(self, sql);
+    }
+}
+
+impl SelectStatement {
+    pub fn build_any(&self, query_builder: &impl QueryBuilder) -> (String, Values) {
+        <Self as QueryStatementBuilder>::build_any(self, query_builder)
+    }
+
+    pub fn build_collect_any(
+        &self,
+        query_builder: &impl QueryBuilder,
+        sql: &mut impl SqlWriter,
+    ) -> String {
+        <Self as QueryStatementBuilder>::build_collect_any(self, query_builder, sql)
+    }
+
     pub fn build_collect_any_into(
         &self,
         query_builder: &impl QueryBuilder,
         sql: &mut impl SqlWriter,
     ) {
-        query_builder.prepare_select_statement(self, sql);
+        <Self as QueryStatementBuilder>::build_collect_any_into(self, query_builder, sql)
     }
-
-    pub fn build_any(&self, query_builder: &impl QueryBuilder) -> (String, Values);
-    pub fn build_collect_any(
-        &self,
-        query_builder: &impl QueryBuilder,
-        sql: &mut impl SqlWriter,
-    ) -> String;
 }
 
 impl From<SelectStatement> for QueryStatement {
@@ -2737,85 +2746,143 @@ impl From<SelectStatement> for SubQueryStatement {
     }
 }
 
-#[inherent]
 impl QueryStatementWriter for SelectStatement {
-    pub fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
         query_builder.prepare_select_statement(self, sql);
+    }
+}
+
+impl SelectStatement {
+    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
+        <Self as QueryStatementWriter>::to_string(self, query_builder)
+    }
+
+    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
+        <Self as QueryStatementWriter>::build(self, query_builder)
     }
 
     pub fn build_collect<T: QueryBuilder>(
         &self,
         query_builder: T,
         sql: &mut impl SqlWriter,
-    ) -> String;
-    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values);
-    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String;
+    ) -> String {
+        <Self as QueryStatementWriter>::build_collect(self, query_builder, sql)
+    }
+
+    pub fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
+        <Self as QueryStatementWriter>::build_collect_into(self, query_builder, sql);
+    }
 }
 
-#[inherent]
 impl OrderedStatement for SelectStatement {
-    pub fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
+    fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
         self.orders.push(order);
         self
     }
 
-    pub fn clear_order_by(&mut self) -> &mut Self {
+    fn clear_order_by(&mut self) -> &mut Self {
         self.orders = Vec::new();
         self
     }
+}
 
-    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self
-    where
-        T: IntoColumnRef;
+impl SelectStatement {
+    pub fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
+        <Self as OrderedStatement>::add_order_by(self, order)
+    }
 
-    pub fn order_by_expr(&mut self, expr: Expr, order: Order) -> &mut Self;
+    pub fn clear_order_by(&mut self) -> &mut Self {
+        <Self as OrderedStatement>::clear_order_by(self)
+    }
+
+    pub fn order_by<T: IntoColumnRef>(&mut self, col: T, order: Order) -> &mut Self {
+        <Self as OrderedStatement>::order_by(self, col, order)
+    }
+
+    pub fn order_by_expr(&mut self, expr: Expr, order: Order) -> &mut Self {
+        <Self as OrderedStatement>::order_by_expr(self, expr, order)
+    }
+
     pub fn order_by_customs<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: Into<Cow<'static, str>>,
-        I: IntoIterator<Item = (T, Order)>;
+        I: IntoIterator<Item = (T, Order)>,
+    {
+        <Self as OrderedStatement>::order_by_customs(self, cols)
+    }
+
     pub fn order_by_columns<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
-        I: IntoIterator<Item = (T, Order)>;
-    pub fn order_by_with_nulls<T>(
+        I: IntoIterator<Item = (T, Order)>,
+    {
+        <Self as OrderedStatement>::order_by_columns(self, cols)
+    }
+
+    pub fn order_by_with_nulls<T: IntoColumnRef>(
         &mut self,
         col: T,
         order: Order,
         nulls: NullOrdering,
-    ) -> &mut Self
-    where
-        T: IntoColumnRef;
+    ) -> &mut Self {
+        <Self as OrderedStatement>::order_by_with_nulls(self, col, order, nulls)
+    }
+
     pub fn order_by_expr_with_nulls(
         &mut self,
         expr: Expr,
         order: Order,
         nulls: NullOrdering,
-    ) -> &mut Self;
+    ) -> &mut Self {
+        <Self as OrderedStatement>::order_by_expr_with_nulls(self, expr, order, nulls)
+    }
+
     pub fn order_by_customs_with_nulls<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: Into<Cow<'static, str>>,
-        I: IntoIterator<Item = (T, Order, NullOrdering)>;
+        I: IntoIterator<Item = (T, Order, NullOrdering)>,
+    {
+        <Self as OrderedStatement>::order_by_customs_with_nulls(self, cols)
+    }
+
     pub fn order_by_columns_with_nulls<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
-        I: IntoIterator<Item = (T, Order, NullOrdering)>;
+        I: IntoIterator<Item = (T, Order, NullOrdering)>,
+    {
+        <Self as OrderedStatement>::order_by_columns_with_nulls(self, cols)
+    }
 }
 
-#[inherent]
 impl ConditionalStatement for SelectStatement {
-    pub fn and_or_where(&mut self, condition: LogicalChainOper) -> &mut Self {
+    fn and_or_where(&mut self, condition: LogicalChainOper) -> &mut Self {
         self.r#where.add_and_or(condition);
         self
     }
 
-    pub fn cond_where<C>(&mut self, condition: C) -> &mut Self
+    fn cond_where<C>(&mut self, condition: C) -> &mut Self
     where
         C: IntoCondition,
     {
         self.r#where.add_condition(condition.into_condition());
         self
     }
+}
 
-    pub fn and_where_option(&mut self, other: Option<Expr>) -> &mut Self;
-    pub fn and_where(&mut self, other: Expr) -> &mut Self;
+impl SelectStatement {
+    pub fn and_where(&mut self, other: Expr) -> &mut Self {
+        <Self as ConditionalStatement>::and_where(self, other)
+    }
+
+    pub fn and_where_option(&mut self, other: Option<Expr>) -> &mut Self {
+        <Self as ConditionalStatement>::and_where_option(self, other)
+    }
+
+    pub fn and_or_where(&mut self, condition: LogicalChainOper) -> &mut Self {
+        <Self as ConditionalStatement>::and_or_where(self, condition)
+    }
+
+    pub fn cond_where<C: IntoCondition>(&mut self, condition: C) -> &mut Self {
+        <Self as ConditionalStatement>::cond_where(self, condition)
+    }
 }

--- a/src/query/update.rs
+++ b/src/query/update.rs
@@ -1,4 +1,3 @@
-use inherent::inherent;
 use std::borrow::Cow;
 
 use crate::{
@@ -455,22 +454,32 @@ impl UpdateStatement {
     }
 }
 
-#[inherent]
 impl QueryStatementBuilder for UpdateStatement {
+    fn build_collect_any_into(&self, query_builder: &impl QueryBuilder, sql: &mut impl SqlWriter) {
+        query_builder.prepare_update_statement(self, sql);
+    }
+}
+
+impl UpdateStatement {
+    pub fn build_any(&self, query_builder: &impl QueryBuilder) -> (String, Values) {
+        <Self as QueryStatementBuilder>::build_any(self, query_builder)
+    }
+
+    pub fn build_collect_any(
+        &self,
+        query_builder: &impl QueryBuilder,
+        sql: &mut impl SqlWriter,
+    ) -> String {
+        <Self as QueryStatementBuilder>::build_collect_any(self, query_builder, sql)
+    }
+
     pub fn build_collect_any_into(
         &self,
         query_builder: &impl QueryBuilder,
         sql: &mut impl SqlWriter,
     ) {
-        query_builder.prepare_update_statement(self, sql);
+        <Self as QueryStatementBuilder>::build_collect_any_into(self, query_builder, sql)
     }
-
-    pub fn build_any(&self, query_builder: &impl QueryBuilder) -> (String, Values);
-    pub fn build_collect_any(
-        &self,
-        query_builder: &impl QueryBuilder,
-        sql: &mut impl SqlWriter,
-    ) -> String;
 }
 
 impl From<UpdateStatement> for QueryStatement {
@@ -485,84 +494,143 @@ impl From<UpdateStatement> for SubQueryStatement {
     }
 }
 
-#[inherent]
 impl QueryStatementWriter for UpdateStatement {
-    pub fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
         query_builder.prepare_update_statement(self, sql);
+    }
+}
+
+impl UpdateStatement {
+    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
+        <Self as QueryStatementWriter>::to_string(self, query_builder)
+    }
+
+    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
+        <Self as QueryStatementWriter>::build(self, query_builder)
     }
 
     pub fn build_collect<T: QueryBuilder>(
         &self,
         query_builder: T,
         sql: &mut impl SqlWriter,
-    ) -> String;
-    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values);
-    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String;
+    ) -> String {
+        <Self as QueryStatementWriter>::build_collect(self, query_builder, sql)
+    }
+
+    pub fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
+        <Self as QueryStatementWriter>::build_collect_into(self, query_builder, sql);
+    }
 }
 
-#[inherent]
 impl OrderedStatement for UpdateStatement {
-    pub fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
+    fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
         self.orders.push(order);
         self
     }
 
-    pub fn clear_order_by(&mut self) -> &mut Self {
+    fn clear_order_by(&mut self) -> &mut Self {
         self.orders = Vec::new();
         self
     }
-    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self
-    where
-        T: IntoColumnRef;
+}
 
-    pub fn order_by_expr(&mut self, expr: Expr, order: Order) -> &mut Self;
+impl UpdateStatement {
+    pub fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
+        <Self as OrderedStatement>::add_order_by(self, order)
+    }
+
+    pub fn clear_order_by(&mut self) -> &mut Self {
+        <Self as OrderedStatement>::clear_order_by(self)
+    }
+
+    pub fn order_by<T: IntoColumnRef>(&mut self, col: T, order: Order) -> &mut Self {
+        <Self as OrderedStatement>::order_by(self, col, order)
+    }
+
+    pub fn order_by_expr(&mut self, expr: Expr, order: Order) -> &mut Self {
+        <Self as OrderedStatement>::order_by_expr(self, expr, order)
+    }
+
     pub fn order_by_customs<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: Into<Cow<'static, str>>,
-        I: IntoIterator<Item = (T, Order)>;
+        I: IntoIterator<Item = (T, Order)>,
+    {
+        <Self as OrderedStatement>::order_by_customs(self, cols)
+    }
+
     pub fn order_by_columns<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
-        I: IntoIterator<Item = (T, Order)>;
-    pub fn order_by_with_nulls<T>(
+        I: IntoIterator<Item = (T, Order)>,
+    {
+        <Self as OrderedStatement>::order_by_columns(self, cols)
+    }
+
+    pub fn order_by_with_nulls<T: IntoColumnRef>(
         &mut self,
         col: T,
         order: Order,
         nulls: NullOrdering,
-    ) -> &mut Self
-    where
-        T: IntoColumnRef;
+    ) -> &mut Self {
+        <Self as OrderedStatement>::order_by_with_nulls(self, col, order, nulls)
+    }
+
     pub fn order_by_expr_with_nulls(
         &mut self,
         expr: Expr,
         order: Order,
         nulls: NullOrdering,
-    ) -> &mut Self;
+    ) -> &mut Self {
+        <Self as OrderedStatement>::order_by_expr_with_nulls(self, expr, order, nulls)
+    }
+
     pub fn order_by_customs_with_nulls<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: Into<Cow<'static, str>>,
-        I: IntoIterator<Item = (T, Order, NullOrdering)>;
+        I: IntoIterator<Item = (T, Order, NullOrdering)>,
+    {
+        <Self as OrderedStatement>::order_by_customs_with_nulls(self, cols)
+    }
+
     pub fn order_by_columns_with_nulls<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
-        I: IntoIterator<Item = (T, Order, NullOrdering)>;
+        I: IntoIterator<Item = (T, Order, NullOrdering)>,
+    {
+        <Self as OrderedStatement>::order_by_columns_with_nulls(self, cols)
+    }
 }
 
-#[inherent]
 impl ConditionalStatement for UpdateStatement {
-    pub fn and_or_where(&mut self, condition: LogicalChainOper) -> &mut Self {
+    fn and_or_where(&mut self, condition: LogicalChainOper) -> &mut Self {
         self.r#where.add_and_or(condition);
         self
     }
 
-    pub fn cond_where<C>(&mut self, condition: C) -> &mut Self
+    fn cond_where<C>(&mut self, condition: C) -> &mut Self
     where
         C: IntoCondition,
     {
         self.r#where.add_condition(condition.into_condition());
         self
     }
+}
 
-    pub fn and_where_option(&mut self, other: Option<Expr>) -> &mut Self;
-    pub fn and_where(&mut self, other: Expr) -> &mut Self;
+impl UpdateStatement {
+    pub fn and_where(&mut self, other: Expr) -> &mut Self {
+        <Self as ConditionalStatement>::and_where(self, other)
+    }
+
+    pub fn and_where_option(&mut self, other: Option<Expr>) -> &mut Self {
+        <Self as ConditionalStatement>::and_where_option(self, other)
+    }
+
+    pub fn and_or_where(&mut self, condition: LogicalChainOper) -> &mut Self {
+        <Self as ConditionalStatement>::and_or_where(self, condition)
+    }
+
+    pub fn cond_where<C: IntoCondition>(&mut self, condition: C) -> &mut Self {
+        <Self as ConditionalStatement>::cond_where(self, condition)
+    }
 }

--- a/src/query/window.rs
+++ b/src/query/window.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use crate::{Expr, IntoColumnRef, NullOrdering, Order, OrderExpr, OrderedStatement};
-use inherent::inherent;
 
 pub trait OverStatement {
     #[doc(hidden)]
@@ -196,51 +195,82 @@ impl OverStatement for WindowStatement {
     }
 }
 
-#[inherent]
 impl OrderedStatement for WindowStatement {
-    pub fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
+    fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
         self.order_by.push(order);
         self
     }
 
-    pub fn clear_order_by(&mut self) -> &mut Self {
+    fn clear_order_by(&mut self) -> &mut Self {
         self.order_by = Vec::new();
         self
     }
+}
 
-    pub fn order_by<T>(&mut self, col: T, order: Order) -> &mut Self
-    where
-        T: IntoColumnRef;
+impl WindowStatement {
+    pub fn add_order_by(&mut self, order: OrderExpr) -> &mut Self {
+        <Self as OrderedStatement>::add_order_by(self, order)
+    }
 
-    pub fn order_by_expr(&mut self, expr: Expr, order: Order) -> &mut Self;
+    pub fn clear_order_by(&mut self) -> &mut Self {
+        <Self as OrderedStatement>::clear_order_by(self)
+    }
+
+    pub fn order_by<T: IntoColumnRef>(&mut self, col: T, order: Order) -> &mut Self {
+        <Self as OrderedStatement>::order_by(self, col, order)
+    }
+
+    pub fn order_by_expr(&mut self, expr: Expr, order: Order) -> &mut Self {
+        <Self as OrderedStatement>::order_by_expr(self, expr, order)
+    }
+
     pub fn order_by_customs<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: Into<Cow<'static, str>>,
-        I: IntoIterator<Item = (T, Order)>;
+        I: IntoIterator<Item = (T, Order)>,
+    {
+        <Self as OrderedStatement>::order_by_customs(self, cols)
+    }
+
     pub fn order_by_columns<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
-        I: IntoIterator<Item = (T, Order)>;
-    pub fn order_by_with_nulls<T>(
+        I: IntoIterator<Item = (T, Order)>,
+    {
+        <Self as OrderedStatement>::order_by_columns(self, cols)
+    }
+
+    pub fn order_by_with_nulls<T: IntoColumnRef>(
         &mut self,
         col: T,
         order: Order,
         nulls: NullOrdering,
-    ) -> &mut Self
-    where
-        T: IntoColumnRef;
+    ) -> &mut Self {
+        <Self as OrderedStatement>::order_by_with_nulls(self, col, order, nulls)
+    }
+
     pub fn order_by_expr_with_nulls(
         &mut self,
         expr: Expr,
         order: Order,
         nulls: NullOrdering,
-    ) -> &mut Self;
+    ) -> &mut Self {
+        <Self as OrderedStatement>::order_by_expr_with_nulls(self, expr, order, nulls)
+    }
+
     pub fn order_by_customs_with_nulls<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: Into<Cow<'static, str>>,
-        I: IntoIterator<Item = (T, Order, NullOrdering)>;
+        I: IntoIterator<Item = (T, Order, NullOrdering)>,
+    {
+        <Self as OrderedStatement>::order_by_customs_with_nulls(self, cols)
+    }
+
     pub fn order_by_columns_with_nulls<I, T>(&mut self, cols: I) -> &mut Self
     where
         T: IntoColumnRef,
-        I: IntoIterator<Item = (T, Order, NullOrdering)>;
+        I: IntoIterator<Item = (T, Order, NullOrdering)>,
+    {
+        <Self as OrderedStatement>::order_by_columns_with_nulls(self, cols)
+    }
 }

--- a/src/query/with.rs
+++ b/src/query/with.rs
@@ -3,7 +3,6 @@ use crate::{
     QueryStatementWriter, SelectExpr, SelectStatement, SqlWriter, SubQueryStatement, TableName,
     TableRef, Values,
 };
-use inherent::inherent;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum CteQuery {
@@ -607,17 +606,30 @@ impl From<WithQuery> for SubQueryStatement {
     }
 }
 
-#[inherent]
 impl QueryStatementWriter for WithQuery {
-    pub fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
+    fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
         query_builder.prepare_with_query(self, sql);
+    }
+}
+
+impl WithQuery {
+    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String {
+        <Self as QueryStatementWriter>::to_string(self, query_builder)
+    }
+
+    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values) {
+        <Self as QueryStatementWriter>::build(self, query_builder)
     }
 
     pub fn build_collect<T: QueryBuilder>(
         &self,
         query_builder: T,
         sql: &mut impl SqlWriter,
-    ) -> String;
-    pub fn build<T: QueryBuilder>(&self, query_builder: T) -> (String, Values);
-    pub fn to_string<T: QueryBuilder>(&self, query_builder: T) -> String;
+    ) -> String {
+        <Self as QueryStatementWriter>::build_collect(self, query_builder, sql)
+    }
+
+    pub fn build_collect_into<T: QueryBuilder>(&self, query_builder: T, sql: &mut impl SqlWriter) {
+        <Self as QueryStatementWriter>::build_collect_into(self, query_builder, sql);
+    }
 }

--- a/src/table/alter.rs
+++ b/src/table/alter.rs
@@ -2,7 +2,6 @@ use crate::{
     ColumnDef, IntoColumnDef, SchemaStatementBuilder, TableForeignKey, backend::SchemaBuilder,
     types::*,
 };
-use inherent::inherent;
 
 /// Alter a table
 ///
@@ -436,18 +435,20 @@ impl TableAlterStatement {
     }
 }
 
-#[inherent]
 impl SchemaStatementBuilder for TableAlterStatement {
-    pub fn build<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder,
-    {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_alter_statement(self, &mut sql);
         sql
     }
+}
 
-    pub fn to_string<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder;
+impl TableAlterStatement {
+    pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::build(self, schema_builder)
+    }
+
+    pub fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::to_string(self, schema_builder)
+    }
 }

--- a/src/table/create.rs
+++ b/src/table/create.rs
@@ -1,5 +1,3 @@
-use inherent::inherent;
-
 use crate::{
     ColumnDef, Expr, IntoColumnDef, SchemaStatementBuilder, backend::SchemaBuilder, foreign_key::*,
     index::*, table::constraint::Check, types::*,
@@ -707,18 +705,20 @@ impl TableCreateStatement {
     }
 }
 
-#[inherent]
 impl SchemaStatementBuilder for TableCreateStatement {
-    pub fn build<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder,
-    {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_create_statement(self, &mut sql);
         sql
     }
+}
 
-    pub fn to_string<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder;
+impl TableCreateStatement {
+    pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::build(self, schema_builder)
+    }
+
+    pub fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::to_string(self, schema_builder)
+    }
 }

--- a/src/table/drop.rs
+++ b/src/table/drop.rs
@@ -1,5 +1,3 @@
-use inherent::inherent;
-
 use crate::{SchemaStatementBuilder, backend::SchemaBuilder, types::*};
 
 /// Drop a table
@@ -84,18 +82,20 @@ impl TableDropStatement {
     }
 }
 
-#[inherent]
 impl SchemaStatementBuilder for TableDropStatement {
-    pub fn build<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder,
-    {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_drop_statement(self, &mut sql);
         sql
     }
+}
 
-    pub fn to_string<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder;
+impl TableDropStatement {
+    pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::build(self, schema_builder)
+    }
+
+    pub fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::to_string(self, schema_builder)
+    }
 }

--- a/src/table/rename.rs
+++ b/src/table/rename.rs
@@ -1,5 +1,3 @@
-use inherent::inherent;
-
 use crate::{SchemaStatementBuilder, backend::SchemaBuilder, types::*};
 
 /// Rename a table
@@ -55,18 +53,20 @@ impl TableRenameStatement {
     }
 }
 
-#[inherent]
 impl SchemaStatementBuilder for TableRenameStatement {
-    pub fn build<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder,
-    {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_rename_statement(self, &mut sql);
         sql
     }
+}
 
-    pub fn to_string<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder;
+impl TableRenameStatement {
+    pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::build(self, schema_builder)
+    }
+
+    pub fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::to_string(self, schema_builder)
+    }
 }

--- a/src/table/truncate.rs
+++ b/src/table/truncate.rs
@@ -1,5 +1,3 @@
-use inherent::inherent;
-
 use crate::{SchemaStatementBuilder, backend::SchemaBuilder, types::*};
 
 /// Drop a table
@@ -48,18 +46,20 @@ impl TableTruncateStatement {
     }
 }
 
-#[inherent]
 impl SchemaStatementBuilder for TableTruncateStatement {
-    pub fn build<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder,
-    {
+    fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
         let mut sql = String::with_capacity(256);
         schema_builder.prepare_table_truncate_statement(self, &mut sql);
         sql
     }
+}
 
-    pub fn to_string<T>(&self, schema_builder: T) -> String
-    where
-        T: SchemaBuilder;
+impl TableTruncateStatement {
+    pub fn build<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::build(self, schema_builder)
+    }
+
+    pub fn to_string<T: SchemaBuilder>(&self, schema_builder: T) -> String {
+        <Self as SchemaStatementBuilder>::to_string(self, schema_builder)
+    }
 }


### PR DESCRIPTION
I recently wanted to out this project however the additional dependency was not desirable, especially since `inherent` utilizes proc-macros making it a relatively heavy dependency to import.

I realized you can rather easily cover the current `inherent` coverage with a couple manual implementations without relying on shims as in the past: #614.

It also allows going back to the original claim of "no dependencies".

## Changes

- Removes `inherent` in favor of manual function implementations.
