### PR TITLE
deps(cargo): upgrade `sqlx` from `0.8` to `0.9`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ bigdecimal = { version = "0.4", default-features = false, optional = true }
 uuid = { version = "1", default-features = false, optional = true }
 time = { version = "0.3.47", default-features = false, optional = true, features = ["macros", "formatting"] }
 jiff = { version = "0.2.15", default-features = false, optional = true, features = ["std", "perf-inline"] }
-ipnetwork = { version = "0.20", default-features = false, optional = true }
+ipnetwork = { version = "0.21.1", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
 ordered-float = { version = "4.6", default-features = false, optional = true }
 itoa = { version = "1.0.15", optional = true }

--- a/examples/sqlx_mysql/Cargo.toml
+++ b/examples/sqlx_mysql/Cargo.toml
@@ -5,7 +5,7 @@
 name = "sea-query-sqlx-mysql-example"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
@@ -16,7 +16,7 @@ serde_json = "1"
 rust_decimal = { version = "1" }
 bigdecimal = { version = "0.4" }
 async-std = { version = "1.8", features = [ "attributes" ] }
-sqlx = "0.8"
+sqlx = "0.9"
 sea-query = { path = "../../" }
 sea-query-sqlx = { path = "../../sea-query-sqlx", features = [
     "sqlx-mysql",
@@ -26,7 +26,8 @@ sea-query-sqlx = { path = "../../sea-query-sqlx", features = [
     "with-bigdecimal",
     "with-uuid",
     "with-time",
-    "runtime-async-std-native-tls",
+    "runtime-async-std",
+    "tls-native-tls",
 ] }
 
 # NOTE: if you are copying this example into your own project, use the following line instead:

--- a/examples/sqlx_postgres/Cargo.toml
+++ b/examples/sqlx_postgres/Cargo.toml
@@ -5,7 +5,7 @@
 name = "sea-query-sqlx-postgres-example"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
@@ -14,7 +14,7 @@ jiff = { version = "0.2.15", features = ["std"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 serde_json = { version = "1" }
 async-std = { version = "1.8", features = [ "attributes" ] }
-sqlx = "0.8"
+sqlx = "0.9"
 sea-query = { path = "../../" }
 sea-query-sqlx = { path = "../../sea-query-sqlx", features = [
     "sqlx-postgres",
@@ -27,7 +27,8 @@ sea-query-sqlx = { path = "../../sea-query-sqlx", features = [
     "with-jiff",
     "with-ipnetwork",
     "with-mac_address",
-    "runtime-async-std-native-tls",
+    "runtime-async-std",
+    "tls-native-tls",
 ] }
 
 # NOTE: if you are copying this example into your own project, use the following line instead:

--- a/examples/sqlx_sqlite/Cargo.toml
+++ b/examples/sqlx_sqlite/Cargo.toml
@@ -5,7 +5,7 @@
 name = "sea-query-sqlx-sqlite-example"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.94.0"
 publish = false
 
 [dependencies]
@@ -14,7 +14,7 @@ time = { version = "0.3.36", features = ["macros"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 serde_json = "1"
 async-std = { version = "1.8", features = ["attributes"] }
-sqlx = "0.8"
+sqlx = "0.9"
 sea-query = { path = "../../", features = ["sqlx-utils"]}
 sea-query-sqlx = { path = "../../sea-query-sqlx", features = [
     "sqlx-sqlite",
@@ -22,7 +22,8 @@ sea-query-sqlx = { path = "../../sea-query-sqlx", features = [
     "with-json",
     "with-uuid",
     "with-time",
-    "runtime-async-std-native-tls",
+    "runtime-async-std",
+    "tls-native-tls",
 ] }
 
 # NOTE: if you are copying this example into your own project, use the following line instead:

--- a/sea-query-sqlx/Cargo.toml
+++ b/sea-query-sqlx/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.94.0"
 [dependencies]
 sea-query = { version = "1.0.0-rc.34", path = "..", default-features = false, features = ["thread-safe"] }
 sqlx = { version = "0.9", default-features = false, optional = true }
-ipnetwork = { version = "0.20", default-features = false, optional = true } # pin dependency
+ipnetwork = { version = "0.21.1", default-features = false, optional = true } # pin dependency
 pgvector = { version = "0.4.2", default-features = false, optional = true } # requires feature flag
 jiff = { version = "0.2.15", default-features = false, optional = true, features = ["std", "perf-inline"] }
 jiff-sqlx = { version = "0.1", optional = true }

--- a/sea-query-sqlx/Cargo.toml
+++ b/sea-query-sqlx/Cargo.toml
@@ -12,13 +12,13 @@ documentation = "https://docs.rs/sea-query"
 repository = "https://github.com/SeaQL/sea-query"
 categories = [ "database" ]
 keywords = [ "database", "sql", "mysql", "postgres", "sqlite" ]
-rust-version = "1.88.0"
+rust-version = "1.94.0"
 
 [lib]
 
 [dependencies]
 sea-query = { version = "1.0.0-rc.34", path = "..", default-features = false, features = ["thread-safe"] }
-sqlx = { version = "0.8", default-features = false, optional = true }
+sqlx = { version = "0.9", default-features = false, optional = true }
 ipnetwork = { version = "0.20", default-features = false, optional = true } # pin dependency
 pgvector = { version = "0.4", default-features = false, optional = true } # requires feature flag
 jiff = { version = "0.2.15", default-features = false, optional = true, features = ["std", "perf-inline"] }
@@ -42,14 +42,23 @@ unimplemented-jiff-sqlx-mysql = []
 postgres-array = ["sea-query/postgres-array"]
 postgres-vector = ["sea-query/postgres-vector", "pgvector/sqlx"]
 runtime-async-std = ["sqlx?/runtime-async-std"]
-runtime-async-std-native-tls = ["sqlx?/runtime-async-std-native-tls"]
-runtime-async-std-rustls = ["sqlx?/runtime-async-std-rustls", ]
 runtime-actix = ["sqlx?/runtime-tokio"]
-runtime-actix-native-tls = ["sqlx?/runtime-tokio-native-tls"]
-runtime-actix-rustls = ["sqlx?/runtime-tokio-rustls"]
 runtime-tokio = ["sqlx?/runtime-tokio"]
-runtime-tokio-native-tls = ["sqlx?/runtime-tokio-native-tls"]
-runtime-tokio-rustls = ["sqlx?/runtime-tokio-rustls"]
+tls-none = ["sqlx?/tls-none"]
+tls-native-tls = ["sqlx?/tls-native-tls"]
+tls-rustls = ["sqlx?/tls-rustls"]
+tls-rustls-aws-lc-rs = ["sqlx?/tls-rustls-aws-lc-rs"]
+tls-rustls-ring = ["sqlx?/tls-rustls-ring"]
+tls-rustls-ring-native-roots = ["sqlx?/tls-rustls-ring-native-roots"]
+tls-rustls-ring-webpki = ["sqlx?/tls-rustls-ring-webpki"]
+
+# TODO: Remove those features as a breaking change.
+runtime-async-std-native-tls = ["runtime-async-std", "tls-native-tls"]
+runtime-async-std-rustls = ["runtime-async-std", "tls-rustls"]
+runtime-actix-native-tls = ["runtime-actix", "tls-native-tls"]
+runtime-actix-rustls = ["runtime-actix", "tls-rustls"]
+runtime-tokio-native-tls = ["runtime-tokio", "tls-native-tls"]
+runtime-tokio-rustls = ["runtime-tokio", "tls-rustls"]
 
 
 [package.metadata.docs.rs]

--- a/sea-query-sqlx/Cargo.toml
+++ b/sea-query-sqlx/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.94.0"
 sea-query = { version = "1.0.0-rc.34", path = "..", default-features = false, features = ["thread-safe"] }
 sqlx = { version = "0.9", default-features = false, optional = true }
 ipnetwork = { version = "0.20", default-features = false, optional = true } # pin dependency
-pgvector = { version = "0.4", default-features = false, optional = true } # requires feature flag
+pgvector = { version = "0.4.2", default-features = false, optional = true } # requires feature flag
 jiff = { version = "0.2.15", default-features = false, optional = true, features = ["std", "perf-inline"] }
 jiff-sqlx = { version = "0.1", optional = true }
 

--- a/sea-query-sqlx/src/sqlx_mysql.rs
+++ b/sea-query-sqlx/src/sqlx_mysql.rs
@@ -1,7 +1,7 @@
 use crate::SqlxValues;
 use sea_query::{OptionEnum, Value};
 
-impl sqlx::IntoArguments<'_, sqlx::mysql::MySql> for SqlxValues {
+impl sqlx::IntoArguments<sqlx::mysql::MySql> for SqlxValues {
     fn into_arguments(self) -> sqlx::mysql::MySqlArguments {
         let mut args = sqlx::mysql::MySqlArguments::default();
         for arg in self.0.into_iter() {

--- a/sea-query-sqlx/src/sqlx_postgres.rs
+++ b/sea-query-sqlx/src/sqlx_postgres.rs
@@ -21,7 +21,7 @@ use sea_query::{OptionEnum, Value};
 
 use crate::SqlxValues;
 
-impl sqlx::IntoArguments<'_, sqlx::postgres::Postgres> for SqlxValues {
+impl sqlx::IntoArguments<sqlx::postgres::Postgres> for SqlxValues {
     fn into_arguments(self) -> sqlx::postgres::PgArguments {
         let mut args = sqlx::postgres::PgArguments::default();
         for arg in self.0.into_iter() {

--- a/sea-query-sqlx/src/sqlx_sqlite.rs
+++ b/sea-query-sqlx/src/sqlx_sqlite.rs
@@ -1,8 +1,8 @@
 use crate::SqlxValues;
 use sea_query::{OptionEnum, Value};
 
-impl<'q> sqlx::IntoArguments<'q, sqlx::sqlite::Sqlite> for SqlxValues {
-    fn into_arguments(self) -> sqlx::sqlite::SqliteArguments<'q> {
+impl<'q> sqlx::IntoArguments<sqlx::sqlite::Sqlite> for SqlxValues {
+    fn into_arguments(self) -> sqlx::sqlite::SqliteArguments {
         let mut args = sqlx::sqlite::SqliteArguments::default();
         for arg in self.0.into_iter() {
             use sqlx::Arguments;


### PR DESCRIPTION
`sqlx` had a breaking change in its cargo build features that is ported to `sea-query` in a compatible way. Old features should be documented as deprecated in the next release's changelog.

As per `sqlx`'s [MSRV policy](https://github.com/launchbadge/sqlx/blob/75bc0487eb661da811bb7a3c5d158f1bd463fef4/FAQ.md#MSRV), the supported Rust version is [1.94.0](https://doc.rust-lang.org/stable/releases.html#version-1940-2026-03-05).

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link -->

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies:
  - https://github.com/pgvector/pgvector-rust/issues/25

<!-- any PR depends on this PR? (if applicable) -->
- Dependents:
  - https://github.com/SeaQL/sea-orm/pull/3065

## New Features

<!-- - [ ] <!-- what are the new features? -->

## Bug Fixes

<!-- - [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

<!-- - [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [x] Upgrade `sqlx` to `0.9`
- [x] New `tls-*` cargo features were exposed from `sqlx`.
