### PR TITLE
feat(index): add Gin and Gist variants to IndexType and helper methods

### DIFF
--- a/src/backend/mysql/index.rs
+++ b/src/backend/mysql/index.rs
@@ -86,6 +86,8 @@ impl IndexBuilder for MysqlQueryBuilder {
                 sql.write_str(match index_type {
                     IndexType::BTree => "BTREE",
                     IndexType::FullText => unreachable!(),
+                    IndexType::Gin => "GIN",
+                    IndexType::Gist => "GIST",
                     IndexType::Hash => "HASH",
                     IndexType::Custom(custom) => &custom.0,
                 })

--- a/src/backend/postgres/index.rs
+++ b/src/backend/postgres/index.rs
@@ -123,7 +123,8 @@ impl IndexBuilder for PostgresQueryBuilder {
             sql.write_str(" USING ").unwrap();
             match index_type {
                 IndexType::BTree => sql.write_str("BTREE"),
-                IndexType::FullText => sql.write_str("GIN"),
+                IndexType::FullText | IndexType::Gin => sql.write_str("GIN"),
+                IndexType::Gist => sql.write_str("GIST"),
                 IndexType::Hash => sql.write_str("HASH"),
                 IndexType::Custom(custom) => sql.write_str(&custom.0),
             }

--- a/src/index/create.rs
+++ b/src/index/create.rs
@@ -225,6 +225,8 @@ pub struct IndexCreateStatement {
 pub enum IndexType {
     BTree,
     FullText,
+    Gin,
+    Gist,
     Hash,
     Custom(DynIden),
 }
@@ -308,6 +310,16 @@ impl IndexCreateStatement {
     /// On PgSQL, this is `GIN`.
     pub fn full_text(&mut self) -> &mut Self {
         self.index_type(IndexType::FullText)
+    }
+
+    /// Set index type as `GIN`. Only available on Postgres.
+    pub fn gin(&mut self) -> &mut Self {
+        self.index_type(IndexType::Gin)
+    }
+
+    /// Set index type as `GIST`. Only available on Postgres.
+    pub fn gist(&mut self) -> &mut Self {
+        self.index_type(IndexType::Gist)
     }
 
     /// Set index type. Not available on Sqlite.

--- a/tests/postgres/index.rs
+++ b/tests/postgres/index.rs
@@ -225,3 +225,29 @@ fn drop_5() {
         .table(("database", "schema", Glyph::Table))
         .to_string(PostgresQueryBuilder);
 }
+
+#[test]
+fn create_gin() {
+    assert_eq!(
+        Index::create()
+            .gin()
+            .name("idx-glyph-image-gin")
+            .table(Glyph::Table)
+            .col(Glyph::Image)
+            .to_string(PostgresQueryBuilder),
+        r#"CREATE INDEX "idx-glyph-image-gin" ON "glyph" USING GIN ("image")"#
+    );
+}
+
+#[test]
+fn create_gist() {
+    assert_eq!(
+        Index::create()
+            .gist()
+            .name("idx-glyph-image-gist")
+            .table(Glyph::Table)
+            .col(Glyph::Image)
+            .to_string(PostgresQueryBuilder),
+        r#"CREATE INDEX "idx-glyph-image-gist" ON "glyph" USING GIST ("image")"#
+    );
+}


### PR DESCRIPTION
## Description
Adds `IndexType::Gin` and `IndexType::Gist` variants to `IndexType`, along with `.gin()` and `.gist()` helper methods on `IndexCreateStatement`.

## Motivation
Simplifies creation of Postgres GIN and GIST indexes on table definitions without relying on `IndexType::Custom`.

## Example
```rust
use sea_query::*;

let index = Index::create()
    .gin()
    .name("idx-glyph-image-gin")
    .table(Glyph::Table)
    .col(Glyph::Image)
    .to_string(PostgresQueryBuilder);

assert_eq!(
    index,
    r#"CREATE INDEX "idx-glyph-image-gin" ON "glyph" USING GIN ("image")"#
);
```
