### PR TITLE
Make integer ValueType::try_from lenient via checked conversion

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -1135,15 +1135,81 @@ macro_rules! type_to_value {
 #[allow(unused_imports)]
 use type_to_value;
 
+/// Like [`type_to_value!`], but for the integer scalar types. Identical in every
+/// respect (`From`, `Nullable`, `type_name`, `array_type`, `column_type`) except
+/// that `try_from` accepts *any* integer `Value` variant and converts it with a
+/// *checked* std conversion (`<$type>::try_from`). This lets an integer be read
+/// from a variant other than its own — e.g. an `i32` model field from a
+/// `Value::BigInt` emitted by a backend whose database has only one integer width
+/// (such as Spanner's `INT64`). NULL and out-of-range both map to `ValueTypeErr`,
+/// preserving the original strict behaviour for those cases (no silent truncation).
+macro_rules! int_type_to_value {
+    ( $type: ty, $name: ident, $col_type: expr ) => {
+        impl From<$type> for Value {
+            fn from(x: $type) -> Value {
+                Value::$name(Some(x))
+            }
+        }
+
+        impl Nullable for $type {
+            fn null() -> Value {
+                Value::$name(None)
+            }
+        }
+
+        impl ValueType for $type {
+            fn try_from(v: Value) -> Result<Self, ValueTypeErr> {
+                // Fully-qualified `TryFrom` because `$type` also has a
+                // `ValueType::try_from` in scope (the impl below), which would
+                // otherwise make the call ambiguous.
+                let converted: Option<$type> = match v {
+                    Value::TinyInt(x) => x.and_then(|n| <$type as TryFrom<_>>::try_from(n).ok()),
+                    Value::SmallInt(x) => x.and_then(|n| <$type as TryFrom<_>>::try_from(n).ok()),
+                    Value::Int(x) => x.and_then(|n| <$type as TryFrom<_>>::try_from(n).ok()),
+                    Value::BigInt(x) => x.and_then(|n| <$type as TryFrom<_>>::try_from(n).ok()),
+                    Value::TinyUnsigned(x) => {
+                        x.and_then(|n| <$type as TryFrom<_>>::try_from(n).ok())
+                    }
+                    Value::SmallUnsigned(x) => {
+                        x.and_then(|n| <$type as TryFrom<_>>::try_from(n).ok())
+                    }
+                    Value::Unsigned(x) => x.and_then(|n| <$type as TryFrom<_>>::try_from(n).ok()),
+                    Value::BigUnsigned(x) => {
+                        x.and_then(|n| <$type as TryFrom<_>>::try_from(n).ok())
+                    }
+                    _ => return Err(ValueTypeErr),
+                };
+                converted.ok_or(ValueTypeErr)
+            }
+
+            fn type_name() -> String {
+                stringify!($type).to_owned()
+            }
+
+            fn array_type() -> ArrayType {
+                ArrayType::$name
+            }
+
+            fn column_type() -> ColumnType {
+                use ColumnType::*;
+                $col_type
+            }
+        }
+    };
+}
+
+#[allow(unused_imports)]
+use int_type_to_value;
+
 type_to_value!(bool, Bool, Boolean);
-type_to_value!(i8, TinyInt, TinyInteger);
-type_to_value!(i16, SmallInt, SmallInteger);
-type_to_value!(i32, Int, Integer);
-type_to_value!(i64, BigInt, BigInteger);
-type_to_value!(u8, TinyUnsigned, TinyUnsigned);
-type_to_value!(u16, SmallUnsigned, SmallUnsigned);
-type_to_value!(u32, Unsigned, Unsigned);
-type_to_value!(u64, BigUnsigned, BigUnsigned);
+int_type_to_value!(i8, TinyInt, TinyInteger);
+int_type_to_value!(i16, SmallInt, SmallInteger);
+int_type_to_value!(i32, Int, Integer);
+int_type_to_value!(i64, BigInt, BigInteger);
+int_type_to_value!(u8, TinyUnsigned, TinyUnsigned);
+int_type_to_value!(u16, SmallUnsigned, SmallUnsigned);
+int_type_to_value!(u32, Unsigned, Unsigned);
+int_type_to_value!(u64, BigUnsigned, BigUnsigned);
 type_to_value!(f32, Float, Float);
 type_to_value!(f64, Double, Double);
 type_to_value!(char, Char, Char(None));

--- a/src/value.rs
+++ b/src/value.rs
@@ -1135,14 +1135,19 @@ macro_rules! type_to_value {
 #[allow(unused_imports)]
 use type_to_value;
 
-/// Like [`type_to_value!`], but for the integer scalar types. Identical in every
-/// respect (`From`, `Nullable`, `type_name`, `array_type`, `column_type`) except
-/// that `try_from` accepts *any* integer `Value` variant and converts it with a
-/// *checked* std `TryFrom` conversion. This lets an integer be read
-/// from a variant other than its own — e.g. an `i32` model field from a
-/// `Value::BigInt` emitted by a backend whose database has only one integer width
-/// (such as Spanner's `INT64`). NULL and out-of-range both map to `ValueTypeErr`,
-/// preserving the original strict behaviour for those cases (no silent truncation).
+/// Same as [`type_to_value!`], but produces a more forgiving `try_from` for the
+/// integer types.
+///
+/// With `type_to_value!` a value can only be read back from its own variant, so
+/// reading an `i32` out of a `Value::BigInt` fails. That is a problem for backends
+/// built on a database with a single integer width: Spanner, for example, only
+/// has `INT64`, so its proxy backend can only ever hand back `Value::BigInt`, and
+/// an `i32` field becomes unreadable.
+///
+/// Here `try_from` accepts any integer variant and converts it with the standard
+/// library's checked `TryFrom`. If the value does not fit the target type (or it
+/// is NULL) the result is still `ValueTypeErr`, so nothing is truncated silently.
+/// Everything else the macro generates is identical to `type_to_value!`.
 macro_rules! int_type_to_value {
     ( $type: ty, $name: ident, $col_type: expr ) => {
         impl From<$type> for Value {
@@ -1159,9 +1164,9 @@ macro_rules! int_type_to_value {
 
         impl ValueType for $type {
             fn try_from(v: Value) -> Result<Self, ValueTypeErr> {
-                // Fully-qualified `TryFrom` because `$type` also has a
-                // `ValueType::try_from` in scope (the impl below), which would
-                // otherwise make the call ambiguous.
+                // `$type` now has two `try_from`s in scope: `TryFrom`'s and the
+                // one from the `ValueType` impl just below. Name `TryFrom`
+                // explicitly so the call is not ambiguous.
                 let converted: Option<$type> = match v {
                     Value::TinyInt(x) => x.and_then(|n| <$type as TryFrom<_>>::try_from(n).ok()),
                     Value::SmallInt(x) => x.and_then(|n| <$type as TryFrom<_>>::try_from(n).ok()),

--- a/src/value.rs
+++ b/src/value.rs
@@ -1138,7 +1138,7 @@ use type_to_value;
 /// Like [`type_to_value!`], but for the integer scalar types. Identical in every
 /// respect (`From`, `Nullable`, `type_name`, `array_type`, `column_type`) except
 /// that `try_from` accepts *any* integer `Value` variant and converts it with a
-/// *checked* std conversion (`<$type>::try_from`). This lets an integer be read
+/// *checked* std `TryFrom` conversion. This lets an integer be read
 /// from a variant other than its own — e.g. an `i32` model field from a
 /// `Value::BigInt` emitted by a backend whose database has only one integer width
 /// (such as Spanner's `INT64`). NULL and out-of-range both map to `ValueTypeErr`,

--- a/src/value/tests.rs
+++ b/src/value/tests.rs
@@ -52,7 +52,7 @@ fn test_value() {
 fn integer_value_type_is_lenient_and_checked() {
     use crate::{Value, ValueType};
 
-    // Widen / narrow within range.
+    // An integer can be read from any integer variant, not just its own.
     assert_eq!(
         <i32 as ValueType>::try_from(Value::BigInt(Some(123))).unwrap(),
         123
@@ -73,7 +73,6 @@ fn integer_value_type_is_lenient_and_checked() {
     // NULL -> Err, preserving original semantics.
     assert!(<i32 as ValueType>::try_from(Value::Int(None)).is_err());
 
-    // Non-integer -> Err.
     assert!(<i32 as ValueType>::try_from(Value::String(None)).is_err());
 }
 

--- a/src/value/tests.rs
+++ b/src/value/tests.rs
@@ -49,6 +49,35 @@ fn test_value() {
 }
 
 #[test]
+fn integer_value_type_is_lenient_and_checked() {
+    use crate::{Value, ValueType};
+
+    // Widen / narrow within range.
+    assert_eq!(
+        <i32 as ValueType>::try_from(Value::BigInt(Some(123))).unwrap(),
+        123
+    );
+    assert_eq!(
+        <i64 as ValueType>::try_from(Value::Int(Some(25))).unwrap(),
+        25
+    );
+    assert_eq!(
+        <i8 as ValueType>::try_from(Value::BigInt(Some(7))).unwrap(),
+        7
+    );
+
+    // Out of range -> Err (no silent truncation).
+    assert!(<i32 as ValueType>::try_from(Value::BigInt(Some(i64::MAX))).is_err());
+    assert!(<u32 as ValueType>::try_from(Value::Int(Some(-1))).is_err());
+
+    // NULL -> Err, preserving original semantics.
+    assert!(<i32 as ValueType>::try_from(Value::Int(None)).is_err());
+
+    // Non-integer -> Err.
+    assert!(<i32 as ValueType>::try_from(Value::String(None)).is_err());
+}
+
+#[test]
 fn test_option_value() {
     macro_rules! test_some_value {
         ( $type: ty, $val: literal ) => {

--- a/src/value/tests.rs
+++ b/src/value/tests.rs
@@ -52,7 +52,7 @@ fn test_value() {
 fn integer_value_type_is_lenient_and_checked() {
     use crate::{Value, ValueType};
 
-    // An integer can be read from any integer variant, not just its own.
+    // An integer reads back from any integer variant, not only its own.
     assert_eq!(
         <i32 as ValueType>::try_from(Value::BigInt(Some(123))).unwrap(),
         123
@@ -66,11 +66,11 @@ fn integer_value_type_is_lenient_and_checked() {
         7
     );
 
-    // Out of range -> Err (no silent truncation).
+    // A value that does not fit the target type fails instead of being truncated.
     assert!(<i32 as ValueType>::try_from(Value::BigInt(Some(i64::MAX))).is_err());
     assert!(<u32 as ValueType>::try_from(Value::Int(Some(-1))).is_err());
 
-    // NULL -> Err, preserving original semantics.
+    // NULL still fails, the same as before.
     assert!(<i32 as ValueType>::try_from(Value::Int(None)).is_err());
 
     assert!(<i32 as ValueType>::try_from(Value::String(None)).is_err());


### PR DESCRIPTION
Integer types only accept their own `Value` variant on read, so
`i32::try_from(Value::BigInt(..))` fails even when the number fits. This breaks
the mock/proxy backends on databases with a single integer width — e.g. Spanner
only has `INT64`, so the proxy can only emit `Value::BigInt` and an `i32` field
can't be read.

This adds an `int_type_to_value!` macro for the 8 integer types. It's identical
to `type_to_value!` except `try_from` accepts any integer variant and converts
with the std checked `TryFrom`. Out-of-range or NULL still returns
`ValueTypeErr`, so nothing is truncated. Writes, `Nullable` and column types are
unchanged.

Note: this is a behavior change (not an API break) — reads that used to fail now
succeed when the value fits, including across the signed/unsigned boundary
(still range-checked). Happy to restrict it to same-signedness variants if you
prefer.

Tested with a new `integer_value_type_is_lenient_and_checked` case;
`cargo test --lib`, `--doc`, `clippy` and `fmt` all pass.
