### PR TITLE
feat(extension/postgres): add add_value_if_not_exists helper to TypeAlterStatement

### DIFF
--- a/src/extension/postgres/types.rs
+++ b/src/extension/postgres/types.rs
@@ -292,6 +292,30 @@ impl TypeAlterStatement {
         })
     }
 
+    /// Add an enum value if it does not already exist
+    ///
+    /// ```
+    /// use sea_query::{extension::postgres::Type, tests_cfg::*, *};
+    ///
+    /// assert_eq!(
+    ///     Type::alter()
+    ///         .name(Font::Table)
+    ///         .add_value_if_not_exists("weight")
+    ///         .to_string(PostgresQueryBuilder),
+    ///     r#"ALTER TYPE "font" ADD VALUE IF NOT EXISTS 'weight'"#
+    /// );
+    /// ```
+    pub fn add_value_if_not_exists<T>(self, value: T) -> Self
+    where
+        T: IntoIden,
+    {
+        self.alter_option(TypeAlterOpt::Add {
+            value: value.into_iden(),
+            placement: None,
+            if_not_exists: true,
+        })
+    }
+
     /// Add a enum value before an existing value
     ///
     /// ```


### PR DESCRIPTION
## Description
Adds `.add_value_if_not_exists(...)` convenience method directly to `TypeAlterStatement`.

## Motivation
Improves API ergonomics and discoverability when adding new ENUM values dynamically during migrations (`ALTER TYPE ... ADD VALUE IF NOT EXISTS`).

## Example
```rust
use sea_query::{extension::postgres::Type, *};

let sql = Type::alter()
    .name(Font::Table)
    .add_value_if_not_exists("weight")
    .to_string(PostgresQueryBuilder);

assert_eq!(
    sql,
    r#"ALTER TYPE "font" ADD VALUE IF NOT EXISTS 'weight'"#
);
```
