### PR TITLE
Fix: tokenizer treating `[` as a quote start for postgres (#1073)

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -152,7 +152,7 @@ impl<'a> Tokenizer<'a> {
         let mut uses_backslash_escape = false;
         while !self.end() {
             let c = self.get();
-            if first && Self::is_string_delimiter_start(c) {
+            if first && self.is_string_delimiter_start(c) {
                 b = self.p_c(c);
                 first = false;
                 start = c;
@@ -195,7 +195,7 @@ impl<'a> Tokenizer<'a> {
         let mut uses_backslash_escape = false;
         while !self.end() {
             let c = self.get();
-            if first && Self::is_string_delimiter_start(c) {
+            if first && self.is_string_delimiter_start(c) {
                 first = false;
                 start = c;
                 uses_backslash_escape = self.uses_backslash_escape_for(start);
@@ -286,8 +286,12 @@ impl<'a> Tokenizer<'a> {
         c.is_alphabetic() || c.is_ascii_digit()
     }
 
-    fn is_string_delimiter_start(c: char) -> bool {
-        matches!(c, '`' | '[' | '\'' | '"')
+    fn is_string_delimiter_start(&self, c: char) -> bool {
+        match c {
+            '`' | '\'' | '"' => true,
+            '[' => self.backend != TokenizerBackend::Postgres,
+            _ => false,
+        }
     }
 
     fn is_string_escape_for(start: char, c: char) -> bool {
@@ -566,6 +570,41 @@ mod tests {
             string,
             tokens.iter().map(|x| x.as_str()).collect::<String>()
         );
+    }
+
+    #[test]
+    fn test_9_postgres_does_not_treat_brackets_as_quoted() {
+        let string = r"ARRAY[$1, $2]";
+        let tokenizer = Tokenizer::new(string).for_backend(TokenizerBackend::Postgres);
+        let tokens: Vec<Token> = tokenizer.iter().collect();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Unquoted("ARRAY"),
+                Token::Punctuation("["),
+                Token::Punctuation("$"),
+                Token::Unquoted("1"),
+                Token::Punctuation(","),
+                Token::Space(" "),
+                Token::Punctuation("$"),
+                Token::Unquoted("2"),
+                Token::Punctuation("]"),
+            ]
+        );
+        assert_eq!(
+            string,
+            tokens.iter().map(|x| x.as_str()).collect::<String>()
+        );
+    }
+
+    #[test]
+    fn test_9_mysql_and_sqlite_keep_bracketed_quoting() {
+        for backend in [TokenizerBackend::Mysql, TokenizerBackend::Sqlite] {
+            let string = r"[ab]";
+            let tokenizer = Tokenizer::new(string).for_backend(backend);
+            let tokens: Vec<Token> = tokenizer.iter().collect();
+            assert_eq!(tokens, vec![Token::Quoted("[ab]")], "backend={:?}", backend);
+        }
     }
 
     #[test]

--- a/tests/postgres/query.rs
+++ b/tests/postgres/query.rs
@@ -1204,6 +1204,21 @@ fn select_61_custom_values_numbered_placeholders_after_escape_string() {
 }
 
 #[test]
+fn cust_with_values_inside_array_literal_renumbers_placeholders() {
+    let (statement, values) = Query::select()
+        .column(Char::Character)
+        .from(Char::Table)
+        .and_where(Expr::cust_with_values("tags @> ARRAY[$1, $1]", ["needle"]))
+        .build(PostgresQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"SELECT "character" FROM "character" WHERE tags @> ARRAY[$1, $2]"#
+    );
+    assert_eq!(values, Values(vec!["needle".into(), "needle".into()]));
+}
+
+#[test]
 fn select_62() {
     let select = SelectStatement::new()
         .column(Asterisk)


### PR DESCRIPTION
# Stop treating `[` as a string-quote start under PostgreSQL

Fixes #1073.

## Summary

Stops the SQL tokenizer from consuming `ARRAY[...]` / `arr[i]` and similar bracket-bounded fragments as a single `Token::Quoted` when rendering under the PostgreSQL backend. This fixes the `Expr::cust_with_values` bug for any input that places `$N` placeholders between `[` and `]`. MySQL and SQLite are left byte-identical to today.

## What changed

* `Tokenizer::is_string_delimiter_start` is now a `&self` method (matching the existing `&self` shape of `uses_backslash_escape_for` and `next_single_quote_is_postgres_escape_string`). It returns `false` for `[` when `self.backend == TokenizerBackend::Postgres`, and otherwise returns the historical `matches!(c, ...)` result.
* Two call sites in `Tokenizer::quoted` / `Tokenizer::unquote` updated to `self.is_string_delimiter_start(c)`.
* `is_string_delimiter_end_for` is unchanged. Once a `[` quote has been opened (only possible for MySQL/SQLite under the new gate), the close is still `]`.

## Why Postgres-only

`[` is overloaded across dialects:

| Backend | `ARRAY[...]` literal | `[col]` identifier quoting |
| --- | --- | --- |
| Postgres | yes | no |
| MySQL | no | no (MySQL uses backticks) |
| SQLite | no | yes (documented MS Access compat) |

The historical tokenizer treated `[` as a quote start unconditionally for every backend which is a quirk that affected MySQL incidentally even though MySQL has no `[col]` syntax. This PR keeps that historical behavior for MySQL and SQLite, and limits the change to PostgreSQL where `[` is core syntax for `ARRAY[...]` and subscript expressions. 

A follow-up that also removes `[` for MySQL (where it seems to serve no purpose) is reasonable but out of scope here, mostly because I'm not 100% sure that there is no case where MySQL would ever use any [$X] expression without further research that I have not done. I know they use [,] in regex but those are quoted already within `` so while I do think it would be safe I don't know for sure and my use case and expertise is with PostgreSQL.

## Tests

* `token::tests::test_9` unchanged (default backend is MySQL, `[ab]` is still one `Quoted` token).
* `token::tests::test_9_postgres_does_not_treat_brackets_as_quoted` new. Asserts `ARRAY[$1, $2]` tokenizes such that the `$1` and `$2` survive as separate tokens under `TokenizerBackend::Postgres`.
* `token::tests::test_9_mysql_and_sqlite_keep_bracketed_quoting` new. Locks in that MySQL and SQLite still produce `Token::Quoted("[ab]")`.
* `tests/postgres/query.rs::cust_with_values_inside_array_literal_renumbers_placeholders` new. End-to-end through `Expr::cust_with_values` + `PostgresQueryBuilder`:

```rust
let (statement, values) = Query::select()
    .column(Char::Character)
    .from(Char::Table)
    .and_where(Expr::cust_with_values(
        "tags @> ARRAY[$1, $1]",
        ["needle"],
    ))
    .build(PostgresQueryBuilder);

assert_eq!(statement, r#"SELECT "character" FROM "character" WHERE tags @> ARRAY[$1, $2]"#);
assert_eq!(values, Values(vec!["needle".into(), "needle".into()]));
```

## Changelog

```markdown
### Fixes

* Fixed `Expr::cust_with_values` dropping placeholders inside `ARRAY[...]` literals and other `[...]` groups under `PostgresQueryBuilder` https://github.com/SeaQL/sea-query/pull/<n>
```