### PR TITLE
feat(types): add CrossJoinLateral and LeftJoinLateral to JoinType

### DIFF
--- a/src/backend/query_builder.rs
+++ b/src/backend/query_builder.rs
@@ -1011,8 +1011,10 @@ pub trait QueryBuilder:
         sql.write_str(match join_type {
             JoinType::Join => "JOIN",
             JoinType::CrossJoin => "CROSS JOIN",
+            JoinType::CrossJoinLateral => "CROSS JOIN LATERAL",
             JoinType::InnerJoin => "INNER JOIN",
             JoinType::LeftJoin => "LEFT JOIN",
+            JoinType::LeftJoinLateral => "LEFT JOIN LATERAL",
             JoinType::RightJoin => "RIGHT JOIN",
             JoinType::FullOuterJoin => "FULL OUTER JOIN",
             JoinType::StraightJoin => "STRAIGHT_JOIN",

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -116,8 +116,10 @@ pub enum LogicalChainOper {
 pub enum JoinType {
     Join,
     CrossJoin,
+    CrossJoinLateral,
     InnerJoin,
     LeftJoin,
+    LeftJoinLateral,
     RightJoin,
     FullOuterJoin,
     StraightJoin,


### PR DESCRIPTION
## Description
Adds `CrossJoinLateral` and `LeftJoinLateral` variants to `JoinType` and updates `prepare_join_type_common` in `QueryBuilder`.

## Motivation
Provides first-class representation for lateral joins in `JoinType` for AST inspection and statement preparation.