### PR TITLE
Add Value conversions for borrowed scalar primitives

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -1150,6 +1150,29 @@ type_to_value!(char, Char, Char(None));
 type_to_value!(Vec<u8>, Bytes, VarBinary(StringLen::None));
 type_to_value!(String, String, String(StringLen::None));
 
+macro_rules! type_ref_to_value {
+    ( $type: ty, $name: ident ) => {
+        impl From<&$type> for Value {
+            fn from(x: &$type) -> Value {
+                Value::$name(Some(*x))
+            }
+        }
+    };
+}
+
+type_ref_to_value!(bool, Bool);
+type_ref_to_value!(i8, TinyInt);
+type_ref_to_value!(i16, SmallInt);
+type_ref_to_value!(i32, Int);
+type_ref_to_value!(i64, BigInt);
+type_ref_to_value!(u8, TinyUnsigned);
+type_ref_to_value!(u16, SmallUnsigned);
+type_ref_to_value!(u32, Unsigned);
+type_ref_to_value!(u64, BigUnsigned);
+type_ref_to_value!(f32, Float);
+type_ref_to_value!(f64, Double);
+type_ref_to_value!(char, Char);
+
 #[allow(unused_macros)]
 macro_rules! type_to_box_value {
     ( $type: ty, $name: ident, $col_type: expr ) => {

--- a/src/value/tests.rs
+++ b/src/value/tests.rs
@@ -4,7 +4,7 @@ use pretty_assertions::assert_eq;
 #[test]
 fn test_value() {
     macro_rules! test_value {
-        ( $type: ty, $val: literal ) => {
+        ( $type: ty, $val: expr ) => {
             let val: $type = $val;
             let v: Value = val.into();
             let out: $type = v.unwrap();
@@ -12,12 +12,40 @@ fn test_value() {
         };
     }
 
-    test_value!(u8, 255);
-    test_value!(u16, 65535);
+    macro_rules! test_ref_value {
+        ( $type: ty, $val: expr ) => {
+            let val: $type = $val;
+            let v: Value = (&val).into();
+            let out: $type = v.unwrap();
+            assert_eq!(out, val);
+        };
+    }
+
+    test_value!(bool, true);
     test_value!(i8, 127);
     test_value!(i16, 32767);
     test_value!(i32, 1073741824);
     test_value!(i64, 8589934592);
+    test_value!(u8, 255);
+    test_value!(u16, 65535);
+    test_value!(u32, 1073741824);
+    test_value!(u64, 8589934592);
+    test_value!(f32, 3.25);
+    test_value!(f64, 3.25);
+    test_value!(char, 'x');
+
+    test_ref_value!(bool, true);
+    test_ref_value!(i8, 127);
+    test_ref_value!(i16, 32767);
+    test_ref_value!(i32, 1073741824);
+    test_ref_value!(i64, 8589934592);
+    test_ref_value!(u8, 255);
+    test_ref_value!(u16, 65535);
+    test_ref_value!(u32, 1073741824);
+    test_ref_value!(u64, 8589934592);
+    test_ref_value!(f32, 3.25);
+    test_ref_value!(f64, 3.25);
+    test_ref_value!(char, 'x');
 }
 
 #[test]


### PR DESCRIPTION
Adds `From<&T> for Value` for copy scalar primitives.