### PR TITLE
feat: add clear_group_by() and clear_having() to SelectStatement

### DIFF
--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -2135,6 +2135,14 @@ impl SelectStatement {
     ///     r#"SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `glyph`.`aspect` IN (3, 4) AND (`glyph`.`image` LIKE 'A%' OR `glyph`.`image` LIKE 'B%')"#
     /// );
     /// ```
+    pub fn cond_having<C>(&mut self, condition: C) -> &mut Self
+    where
+        C: IntoCondition,
+    {
+        self.having.add_condition(condition.into_condition());
+        self
+    }
+
     /// Clear the having condition.
     ///
     /// # Examples
@@ -2165,14 +2173,6 @@ impl SelectStatement {
     /// ```
     pub fn clear_having(&mut self) -> &mut Self {
         self.having = ConditionHolder::new();
-        self
-    }
-
-    pub fn cond_having<C>(&mut self, condition: C) -> &mut Self
-    where
-        C: IntoCondition,
-    {
-        self.having.add_condition(condition.into_condition());
         self
     }
 

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -2068,7 +2068,7 @@ impl SelectStatement {
     /// ```
     pub fn clear_group_by(&mut self) -> &mut Self {
         self.groups = Vec::new();
-        self;
+        self
     }
 
     /// Add group by expressions from vector of [`SelectExpr`].
@@ -2165,7 +2165,7 @@ impl SelectStatement {
     /// ```
     pub fn clear_having(&mut self) -> &mut Self {
         self.having = ConditionHolder::new();
-        self;
+        self
     }
 
     pub fn cond_having<C>(&mut self, condition: C) -> &mut Self

--- a/src/query/select.rs
+++ b/src/query/select.rs
@@ -2039,6 +2039,38 @@ impl SelectStatement {
         self.group_by_columns([col])
     }
 
+    /// Clear the group by expressions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .from(Char::Table)
+    ///     .column(Char::Character)
+    ///     .add_group_by([Expr::col(Char::SizeW).into()])
+    ///     .clear_group_by()
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `character` FROM `character`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "character" FROM "character""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "character" FROM "character""#
+    /// );
+    /// ```
+    pub fn clear_group_by(&mut self) -> &mut Self {
+        self.groups = Vec::new();
+        self;
+    }
+
     /// Add group by expressions from vector of [`SelectExpr`].
     ///
     /// # Examples
@@ -2103,6 +2135,39 @@ impl SelectStatement {
     ///     r#"SELECT `aspect`, MAX(`image`) FROM `glyph` GROUP BY `aspect` HAVING `glyph`.`aspect` IN (3, 4) AND (`glyph`.`image` LIKE 'A%' OR `glyph`.`image` LIKE 'B%')"#
     /// );
     /// ```
+    /// Clear the having condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sea_query::{tests_cfg::*, *};
+    ///
+    /// let query = Query::select()
+    ///     .from(Glyph::Table)
+    ///     .column(Glyph::Aspect)
+    ///     .group_by_columns([Glyph::Aspect])
+    ///     .cond_having(Expr::col(Glyph::Aspect).gt(2))
+    ///     .clear_having()
+    ///     .to_owned();
+    ///
+    /// assert_eq!(
+    ///     query.to_string(MysqlQueryBuilder),
+    ///     r#"SELECT `aspect` FROM `glyph` GROUP BY `aspect`"#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(PostgresQueryBuilder),
+    ///     r#"SELECT "aspect" FROM "glyph" GROUP BY "aspect""#
+    /// );
+    /// assert_eq!(
+    ///     query.to_string(SqliteQueryBuilder),
+    ///     r#"SELECT "aspect" FROM "glyph" GROUP BY "aspect""#
+    /// );
+    /// ```
+    pub fn clear_having(&mut self) -> &mut Self {
+        self.having = ConditionHolder::new();
+        self;
+    }
+
     pub fn cond_having<C>(&mut self, condition: C) -> &mut Self
     where
         C: IntoCondition,


### PR DESCRIPTION
## Summary

Adds `clear_group_by()` and `clear_having()` methods to `SelectStatement` to allow clearing these clauses when modifying queries dynamically.

Closes #1005

## Changes

- `clear_group_by()`: Clears all group by expressions
- `clear_having()`: Clears the having condition

## Examples

```rust
let query = Query::select()
    .from(Char::Table)
    .column(Char::Character)
    .add_group_by([Expr::col(Char::SizeW).into()])
    .clear_group_by()
    .to_owned();
// Result: SELECT `character` FROM `character`
```

```rust
let query = Query::select()
    .from(Glyph::Table)
    .column(Glyph::Aspect)
    .group_by_columns([Glyph::Aspect])
    .cond_having(Expr::col(Glyph::Aspect).gt(2))
    .clear_having()
    .to_owned();
// Result: SELECT `aspect` FROM `glyph` GROUP BY `aspect`
```