### PR TITLE
Add support for composite types

### DIFF
--- a/src/backend/postgres/types.rs
+++ b/src/backend/postgres/types.rs
@@ -13,27 +13,50 @@ impl TypeBuilder for PostgresQueryBuilder {
             self.prepare_type_ref(name, sql);
         }
 
-        if let Some(as_type) = &create.as_type {
-            sql.write_str(" AS ").unwrap();
-            self.prepare_create_as_type(as_type, sql);
-        }
+        let Some(as_type) = &create.as_type else {
+            return;
+        };
+        
+        sql.write_str(" AS ").unwrap();
+        self.prepare_create_as_type(as_type, sql);
 
-        if !create.values.is_empty() {
-            sql.write_str(" (").unwrap();
+        match as_type {
+            TypeAs::Enum => {
+                if !create.values.is_empty() {
+                    sql.write_str(" (").unwrap();
 
-            let mut vals = create.values.iter();
-            join_io!(
-                vals,
-                val,
-                join {
-                    sql.write_str(", ").unwrap();
-                },
-                do {
-                    self.prepare_value(val.to_string().into(), sql);
+                    let mut vals = create.values.iter();
+                    join_io!(
+                        vals,
+                        val,
+                        join {
+                            sql.write_str(", ").unwrap();
+                        },
+                        do {
+                            self.prepare_value(val.to_string().into(), sql);
+                        }
+                    );
+
+                    sql.write_str(")").unwrap();
                 }
-            );
-
-            sql.write_str(")").unwrap();
+            }
+            TypeAs::Composite => {
+                if !create.fields.is_empty() {
+                    sql.write_str("(").unwrap();
+                    let mut fields = create.fields.iter();
+                    join_io!(
+                        fields,
+                        field,
+                        join { sql.write_str(", ").unwrap(); },
+                        do {
+                            self.prepare_iden(&field.name, sql);
+                            sql.write_str(" ").unwrap();
+                            self.prepare_column_type(&field.col_type, sql);
+                        }
+                    );
+                    sql.write_str(")").unwrap();
+                }
+            }
         }
     }
 
@@ -79,6 +102,7 @@ impl TypeBuilder for PostgresQueryBuilder {
 impl PostgresQueryBuilder {
     fn prepare_create_as_type(&self, as_type: &TypeAs, sql: &mut impl SqlWriter) {
         sql.write_str(match as_type {
+            TypeAs::Composite => "",
             TypeAs::Enum => "ENUM",
         })
         .unwrap();

--- a/src/backend/postgres/types.rs
+++ b/src/backend/postgres/types.rs
@@ -151,6 +151,16 @@ impl PostgresQueryBuilder {
                 sql.write_str(" TO ").unwrap();
                 self.prepare_value(new_name.to_string().into(), sql);
             }
+            TypeAlterOpt::AddAttribute(field) => {
+                sql.write_str(" ADD ATTRIBUTE ").unwrap();
+                self.prepare_iden(&field.name, sql);
+                sql.write_str(" ").unwrap();
+                self.prepare_column_type(&field.col_type, sql);
+            }
+            TypeAlterOpt::DropAttribute(field) => {
+                sql.write_str(" DROP ATTRIBUTE ").unwrap();
+                self.prepare_iden(&field.name, sql);
+            }
         }
     }
 }

--- a/src/backend/postgres/types.rs
+++ b/src/backend/postgres/types.rs
@@ -16,7 +16,7 @@ impl TypeBuilder for PostgresQueryBuilder {
         let Some(as_type) = &create.as_type else {
             return;
         };
-        
+
         sql.write_str(" AS ").unwrap();
         self.prepare_create_as_type(as_type, sql);
 

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -175,18 +175,14 @@ impl TypeCreateStatement {
     ///     r#"CREATE TYPE "font_family" AS ("serif" text, "sans" text, "monospace" text)"#,
     /// );
     /// ```
-    pub fn as_composite<T>(&mut self, name: T) -> &mut Self
-    where
-        T: IntoTypeRef,
-    {
-        self.as_type(name, TypeAs::Composite)
+    pub fn as_composite(&mut self, name: impl IntoTypeRef) -> &mut Self {
+        self.as_type(name.into_type_ref(), TypeAs::Composite)
     }
 
-    pub fn fields<N, I>(&mut self, fields: I) -> &mut Self
-    where
-        N: IntoIden,
-        I: IntoIterator<Item = (N, ColumnType)>,
-    {
+    pub fn fields(
+        &mut self,
+        fields: impl IntoIterator<Item = (impl IntoIden, ColumnType)>,
+    ) -> &mut Self {
         for (name, col_type) in fields {
             self.fields.push(CompositeFieldType {
                 name: name.into_iden(),
@@ -196,10 +192,7 @@ impl TypeCreateStatement {
         self
     }
 
-    fn as_type<T>(&mut self, name: T, as_type: TypeAs) -> &mut Self
-    where
-        T: IntoTypeRef,
-    {
+    fn as_type(&mut self, name: impl IntoTypeRef, as_type: TypeAs) -> &mut Self {
         self.name = Some(name.into_type_ref());
         self.as_type = Some(as_type);
         self
@@ -456,10 +449,7 @@ impl TypeAlterStatement {
     ///     r#"ALTER TYPE "font" ADD ATTRIBUTE "variant" text"#
     /// )
     /// ```
-    pub fn add_attribute<T>(self, name: T, col_type: ColumnType) -> Self
-    where
-        T: IntoIden,
-    {
+    pub fn add_attribute(self, name: impl IntoIden, col_type: ColumnType) -> Self {
         self.alter_option(TypeAlterOpt::AddAttribute(CompositeFieldType {
             name: name.into_iden(),
             col_type,
@@ -479,10 +469,7 @@ impl TypeAlterStatement {
     ///     r#"ALTER TYPE "font" DROP ATTRIBUTE "variant""#
     /// )
     /// ```
-    pub fn drop_attribute<T>(self, name: T) -> Self
-    where
-        T: IntoIden,
-    {
+    pub fn drop_attribute(self, name: impl IntoIden) -> Self {
         self.alter_option(TypeAlterOpt::DropAttribute(CompositeFieldType {
             name: name.into_iden(),
             col_type: ColumnType::Text,

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -1,3 +1,4 @@
+use crate::ColumnType;
 use crate::{QueryBuilder, QuotedBuilder, prepare::*, types::*};
 
 /// Helper for constructing any type statement
@@ -10,17 +11,24 @@ pub use crate::TypeRef;
 // This trait used to be defined here. Let's keep exporting it for compatibility.
 pub use crate::IntoTypeRef;
 
+#[derive(Debug, Clone)]
+pub struct CompositeFieldType {
+    pub(crate) name: DynIden,
+    pub(crate) col_type: ColumnType,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct TypeCreateStatement {
     pub(crate) name: Option<TypeRef>,
     pub(crate) as_type: Option<TypeAs>,
     pub(crate) values: Vec<DynIden>,
+    pub(crate) fields: Vec<CompositeFieldType>,
 }
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum TypeAs {
-    // Composite,
+    Composite,
     Enum,
     /* Range,
      * Base,
@@ -125,9 +133,7 @@ impl TypeCreateStatement {
     where
         T: IntoTypeRef,
     {
-        self.name = Some(name.into_type_ref());
-        self.as_type = Some(TypeAs::Enum);
-        self
+        self.as_type(name, TypeAs::Enum)
     }
 
     pub fn values<T, I>(&mut self, values: I) -> &mut Self
@@ -138,6 +144,63 @@ impl TypeCreateStatement {
         for v in values.into_iter() {
             self.values.push(v.into_iden());
         }
+        self
+    }
+
+    /// Create composite as custom type
+    ///
+    /// ```
+    /// use sea_query::{extension::postgres::Type, *};
+    ///
+    /// #[derive(Iden)]
+    /// enum FontFamily {
+    ///     #[iden = "font_family"]
+    ///     Type,
+    ///     Serif,
+    ///     Sans,
+    ///     Monospace,
+    /// }
+    ///
+    /// assert_eq!(
+    ///     Type::create()
+    ///         .as_composite(FontFamily::Type)
+    ///         .fields([
+    ///             (FontFamily::Serif, ColumnType::Text),
+    ///             (FontFamily::Sans, ColumnType::Text),
+    ///             (FontFamily::Monospace, ColumnType::Text),
+    ///         ])
+    ///         .to_string(PostgresQueryBuilder),
+    ///     r#"CREATE TYPE "font_family" AS ("serif" text, "sans" text, "monospace" text)"#,
+    /// );
+    /// ```
+    pub fn as_composite<T>(&mut self, name: T) -> &mut Self
+    where
+        T: IntoTypeRef,
+    {
+        self.as_type(name, TypeAs::Composite)
+
+    }
+   
+    pub fn fields<N, I>(&mut self, fields: I) -> &mut Self
+    where
+        N: IntoIden,
+        I: IntoIterator<Item = (N, ColumnType)>,
+    {
+        for (name, col_type) in fields {
+            self.fields.push(CompositeFieldType {
+                name: name.into_iden(),
+                col_type,
+            });
+        }
+        self
+    }
+
+    fn as_type<T>(&mut self, name: T, as_type: TypeAs) -> &mut Self
+    where
+        T: IntoTypeRef,
+    {
+        self.name = Some(name.into_type_ref());
+        self.as_type = Some(as_type);
         self
     }
 }

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -65,6 +65,8 @@ pub enum TypeAlterOpt {
     },
     Rename(DynIden),
     RenameValue(DynIden, DynIden),
+    AddAttribute(CompositeFieldType),
+    DropAttribute(CompositeFieldType),
 }
 
 #[derive(Debug, Clone)]
@@ -440,6 +442,52 @@ impl TypeAlterStatement {
             existing.into_iden(),
             new_name.into_iden(),
         ))
+    }
+
+    /// Add an attribute to a composite type
+    ///
+    /// ```
+    /// use sea_query::{extension::postgres::Type, tests_cfg::*, *};
+    ///
+    /// assert_eq!(
+    ///     Type::alter()
+    ///         .name(Font::Table)
+    ///         .add_attribute(Font::Variant, ColumnType::Text)
+    ///         .to_string(PostgresQueryBuilder),
+    ///     r#"ALTER TYPE "font" ADD ATTRIBUTE "variant" text"#
+    /// )
+    /// ```
+    pub fn add_attribute<T>(self, name: T, col_type: ColumnType) -> Self
+    where
+        T: IntoIden,
+    {
+        self.alter_option(TypeAlterOpt::AddAttribute(CompositeFieldType {
+                name: name.into_iden(),
+                col_type,
+            }))
+    }
+
+    /// Drop an attribute from a composite type
+    ///
+    /// ```
+    /// use sea_query::{extension::postgres::Type, tests_cfg::*, *};
+    ///
+    /// assert_eq!(
+    ///     Type::alter()
+    ///         .name(Font::Table)
+    ///         .drop_attribute(Font::Variant)
+    ///         .to_string(PostgresQueryBuilder),
+    ///     r#"ALTER TYPE "font" DROP ATTRIBUTE "variant""#
+    /// )
+    /// ```
+    pub fn drop_attribute<T>(self, name: T) -> Self
+    where
+        T: IntoIden,
+    {
+        self.alter_option(TypeAlterOpt::DropAttribute(CompositeFieldType {
+            name: name.into_iden(),
+            col_type: ColumnType::Text,
+        }))
     }
 
     fn alter_option(mut self, option: TypeAlterOpt) -> Self {

--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -180,9 +180,8 @@ impl TypeCreateStatement {
         T: IntoTypeRef,
     {
         self.as_type(name, TypeAs::Composite)
-
     }
-   
+
     pub fn fields<N, I>(&mut self, fields: I) -> &mut Self
     where
         N: IntoIden,
@@ -462,9 +461,9 @@ impl TypeAlterStatement {
         T: IntoIden,
     {
         self.alter_option(TypeAlterOpt::AddAttribute(CompositeFieldType {
-                name: name.into_iden(),
-                col_type,
-            }))
+            name: name.into_iden(),
+            col_type,
+        }))
     }
 
     /// Drop an attribute from a composite type

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -52,6 +52,55 @@ fn create_3() {
 }
 
 #[test]
+fn create_4() {
+    #[derive(Iden)]
+    enum FontFamily {
+        #[iden = "font_family"]
+        Type,
+        Serif,
+        Sans,
+        Monospace,
+    }
+    assert_eq!(
+        Type::create()
+            .as_composite(FontFamily::Type)
+            .fields([
+                (FontFamily::Serif, ColumnType::Text),
+                (FontFamily::Sans, ColumnType::Text),
+                (FontFamily::Monospace, ColumnType::Text),
+            ])
+            .to_string(PostgresQueryBuilder),
+        r#"CREATE TYPE "font_family" AS ("serif" text, "sans" text, "monospace" text)"#,
+    );
+}
+#[test]
+fn create_5() {
+    assert_eq!(
+        Type::create()
+            .as_composite(("schema", Font::Table))
+            .fields([
+                ("serif", ColumnType::Text),
+                ("sans", ColumnType::Text),
+                ("monospace", ColumnType::Text),
+            ])
+            .to_string(PostgresQueryBuilder),
+        r#"CREATE TYPE "schema"."font" AS ("serif" text, "sans" text, "monospace" text)"#,
+    );
+}
+#[test]
+fn create_6() {
+    assert_eq!(
+        Type::create()
+            .as_composite("outer_type")
+            .fields([
+                ("inner", ColumnType::custom("inner_type")),
+            ])
+            .to_string(PostgresQueryBuilder),
+        r#"CREATE TYPE "outer_type" AS ("inner" inner_type)"#,
+    );
+}
+
+#[test]
 fn drop_1() {
     assert_eq!(
         Type::drop()

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -92,9 +92,7 @@ fn create_6() {
     assert_eq!(
         Type::create()
             .as_composite("outer_type")
-            .fields([
-                ("inner", ColumnType::custom("inner_type")),
-            ])
+            .fields([("inner", ColumnType::custom("inner_type"))])
             .to_string(PostgresQueryBuilder),
         r#"CREATE TYPE "outer_type" AS ("inner" inner_type)"#,
     );

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -212,6 +212,28 @@ fn alter_6() {
 }
 
 #[test]
+fn alter_7() {
+    assert_eq!(
+        Type::alter()
+            .name(Font::Table)
+            .add_attribute(Font::Variant, ColumnType::Text)
+            .to_string(PostgresQueryBuilder),
+        r#"ALTER TYPE "font" ADD ATTRIBUTE "variant" text"#
+    )
+}
+
+#[test]
+fn alter_8() {
+    assert_eq!(
+        Type::alter()
+            .name(Font::Table)
+            .drop_attribute(Font::Variant)
+            .to_string(PostgresQueryBuilder),
+        r#"ALTER TYPE "font" DROP ATTRIBUTE "variant""#
+    );
+}
+
+#[test]
 fn unsigned_types() {
     let query_builder = PostgresQueryBuilder {};
 


### PR DESCRIPTION
## PR Info
- Closes #950 

## New Features

- [x] Add support to create composite types 
- [x] Add add Attribute to add an attribute to an existing composite type 
- [x] Add drop attribute in order to drop an attribute from a composite type 

## Breaking Changes

- [x] No breaking changes 
- [x] No change in behavior, update `prepare_type_create_statement` in order to match on composite type
- [x] No change in behavior, update to `as_enum`, this was a code refactor, change as_[TYPE] function to be handled by a helpler function

## Changes
- [x] add `CompositeFieldType` struct
- [x] added `TypeAlterOpt::AddAttribute` and `TypeAlterOpt::DropAttribute` in  `TypeAlterOpt` struct

<img width="1891" height="1005" alt="image" src="https://github.com/user-attachments/assets/955f5fc7-0fe6-478c-87e3-68c1f15b6f86" />
