### PR TITLE
fix(backend/postgres): emit USING clause directly after TYPE in modify_column (#1099)

### DIFF
--- a/src/backend/postgres/table.rs
+++ b/src/backend/postgres/table.rs
@@ -370,6 +370,10 @@ impl PostgresQueryBuilder {
             self.prepare_iden(&column_def.name, sql);
             write!(sql, " TYPE ").unwrap();
             self.prepare_column_type(column_type, sql);
+            if let Some(expr) = &column_def.spec.using {
+                write!(sql, " USING ").unwrap();
+                QueryBuilder::prepare_expr(self, expr, sql);
+            }
             is_first = false;
         }
 
@@ -420,9 +424,11 @@ impl PostgresQueryBuilder {
             let _ = x;
         }
 
-        if let Some(expr) = &column_def.spec.using {
-            write!(sql, " USING ").unwrap();
-            QueryBuilder::prepare_expr(self, expr, sql);
+        if column_def.types.is_none() {
+            if let Some(expr) = &column_def.spec.using {
+                write!(sql, " USING ").unwrap();
+                QueryBuilder::prepare_expr(self, expr, sql);
+            }
         }
 
         if let Some(extra) = &column_def.spec.extra {

--- a/tests/postgres/table.rs
+++ b/tests/postgres/table.rs
@@ -871,3 +871,21 @@ fn create_partition_values_less_than_panics() {
         .values_less_than([10])
         .to_string(PostgresQueryBuilder);
 }
+
+#[test]
+fn test_alter_column_using_with_not_null() {
+    let statement = Table::alter()
+        .table(Char::Table)
+        .modify_column(
+            ColumnDef::new(Char::Id)
+                .integer()
+                .not_null()
+                .using(Expr::col(Char::Id).cast_as("integer")),
+        )
+        .to_string(PostgresQueryBuilder);
+
+    assert_eq!(
+        statement,
+        r#"ALTER TABLE "character" ALTER COLUMN "id" TYPE integer USING CAST("id" AS integer), ALTER COLUMN "id" SET NOT NULL"#
+    );
+}


### PR DESCRIPTION
## Description
Fixes PostgreSQL statement preparation in `prepare_modify_column` so that `USING` expression clauses are emitted directly after the `ALTER COLUMN ... TYPE ...` clause rather than at the end of the entire `modify_column` statement after `SET NOT NULL` / `DEFAULT`.

Fixes #1099.

## Motivation
When modifying a column in Postgres to change both its type and nullability (e.g. converting a column to an enum with `USING` cast and `NOT NULL`), Postgres rejects `SET NOT NULL USING ...` with a syntax error because `USING` is only valid directly attached to the `TYPE` clause.

## Example
```rust
use sea_query::*;

let statement = Table::alter()
    .table(Character::Table)
    .modify_column(
        ColumnDef::new(Character::Id)
            .integer()
            .not_null()
            .using(Expr::col(Character::Id).cast_as("integer")),
    )
    .to_string(PostgresQueryBuilder);

assert_eq!(
    statement,
    r#"ALTER TABLE "character" ALTER COLUMN "id" TYPE integer USING CAST("id" AS integer), ALTER COLUMN "id" SET NOT NULL"#
);
```
